### PR TITLE
Nested virtual documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp",
-  "version": "0.4.1",
+  "version": "0.5.0-alpha.0",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp",
-  "version": "0.5.0-alpha.0",
+  "version": "0.5.0-alpha.1",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -60,6 +60,14 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     let listeners = this.editorListeners;
 
     let wrapper = this.editor.getWrapperElement();
+    this.editor.addEventListener(
+      'mouseleave',
+      this.remove_range_highlight.bind(this)
+    );
+    wrapper.addEventListener(
+      'mouseleave',
+      this.remove_range_highlight.bind(this)
+    );
     // detach the adapters contextmenu
     wrapper.removeEventListener('contextmenu', listeners.contextmenu);
 
@@ -68,6 +76,7 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
 
     // show hover after pressing the modifier key
     wrapper.addEventListener('keydown', (event: KeyboardEvent) => {
+      //event.target
       if (
         (!hover_modifier || getModifierState(event, hover_modifier)) &&
         this.hover_character === this.last_hover_character
@@ -129,9 +138,13 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     }
   }
 
-  protected remove_tooltip() {
+  protected remove_range_highlight() {
     // @ts-ignore
     this._removeHover(); // this removes underlines
+  }
+
+  protected remove_tooltip() {
+    this.remove_range_highlight();
 
     if (this._tooltip !== undefined) {
       this._tooltip.dispose();

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -271,9 +271,7 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
       start_in_editor = this.virtual_document.transform_virtual_to_editor(
         start
       );
-      end_in_editor = this.virtual_document.transform_virtual_to_editor(
-        end
-      );
+      end_in_editor = this.virtual_document.transform_virtual_to_editor(end);
 
       cm_editor = this.editor.get_editor_at_root_position(hover_character);
     } else {
@@ -443,8 +441,6 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     let diagnostics_by_range = this.collapse_overlapping_diagnostics(
       response.diagnostics
     );
-    console.log(this.virtual_document.value)
-    console.log(this.virtual_document.last_virtual_line)
 
     diagnostics_by_range.forEach(
       (diagnostics: lsProtocol.Diagnostic[], range: lsProtocol.Range) => {

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -471,8 +471,14 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
           return;
         }
 
-        if (!document.virtual_lines.get(start.line).inspect) {
-          console.log(`Ignoring silenced inspections: ${diagnostics}.`);
+        if (
+          document.virtual_lines
+            .get(start.line)
+            .skip_inspect.indexOf(document.id_path) !== -1
+        ) {
+          console.log(
+            'Ignoring inspections silenced for this document:', diagnostics
+          );
           return;
         }
 

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -277,13 +277,8 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     let end_in_editor: any;
 
     let cm_editor: any;
-    /* Already checked before
-    let { document } = this.editor.get_virtual_document(hover_character);
-
-    if (document !== this.virtual_document) {
-      console.log('Skipping highlight: should be handled be another virtual document');
-    }
-     */
+    // NOTE: foreign document ranges are checked before the request is sent,
+    // no need to to this again here.
 
     if (range) {
       start = PositionConverter.lsp_to_cm(range.start) as IVirtualPosition;

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -443,12 +443,14 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     let diagnostics_by_range = this.collapse_overlapping_diagnostics(
       response.diagnostics
     );
+    console.log(this.virtual_document.value)
+    console.log(this.virtual_document.last_virtual_line)
 
     diagnostics_by_range.forEach(
       (diagnostics: lsProtocol.Diagnostic[], range: lsProtocol.Range) => {
         const start = PositionConverter.lsp_to_cm(range.start) as IVirtualPosition;
         const end = PositionConverter.lsp_to_cm(range.end) as IVirtualPosition;
-        if (start.line > this.virtual_document.source_lines.size) {
+        if (start.line > this.virtual_document.last_virtual_line) {
           console.log(
             'Malformed diagnostic was skipped (out of lines) ',
             diagnostics
@@ -466,7 +468,8 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
           console.log(
             `Ignoring inspections from ${response.uri}`,
             ` (this region is covered by a another virtual document: ${document.uri})`,
-            ` inspections: ${diagnostics}.`
+            ` inspections: `,
+            diagnostics
           );
           return;
         }
@@ -477,7 +480,8 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
             .skip_inspect.indexOf(document.id_path) !== -1
         ) {
           console.log(
-            'Ignoring inspections silenced for this document:', diagnostics
+            'Ignoring inspections silenced for this document:',
+            diagnostics
           );
           return;
         }
@@ -556,14 +560,13 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     );
   }
 
-  private transform_virtual_position_to_root_position(start: IVirtualPosition): IRootPosition {
+  private transform_virtual_position_to_root_position(
+    start: IVirtualPosition
+  ): IRootPosition {
     let cm_editor = this.virtual_document.virtual_lines.get(start.line).editor;
     let editor_position = this.virtual_document.transform_virtual_to_editor(
       start
     );
-    return this.editor.transform_editor_to_root(
-      cm_editor,
-      editor_position
-    );
+    return this.editor.transform_editor_to_root(cm_editor, editor_position);
   }
 }

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -270,16 +270,24 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
   protected highlight_range(range: lsProtocol.Range, class_name: string) {
     let hover_character = this.hover_character;
 
-    let start: CodeMirror.Position;
-    let end: CodeMirror.Position;
+    let start: IVirtualPosition;
+    let end: IVirtualPosition;
 
     let start_in_editor: any;
     let end_in_editor: any;
 
     let cm_editor: any;
+    /* Already checked before
+    let { document } = this.editor.get_virtual_document(hover_character);
+
+    if (document !== this.virtual_document) {
+      console.log('Skipping highlight: should be handled be another virtual document');
+    }
+     */
+
     if (range) {
-      start = PositionConverter.lsp_to_cm(range.start);
-      end = PositionConverter.lsp_to_cm(range.end);
+      start = PositionConverter.lsp_to_cm(range.start) as IVirtualPosition;
+      end = PositionConverter.lsp_to_cm(range.end) as IVirtualPosition;
 
       start_in_editor = this.virtual_document.transform_virtual_to_editor(
         start

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -98,14 +98,20 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
   private _signatureCharacters: string[];
 
   get completionCharacters() {
-    if (!this._completionCharacters.length) {
+    if (
+      typeof this._completionCharacters === 'undefined' ||
+      !this._completionCharacters.length
+    ) {
       this._completionCharacters = this.connection.getLanguageCompletionCharacters();
     }
     return this._completionCharacters;
   }
 
   get signatureCharacters() {
-    if (!this._signatureCharacters.length) {
+    if (
+      typeof this._signatureCharacters === 'undefined' ||
+      !this._signatureCharacters.length
+    ) {
       this._signatureCharacters = this.connection.getLanguageSignatureCharacters();
     }
     return this._signatureCharacters;

--- a/src/adapters/codemirror.ts
+++ b/src/adapters/codemirror.ts
@@ -76,7 +76,6 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
 
     // show hover after pressing the modifier key
     wrapper.addEventListener('keydown', (event: KeyboardEvent) => {
-      //event.target
       if (
         (!hover_modifier || getModifierState(event, hover_modifier)) &&
         this.hover_character === this.last_hover_character
@@ -141,6 +140,7 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
   protected remove_range_highlight() {
     // @ts-ignore
     this._removeHover(); // this removes underlines
+    this.last_hover_character = null;
   }
 
   protected remove_tooltip() {
@@ -157,6 +157,7 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     this.last_hover_response = null;
 
     if (
+      !this.hover_character ||
       !response ||
       !response.contents ||
       (Array.isArray(response.contents) && response.contents.length === 0)
@@ -346,6 +347,8 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
     // happens because mousemove is attached to panel, not individual code cells,
     // and because some regions of the editor (between lines) have no characters
     if (typeof root_position === 'undefined') {
+      this.remove_range_highlight();
+      this.hover_character = null;
       return;
     }
 
@@ -361,6 +364,8 @@ export class CodeMirrorAdapterExtension extends CodeMirrorAdapter {
       // @ts-ignore
       !this._isEventInsideVisible(event)
     ) {
+      this.remove_range_highlight();
+      this.hover_character = null;
       return;
     }
 

--- a/src/adapters/file_editor.ts
+++ b/src/adapters/file_editor.ts
@@ -54,15 +54,18 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
     this.widget = editor_widget;
     this.editor = editor_widget.content;
 
-    this.virtual_editor = new VirtualFileEditor(this.language, this.cm_editor);
+    this.virtual_editor = new VirtualFileEditor(
+      this.language,
+      this.document_path,
+      this.cm_editor
+    );
 
     this.connect(this.virtual_editor.virtual_document).then();
-    this.create_adapter();
 
     const connector = new LSPConnector({
       editor: this.editor.editor,
-      connection: this.main_connection,
-      coordinates_transform: null
+      connections: this.connections,
+      virtual_editor: this.virtual_editor
     });
     completion_manager.register({
       connector,

--- a/src/adapters/notebook.ts
+++ b/src/adapters/notebook.ts
@@ -30,7 +30,7 @@ let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     // R line magic
     new RegExpForeignCodeExtractor({
       language: 'R',
-      pattern: '(^|\n)%R (.*)\n',
+      pattern: '(^|\n)%R (.*)\n?',
       extract_to_foreign: '$2',
       keep_in_host: true,
       is_standalone: false

--- a/src/adapters/notebook.ts
+++ b/src/adapters/notebook.ts
@@ -22,7 +22,15 @@ let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     // R magic will always be in the same, single R-namespace
     new RegExpForeignCodeExtractor({
       language: 'R',
-      pattern: '%%R( .*?)?\n([^]*)',
+      pattern: '^%%R( .*?)?\n([^]*)',
+      extract_to_foreign: '$2',
+      keep_in_host: true,
+      is_standalone: false
+    }),
+    // R line magic
+    new RegExpForeignCodeExtractor({
+      language: 'R',
+      pattern: '(^|\n)%R (.*)\n',
       extract_to_foreign: '$2',
       keep_in_host: true,
       is_standalone: false
@@ -30,14 +38,14 @@ let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     // most magics are standalone, i.e. consecutive code cells with the same magic create two different namespaces
     new RegExpForeignCodeExtractor({
       language: 'python',
-      pattern: '%%python( .*?)?\n(.*)',
+      pattern: '^%%python( .*?)?\n(.*)',
       extract_to_foreign: '$2',
       keep_in_host: false,
       is_standalone: true
     }),
     new RegExpForeignCodeExtractor({
       language: 'python',
-      pattern: '%%timeit( .*?)?\n(.*)',
+      pattern: '^%%timeit( .*?)?\n(.*)',
       extract_to_foreign: '$2',
       keep_in_host: false,
       is_standalone: true

--- a/src/adapters/notebook.ts
+++ b/src/adapters/notebook.ts
@@ -12,6 +12,7 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IForeignCodeExtractorsRegistry } from '../extractors/types';
 import { RegExpForeignCodeExtractor } from '../extractors/regexp';
 import { language_specific_overrides } from '../magics/defaults';
+import { VirtualDocument } from '../virtual/document';
 
 // TODO: make the regex code extractors configurable
 
@@ -21,7 +22,7 @@ let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     // R magic will always be in the same, single R-namespace
     new RegExpForeignCodeExtractor({
       language: 'R',
-      pattern: '%%R( [^]*)?\n([^]*)',
+      pattern: '%%R( .*?)?\n([^]*)',
       extract_to_foreign: '$2',
       keep_in_host: true,
       is_standalone: false
@@ -29,14 +30,14 @@ let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     // most magics are standalone, i.e. consecutive code cells with the same magic create two different namespaces
     new RegExpForeignCodeExtractor({
       language: 'python',
-      pattern: '%%python( [^]*)?\n(.*)',
+      pattern: '%%python( .*?)?\n(.*)',
       extract_to_foreign: '$2',
       keep_in_host: false,
       is_standalone: true
     }),
     new RegExpForeignCodeExtractor({
       language: 'python',
-      pattern: '%%timeit( [^]*)?\n(.*)',
+      pattern: '%%timeit( .*?)?\n(.*)',
       extract_to_foreign: '$2',
       keep_in_host: false,
       is_standalone: true
@@ -101,11 +102,11 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
       this.widget,
       this.language,
       language_specific_overrides,
-      foreign_code_extractors
+      foreign_code_extractors,
+      this.document_path
     );
 
     this.connect(this.virtual_editor.virtual_document);
-    this.create_adapter();
 
     // refresh server held state after every change
     // note this may be changed soon: https://github.com/jupyterlab/jupyterlab/issues/5382#issuecomment-515643504
@@ -119,14 +120,20 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
     );
 
     // register completion connectors on cells
+    this.document_connected.connect(() => this.connect_completion() );
+  }
 
+  async connect(virtual_document: VirtualDocument): Promise<void> {
+    return super.connect(virtual_document);
+  }
+
+  connect_completion() {
     // see https://github.com/jupyterlab/jupyterlab/blob/c0e9eb94668832d1208ad3b00a9791ef181eca4c/packages/completer-extension/src/index.ts#L198-L213
     const cell = this.widget.content.activeCell;
     const connector = new LSPConnector({
       editor: cell.editor,
-      connection: this.main_connection,
-      coordinates_transform: (position: CodeMirror.Position) =>
-        this.virtual_editor.transform_from_notebook(cell, position),
+      connections: this.connections,
+      virtual_editor: this.virtual_editor,
       session: this.widget.session
     });
     const handler = this.completion_manager.register({
@@ -137,9 +144,8 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
     this.widget.content.activeCellChanged.connect((notebook, cell) => {
       const connector = new LSPConnector({
         editor: cell.editor,
-        connection: this.main_connection,
-        coordinates_transform: (position: CodeMirror.Position) =>
-          this.virtual_editor.transform_from_notebook(cell, position),
+        connections: this.connections,
+        virtual_editor: this.virtual_editor,
         session: this.widget.session
       });
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -57,9 +57,6 @@ export class LSPConnector extends DataConnector<
     super();
     this._editor = options.editor;
     this._connections = options.connections;
-    // this._completion_characters = new DefaultMap(key =>
-    //  this._connections.get(key).getLanguageCompletionCharacters()
-    // );
     this.virtual_editor = options.virtual_editor;
     this._context_connector = new ContextConnector({ editor: options.editor });
     if (options.session) {
@@ -110,17 +107,14 @@ export class LSPConnector extends DataConnector<
     let end_in_root = this.transform_from_editor_to_root(end);
     let cursor_in_root = this.transform_from_editor_to_root(cursor);
 
+    let virtual_editor = this.virtual_editor;
+
     // find document for position
-    let {
-      document,
-      virtual_position: virtual_start
-    } = this.virtual_editor.get_virtual_document(start_in_root);
-    let {
-      virtual_position: virtual_end
-    } = this.virtual_editor.get_virtual_document(end_in_root);
-    let {
-      virtual_position: virtual_cursor
-    } = this.virtual_editor.get_virtual_document(cursor_in_root);
+    let document = virtual_editor.document_as_root_position(start_in_root);
+
+    let virtual_start = virtual_editor.root_position_to_virtual_position(start_in_root);
+    let virtual_end = virtual_editor.root_position_to_virtual_position(end_in_root);
+    let virtual_cursor = virtual_editor.root_position_to_virtual_position(cursor_in_root);
 
     try {
       if (
@@ -170,7 +164,6 @@ export class LSPConnector extends DataConnector<
     cursor: IVirtualPosition,
     document: VirtualDocument
   ): Promise<CompletionHandler.IReply> {
-    // let completion_characters = this._compleeion_characters.get('');
     let connection = this._connections.get(document.id_path);
 
     // without sendChange we (sometimes) get outdated suggestions

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -11,8 +11,15 @@ import { ReadonlyJSONObject } from '@phosphor/coreutils';
 import { completionItemKindNames } from './lsp';
 import { until_ready } from './utils';
 import { PositionConverter } from './converter';
-import CodeMirror = require('codemirror');
 import { IClientSession } from '@jupyterlab/apputils';
+import { VirtualDocument } from './virtual/document';
+import { VirtualEditor } from './virtual/editor';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+import {
+  IEditorPosition,
+  IRootPosition,
+  IVirtualPosition
+} from './positioning';
 
 /*
 Feedback: anchor - not clear from docs
@@ -28,12 +35,18 @@ export class LSPConnector extends DataConnector<
   CompletionHandler.IRequest
 > {
   private readonly _editor: CodeEditor.IEditor;
-  private readonly _connection: LspWsConnection;
-  private _completion_characters: Array<string>;
+  private readonly _connections: Map<VirtualDocument.id_path, LspWsConnection>;
+  // completion characters do not belong here, but to "onChanged"
+  // private _completion_characters: DefaultMap<
+  //  VirtualDocument.id_path,
+  //  Array<string>
+  // >;
   private _context_connector: ContextConnector;
   private _kernel_connector: KernelConnector;
   private _kernel_and_context_connector: CompletionConnector;
-  transform_coordinates: (position: CodeMirror.Position) => CodeMirror.Position;
+  protected options: LSPConnector.IOptions;
+
+  virtual_editor: VirtualEditor;
 
   /**
    * Create a new LSP connector for completion requests.
@@ -43,8 +56,11 @@ export class LSPConnector extends DataConnector<
   constructor(options: LSPConnector.IOptions) {
     super();
     this._editor = options.editor;
-    this._connection = options.connection;
-    this._completion_characters = this._connection.getLanguageCompletionCharacters();
+    this._connections = options.connections;
+    // this._completion_characters = new DefaultMap(key =>
+    //  this._connections.get(key).getLanguageCompletionCharacters()
+    // );
+    this.virtual_editor = options.virtual_editor;
     this._context_connector = new ContextConnector({ editor: options.editor });
     if (options.session) {
       let kernel_options = { editor: options.editor, session: options.session };
@@ -53,16 +69,23 @@ export class LSPConnector extends DataConnector<
         kernel_options
       );
     }
-    this.transform_coordinates =
-      options.coordinates_transform !== null
-        ? options.coordinates_transform
-        : position => position;
+    this.options = options;
+  }
+
+  protected get _kernel_language(): string {
+    return this.options.session.kernel.info.language_info.name;
   }
 
   get fallback_connector() {
     return this._kernel_and_context_connector
       ? this._kernel_and_context_connector
       : this._context_connector;
+  }
+
+  transform_from_editor_to_root(position: CodeEditor.IPosition): IRootPosition {
+    let cm_editor = (this._editor as CodeMirrorEditor).editor;
+    let cm_start = PositionConverter.ce_to_cm(position) as IEditorPosition;
+    return this.virtual_editor.transform_editor_to_root(cm_editor, cm_start);
   }
 
   /**
@@ -73,24 +96,63 @@ export class LSPConnector extends DataConnector<
   fetch(
     request: CompletionHandler.IRequest
   ): Promise<CompletionHandler.IReply> {
-    try {
-      if (this._completion_characters === undefined) {
-        this._completion_characters = this._connection.getLanguageCompletionCharacters();
-      }
+    let editor = this._editor;
 
-      if (this._kernel_connector) {
+    const cursor = editor.getCursorPosition();
+    const token = editor.getTokenForPosition(cursor);
+
+    const start = editor.getPositionAt(token.offset);
+    const end = editor.getPositionAt(token.offset + token.value.length);
+
+    const typed_character = token.value[cursor.column - start.column - 1];
+
+    let start_in_root = this.transform_from_editor_to_root(start);
+    let end_in_root = this.transform_from_editor_to_root(end);
+    let cursor_in_root = this.transform_from_editor_to_root(cursor);
+
+    // find document for position
+    let {
+      document,
+      virtual_position: virtual_start
+    } = this.virtual_editor.get_virtual_document(start_in_root);
+    let {
+      virtual_position: virtual_end
+    } = this.virtual_editor.get_virtual_document(end_in_root);
+    let {
+      virtual_position: virtual_cursor
+    } = this.virtual_editor.get_virtual_document(cursor_in_root);
+
+    try {
+      if (
+        this._kernel_connector &&
+        // TODO: this would be awesome if we could connect to rpy2 for R suggestions in Python,
+        //  but this is not the job of this extension; nevertheless its better to keep this in
+        //  mind to avoid introducing design decisions which would make this impossible
+        //  (for other extensions)
+        document.language === this._kernel_language
+      ) {
         return Promise.all([
           this._kernel_connector.fetch(request),
-          this.hint(this._editor, this._connection, this._completion_characters)
+          this.hint(
+            token,
+            typed_character,
+            virtual_start,
+            virtual_end,
+            virtual_cursor,
+            document
+          )
         ]).then(([kernel, lsp]) =>
           this.merge_replies(kernel, lsp, this._editor)
         );
       }
 
       return this.hint(
-        this._editor,
-        this._connection,
-        this._completion_characters
+        token,
+        typed_character,
+        virtual_start,
+        virtual_end,
+        virtual_cursor,
+        document
       ).catch(e => {
         console.log(e);
         return this.fallback_connector.fetch(request);
@@ -101,20 +163,15 @@ export class LSPConnector extends DataConnector<
   }
 
   async hint(
-    editor: CodeEditor.IEditor,
-    connection: LspWsConnection,
-    completion_characters: Array<string>
+    token: CodeEditor.IToken,
+    typed_character: string,
+    start: IVirtualPosition,
+    end: IVirtualPosition,
+    cursor: IVirtualPosition,
+    document: VirtualDocument
   ): Promise<CompletionHandler.IReply> {
-    // Find the token at the cursor
-    const cursor = editor.getCursorPosition();
-    const token = editor.getTokenForPosition(cursor);
-
-    const start = editor.getPositionAt(token.offset);
-    const end = editor.getPositionAt(token.offset + token.value.length);
-
-    // const signatureCharacters = connection.getLanguageSignatureCharacters();
-
-    const typedCharacter = token.value[cursor.column - start.column - 1];
+    // let completion_characters = this._compleeion_characters.get('');
+    let connection = this._connections.get(document.id_path);
 
     // without sendChange we (sometimes) get outdated suggestions
     connection.sendChange();
@@ -128,33 +185,17 @@ export class LSPConnector extends DataConnector<
     // to the matches...
     // Suggested in https://github.com/jupyterlab/jupyterlab/issues/7044, TODO PR
 
-    // if (signatureCharacters.indexOf(typedCharacter) !== -1) {
-    //  // @ts-ignore
-    //  request_completion = connection.getSignatureHelp.bind(this);
-    //  event = 'signature'
-    // } else {
-    // @ts-ignore
-    // request_completion = connection.getCompletion.bind(this);
     event = 'completion';
-    // }
-    // */
-
-    // if(completion_characters.indexOf(typedCharacter) === -1)
-    //  return
-
-    let transform = this.transform_coordinates;
     console.log(token);
 
     connection.getCompletion(
-      transform(PositionConverter.ce_to_cm(cursor)),
+      cursor,
       {
-        start: transform(PositionConverter.ce_to_cm(start)),
-        end: transform(PositionConverter.ce_to_cm(end)),
+        start,
+        end,
         text: token.value
       },
-      // TODO: use force invoke on completion characters
-      // completion_characters.find((c) => c === typedCharacter)
-      typedCharacter
+      typed_character
       // lsProtocol.CompletionTriggerKind.TriggerCharacter,
     );
     let result: any = { set: false };
@@ -188,7 +229,9 @@ export class LSPConnector extends DataConnector<
       // sortText: "amean"
       let text = match.insertText ? match.insertText : match.label;
 
-      if (text.startsWith(token.value)) { all_non_prefixed = false; }
+      if (text.startsWith(token.value)) {
+        all_non_prefixed = false;
+      }
 
       matches.push(text);
       types.push({
@@ -272,7 +315,7 @@ export class LSPConnector extends DataConnector<
         let text = remove_prefix(itemType.text);
         if (!memo_types.has(text)) {
           memo_types.set(text, itemType.type);
-          if (itemType.type != '<unknown>') {
+          if (itemType.type !== '<unknown>') {
             priority_matches.add(text);
           }
         }
@@ -316,13 +359,11 @@ export namespace LSPConnector {
      * The editor used by the LSP connector.
      */
     editor: CodeEditor.IEditor;
+    virtual_editor: VirtualEditor;
     /**
-     * The connection used by the LSP connector.
+     * The connections to be used by the LSP connector.
      */
-    connection: LspWsConnection;
-    coordinates_transform: (
-      position: CodeMirror.Position
-    ) => CodeMirror.Position;
+    connections: Map<VirtualDocument.id_path, LspWsConnection>;
 
     session?: IClientSession;
   }

--- a/src/extractors/regexp.spec.ts
+++ b/src/extractors/regexp.spec.ts
@@ -1,0 +1,199 @@
+import { expect } from 'chai';
+import { position_at_offset, RegExpForeignCodeExtractor } from './regexp';
+
+let R_CELL_MAGIC_EXISTS = `%%R
+some text
+`;
+
+let NO_CELL_MAGIC = `%R
+some text
+%%R
+some text
+`;
+
+let R_LINE_MAGICS = `%R df = data.frame()
+print("df created")
+%R ggplot(df)
+print("plotted")
+`;
+
+describe('positionAtOffset', () => {
+  it('works with single line', () => {
+    let position = position_at_offset(0, ['']);
+    expect(position).deep.equal({ column: 0, line: 0 });
+
+    position = position_at_offset(0, ['abc']);
+    expect(position).deep.equal({ column: 0, line: 0 });
+
+    position = position_at_offset(1, ['abc']);
+    expect(position).deep.equal({ column: 1, line: 0 });
+
+    position = position_at_offset(2, ['abc']);
+    expect(position).deep.equal({ column: 2, line: 0 });
+  });
+
+  it('works two lines', () => {
+    let two_empty_lines = '\n'.split('\n');
+    let two_single_character_lines = 'a\nb'.split('\n');
+
+    let position = position_at_offset(0, two_empty_lines);
+    expect(position).deep.equal({ column: 0, line: 0 });
+
+    position = position_at_offset(1, two_empty_lines);
+    expect(position).deep.equal({ column: 0, line: 1 });
+
+    position = position_at_offset(1, two_single_character_lines);
+    expect(position).deep.equal({ column: 1, line: 0 });
+
+    position = position_at_offset(2, two_single_character_lines);
+    expect(position).deep.equal({ column: 0, line: 1 });
+
+    position = position_at_offset(3, two_single_character_lines);
+    expect(position).deep.equal({ column: 1, line: 1 });
+  });
+});
+
+describe('RegExpForeignCodeExtractor', () => {
+  let r_cell_extractor = new RegExpForeignCodeExtractor({
+    language: 'R',
+    pattern: '^%%R( .*?)?\n([^]*)',
+    extract_to_foreign: '$2',
+    keep_in_host: true,
+    is_standalone: false
+  });
+
+  let r_line_extractor = new RegExpForeignCodeExtractor({
+    language: 'R',
+    pattern: '(^|\n)%R (.*\n)',
+    extract_to_foreign: '$2',
+    keep_in_host: true,
+    is_standalone: false
+  });
+
+  describe('#has_foreign_code()', () => {
+    it('detects cell magics', () => {
+      let result = r_cell_extractor.has_foreign_code(R_CELL_MAGIC_EXISTS);
+      expect(result).to.equal(true);
+
+      result = r_cell_extractor.has_foreign_code(R_LINE_MAGICS);
+      expect(result).to.equal(false);
+
+      result = r_cell_extractor.has_foreign_code(NO_CELL_MAGIC);
+      expect(result).to.equal(false);
+    });
+
+    it('is not stateful', () => {
+      // stateful implementation of regular expressions in JS can easily lead to
+      // an error manifesting it two consecutive checks giving different results,
+      // as the last index was moved in between:
+      let result = r_cell_extractor.has_foreign_code(R_CELL_MAGIC_EXISTS);
+      expect(result).to.equal(true);
+
+      result = r_cell_extractor.has_foreign_code(R_CELL_MAGIC_EXISTS);
+      expect(result).to.equal(true);
+    });
+
+    it('detects line magics', () => {
+      let result = r_line_extractor.has_foreign_code(R_LINE_MAGICS);
+      expect(result).to.equal(true);
+
+      result = r_line_extractor.has_foreign_code(R_CELL_MAGIC_EXISTS);
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('#extract_foreign_code()', () => {
+
+    it('should extract cell magics and keep in host', () => {
+      let results = r_cell_extractor.extract_foreign_code(R_CELL_MAGIC_EXISTS);
+      expect(results.length).to.equal(1);
+
+      let result = results[0];
+
+      expect(result.host_code).to.equal(R_CELL_MAGIC_EXISTS);
+      expect(result.foreign_code).to.equal('some text\n');
+      expect(result.range.start.line).to.equal(1);
+      expect(result.range.start.column).to.equal(0);
+    });
+
+    it('should extract and remove from host', () => {
+      let extractor = new RegExpForeignCodeExtractor({
+        language: 'R',
+        pattern: '^%%R( .*?)?\n([^]*)',
+        extract_to_foreign: '$2',
+        keep_in_host: false,
+        is_standalone: false
+      });
+      let results = extractor.extract_foreign_code(R_CELL_MAGIC_EXISTS);
+      expect(results.length).to.equal(1);
+
+      let result = results[0];
+
+      expect(result.foreign_code).to.equal('some text\n');
+      expect(result.host_code).to.equal('');
+    });
+
+    it('should extract multiple line magics deleting them from host', () => {
+      let r_line_extractor = new RegExpForeignCodeExtractor({
+        language: 'R',
+        pattern: '(^|\n)%R (.*\n)',
+        extract_to_foreign: '$2',
+        keep_in_host: false,
+        is_standalone: false
+      });
+      let results = r_line_extractor.extract_foreign_code(R_LINE_MAGICS);
+
+      // 2 line magics to be extracted + the unprocessed host code
+      expect(results.length).to.eq(3);
+
+      let first_magic = results[0];
+
+      expect(first_magic.foreign_code).to.equal('df = data.frame()\n');
+      expect(first_magic.host_code).to.equal('');
+
+      let second_magic = results[1];
+
+      expect(second_magic.foreign_code).to.equal('ggplot(df)\n');
+      expect(second_magic.host_code).to.equal('print("df created")\n');
+
+      let final_bit = results[2];
+
+      expect(final_bit.foreign_code).to.equal(null);
+      expect(final_bit.host_code).to.equal('print("plotted")\n');
+    });
+
+    it('should extract multiple line magics preserving them in host', () => {
+      let results = r_line_extractor.extract_foreign_code(R_LINE_MAGICS);
+
+      // 2 line magics to be extracted + the unprocessed host code
+      expect(results.length).to.eq(3);
+
+      let first_magic = results[0];
+
+      expect(first_magic.foreign_code).to.equal('df = data.frame()\n');
+      expect(first_magic.host_code).to.equal('%R df = data.frame()\n');
+
+      let second_magic = results[1];
+
+      expect(second_magic.foreign_code).to.equal('ggplot(df)\n');
+      expect(second_magic.host_code).to.equal(
+        'print("df created")\n%R ggplot(df)\n'
+      );
+
+      let final_bit = results[2];
+
+      expect(final_bit.foreign_code).to.equal(null);
+      expect(final_bit.host_code).to.equal('print("plotted")\n');
+    });
+
+    it('should not extract magic-like text from the middle of the cell', () => {
+      let results = r_cell_extractor.extract_foreign_code(NO_CELL_MAGIC);
+
+      expect(results.length).to.eq(1);
+      let result = results[0];
+      expect(result.foreign_code).to.equal(null);
+      expect(result.host_code).to.equal(NO_CELL_MAGIC);
+      expect(result.range).to.equal(null);
+    });
+  });
+});

--- a/src/extractors/regexp.spec.ts
+++ b/src/extractors/regexp.spec.ts
@@ -70,7 +70,7 @@ describe('RegExpForeignCodeExtractor', () => {
 
   let r_line_extractor = new RegExpForeignCodeExtractor({
     language: 'R',
-    pattern: '(^|\n)%R (.*\n)',
+    pattern: '(^|\n)%R (.*)\n?',
     extract_to_foreign: '$2',
     keep_in_host: true,
     is_standalone: false
@@ -167,7 +167,7 @@ describe('RegExpForeignCodeExtractor', () => {
     it('should extract multiple line magics deleting them from host', () => {
       let r_line_extractor = new RegExpForeignCodeExtractor({
         language: 'R',
-        pattern: '(^|\n)%R (.*\n)',
+        pattern: '(^|\n)%R (.*)\n?',
         extract_to_foreign: '$2',
         keep_in_host: false,
         is_standalone: false
@@ -179,12 +179,12 @@ describe('RegExpForeignCodeExtractor', () => {
 
       let first_magic = results[0];
 
-      expect(first_magic.foreign_code).to.equal('df = data.frame()\n');
+      expect(first_magic.foreign_code).to.equal('df = data.frame()');
       expect(first_magic.host_code).to.equal('');
 
       let second_magic = results[1];
 
-      expect(second_magic.foreign_code).to.equal('ggplot(df)\n');
+      expect(second_magic.foreign_code).to.equal('ggplot(df)');
       expect(second_magic.host_code).to.equal('print("df created")\n');
 
       let final_bit = results[2];
@@ -201,12 +201,12 @@ describe('RegExpForeignCodeExtractor', () => {
 
       let first_magic = results[0];
 
-      expect(first_magic.foreign_code).to.equal('df = data.frame()\n');
+      expect(first_magic.foreign_code).to.equal('df = data.frame()');
       expect(first_magic.host_code).to.equal('%R df = data.frame()\n');
 
       let second_magic = results[1];
 
-      expect(second_magic.foreign_code).to.equal('ggplot(df)\n');
+      expect(second_magic.foreign_code).to.equal('ggplot(df)');
       expect(second_magic.host_code).to.equal(
         'print("df created")\n%R ggplot(df)\n'
       );
@@ -215,6 +215,14 @@ describe('RegExpForeignCodeExtractor', () => {
 
       expect(final_bit.foreign_code).to.equal(null);
       expect(final_bit.host_code).to.equal('print("plotted")\n');
+    });
+
+    it('should extract single line magic which does not end with a blank line', () => {
+      let results = r_line_extractor.extract_foreign_code('%R test');
+
+      expect(results.length).to.eq(1);
+      let result = results[0];
+      expect(result.foreign_code).to.equal('test');
     });
 
     it('should not extract magic-like text from the middle of the cell', () => {

--- a/src/extractors/regexp.ts
+++ b/src/extractors/regexp.ts
@@ -11,7 +11,7 @@ export function position_at_offset(
   for (let text_line of lines) {
     // each line has a new line symbol which is accounted for in offset!
     if (text_line.length + 1 <= offset) {
-      offset -= (text_line.length + 1);
+      offset -= text_line.length + 1;
       line += 1;
     } else {
       column = offset;
@@ -24,62 +24,84 @@ export function position_at_offset(
 export class RegExpForeignCodeExtractor implements IForeignCodeExtractor {
   options: RegExpForeignCodeExtractor.IOptions;
   language: string;
+  global_expression: RegExp;
+  test_expression: RegExp;
   expression: RegExp;
   standalone: boolean;
 
   constructor(options: RegExpForeignCodeExtractor.IOptions) {
     this.language = options.language;
     this.options = options;
+    this.global_expression = new RegExp(options.pattern, 'g');
+    this.test_expression = new RegExp(options.pattern, 'g');
     this.expression = new RegExp(options.pattern);
     this.standalone = this.options.is_standalone;
   }
 
-  extract_foreign_code(code: string): IExtractedCode {
-    let match = code.match(this.expression);
-    if (match) {
-      let host_code: string | null;
+  has_foreign_code(code: string): boolean {
+    let result = this.test_expression.test(code);
+    this.test_expression.lastIndex = 0;
+    return result;
+  }
 
-      if (this.options.keep_in_host === true) {
-        host_code = code;
-      } else if (this.options.keep_in_host === false) {
-        host_code = null;
-      } else {
-        host_code = code.replace(this.expression, this.options.keep_in_host);
-      }
+  extract_foreign_code(code: string): IExtractedCode[] {
+    let lines = code.split('\n');
 
-      let lines = code.split('\n');
+    let extracts = new Array<IExtractedCode>();
 
-      let foreign_code = code.replace(
+    let started_from = this.global_expression.lastIndex;
+    let match: RegExpExecArray = this.global_expression.exec(code);
+    let host_code_fragment: string;
+
+    while (match !== null) {
+      let matched_string = match[0];
+      let foreign_code_fragment = matched_string.replace(
         this.expression,
         this.options.extract_to_foreign
       );
-      // TODO this assumes that the extraction does not modify
-      let index = code.indexOf(foreign_code);
-      if (index === -1) {
-        throw Error('Internal error of RegExpr matcher');
-      }
-      // TODO???
-      index += 1
-      if (position_at_offset(index, lines).line === 0){
-        throw Error();
+
+      // NOTE:
+      // match.index + matched_string.length === this.sticky_expression.lastIndex
+
+      let end = this.global_expression.lastIndex;
+
+      if (this.options.keep_in_host) {
+        host_code_fragment = code.substring(started_from, end);
+      } else {
+        if (started_from === match.index) {
+          host_code_fragment = '';
+        } else {
+          host_code_fragment = code.substring(started_from, match.index) + '\n';
+        }
       }
 
-      return {
-        host_code: host_code,
-        foreign_code: foreign_code,
+      extracts.push({
+        host_code: host_code_fragment,
+        foreign_code: foreign_code_fragment,
         range: {
           // TODO: this could be slightly optimized (start at start)
-          start: position_at_offset(index, lines),
-          end: position_at_offset(index + match[0].length, lines)
+          start: position_at_offset(
+            match.index + matched_string.indexOf(foreign_code_fragment),
+            lines
+          ),
+          end: position_at_offset(end, lines)
         }
-      };
-    } else {
-      return {
-        host_code: code,
+      });
+
+      started_from = this.global_expression.lastIndex;
+      match = this.global_expression.exec(code);
+    }
+
+    if (started_from !== code.length) {
+      let final_host_code_fragment = code.substring(started_from, code.length);
+      extracts.push({
+        host_code: final_host_code_fragment,
         foreign_code: null,
         range: null
-      };
+      });
     }
+
+    return extracts;
   }
 }
 
@@ -104,15 +126,14 @@ namespace RegExpForeignCodeExtractor {
      */
     extract_to_foreign: string;
     /**
-     * String specifying match groups to be extracted from the regular expression match,
-     * for the use in virtual document of the host language, or boolean if everything (true)
-     * or nothing (false) should be kept in the host document.
+     * String boolean if everything (true) or nothing (false) should be kept in the host document.
      *
      * For the R example this should be empty if we wish to ignore the cell,
      * but usually a better option is to retain the foreign code and use language
-     * specific overrides to suppress the magic in a more controlled way.
+     * specific overrides to suppress the magic in a more controlled way, providing
+     * dummy python code to handle cell input/output.
      */
-    keep_in_host: string | boolean;
+    keep_in_host: boolean;
     /**
      * Should the foreign code be appended (False) to the previously established virtual document of the same language,
      * or is it standalone snippet which requires separate connection?

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -1,15 +1,14 @@
+import {CodeEditor} from "@jupyterlab/codeeditor";
+
 export interface IExtractedCode {
   /**
    * Foreign code (may be empty, for example line of '%R') or null if none.
    */
   foreign_code: string | null;
   /**
-   * Offsets of the foreign code relative to the original source.
+   * Range of the foreign code relative to the original source.
    */
-  foreign_coordinates: {
-    start: number;
-    end: number;
-  };
+  range: CodeEditor.IRange;
   /**
    * Code to be retained in the virtual document of the host.
    */

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -1,4 +1,4 @@
-import {CodeEditor} from "@jupyterlab/codeeditor";
+import { CodeEditor } from '@jupyterlab/codeeditor';
 
 export interface IExtractedCode {
   /**
@@ -42,12 +42,16 @@ export interface IForeignCodeExtractor {
   /**
    * Split the code into the host and foreign code (if any foreign code was detected)
    */
-  extract_foreign_code(code: string): IExtractedCode;
+  extract_foreign_code(code: string): IExtractedCode[];
   /**
    * Does the extractor produce code which should be appended to the previously established virtual document (False)
    * of the same language, or does it produce standalone snippets which require separate connections (True)?
    */
   standalone: boolean;
+  /**
+   * Test if there is any foreign code in provided code snippet.
+   */
+  has_foreign_code(code: string): boolean;
 }
 
 export interface IForeignCodeExtractorsRegistry {

--- a/src/magics/defaults.spec.ts
+++ b/src/magics/defaults.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { language_specific_overrides } from './defaults';
+import { CellMagicsMap, LineMagicsMap } from './maps';
+
+let CELL_MAGIC_EXISTS = `%%MAGIC
+some text
+`;
+
+let NO_CELL_MAGIC = `%MAGIC
+some text
+%%MAGIC
+some text
+`;
+
+let LINE_MAGIC_WITH_SPACE = `%MAGIC line = dd`;
+
+describe('Default IPython overrides', () => {
+  describe('IPython cell magics', () => {
+    let cell_magics_map = new CellMagicsMap(
+      language_specific_overrides['python'].cell_magics
+    );
+    it('overrides cell magics', () => {
+      let override = cell_magics_map.override_for(CELL_MAGIC_EXISTS);
+      expect(override).to.equal('MAGIC()');
+    });
+    it('does not override cell-magic-like constructs', () => {
+      let override = cell_magics_map.override_for(NO_CELL_MAGIC);
+      expect(override).to.equal(null);
+
+      override = cell_magics_map.override_for(LINE_MAGIC_WITH_SPACE);
+      expect(override).to.equal(null);
+    });
+  });
+
+  describe('IPython line magics', () => {
+    let line_magics_map = new LineMagicsMap(
+      language_specific_overrides['python'].line_magics
+    );
+    it('overrides line magics', () => {
+      let override = line_magics_map.override_for(LINE_MAGIC_WITH_SPACE);
+      expect(override).to.equal('MAGIC()');
+    });
+    it('overrides shell commands', () => {
+      let override = line_magics_map.override_for('!ls -o');
+      expect(override).to.equal('ls()');
+    });
+  });
+});

--- a/src/magics/defaults.ts
+++ b/src/magics/defaults.ts
@@ -11,8 +11,9 @@ export const language_specific_overrides: IOverridesRegistry = {
   python: {
     // if a match for expresion in the key is found against a line, the line is replaced with the value
     line_magics: [
-      // filter out IPython line magics and shell assignments
-      { pattern: '^[%!](.+)', replacement: '$1()' }
+      // filter out IPython line magics and shell assignments:
+      //  remove the content, keep magic/command name and new line at the end
+      { pattern: '^[%!](\\S+)(.*)(\n)?', replacement: '$1()$3' }
     ],
     // if a match for expresion in the key is found at the beginning of a cell, the entire cell is replaced with the value
     cell_magics: [

--- a/src/magics/maps.ts
+++ b/src/magics/maps.ts
@@ -32,19 +32,19 @@ export class LineMagicsMap extends MagicsMap {
 
   replace_all(
     raw_lines: string[]
-  ): { lines: string[]; should_inspect: boolean[] } {
+  ): { lines: string[]; skip_inspect: boolean[] } {
     let substituted_lines = new Array<string>();
-    let should_inspect = new Array<boolean>();
+    let skip_inspect = new Array<boolean>();
 
     for (let i = 0; i < raw_lines.length; i++) {
       let line = raw_lines[i];
       let override = this.override_for(line);
       substituted_lines.push(override === null ? line : override);
-      should_inspect.push(override === null);
+      skip_inspect.push(override !== null);
     }
     return {
       lines: substituted_lines,
-      should_inspect: should_inspect
+      skip_inspect: skip_inspect
     };
   }
 }

--- a/src/positioning.ts
+++ b/src/positioning.ts
@@ -1,0 +1,26 @@
+export import CodeMirror = require('codemirror');
+
+/**
+ * is_* attributes are there only to enforce strict interface type checking
+ */
+export interface IPosition extends CodeMirror.Position {}
+
+export function is_equal(self: IPosition, other: IPosition): boolean {
+  return other && self.line === other.line && self.ch === other.ch;
+}
+
+export interface ISourcePosition extends IPosition {
+  is_source: true;
+}
+
+export interface IEditorPosition extends IPosition {
+  is_editor: true;
+}
+
+export interface IVirtualPosition extends IPosition {
+  is_virtual: true;
+}
+
+export interface IRootPosition extends ISourcePosition {
+  is_root: true;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,7 @@ export class DefaultMap<K, V> extends Map<K, V> {
     if (this.has(k)) {
       return super.get(k);
     } else {
-      let v = this.default_factory(...args);
+      let v = this.default_factory(k, ...args);
       this.set(k, v);
       return v;
     }

--- a/src/virtual/document.spec.ts
+++ b/src/virtual/document.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { RegExpForeignCodeExtractor } from '../extractors/regexp';
 import { VirtualDocument } from './document';
+import CodeMirror = require("codemirror");
+import { ISourcePosition, IVirtualPosition } from "../positioning";
 
 let R_LINE_MAGICS = `%R df = data.frame()
 print("df created")
@@ -16,21 +18,20 @@ describe('RegExpForeignCodeExtractor', () => {
     keep_in_host: false,
     is_standalone: false
   });
+  let document = new VirtualDocument(
+    'python',
+    'test.ipynb',
+    {},
+    { python: [r_line_extractor_removing] },
+    false
+  );
 
   describe('#extract_foreign_code', () => {
     it('joins non-standalone fragments together for both foreign and host code', () => {
-      let document = new VirtualDocument(
-        'python',
-        'test.ipynb',
-        {},
-        { python: [r_line_extractor_removing] },
-        false
-      );
-
       let {
         cell_code_kept,
         foreign_document_map
-      } = document.extract_foreign_code(R_LINE_MAGICS, null);
+      } = document.extract_foreign_code(R_LINE_MAGICS, null, { line: 0, column: 0 });
 
       expect(cell_code_kept).to.equal(
         'print("df created")\nprint("plotted")\n'
@@ -42,6 +43,69 @@ describe('RegExpForeignCodeExtractor', () => {
       );
       expect(r_document.language).to.equal('R');
       expect(r_document.value).to.equal('df = data.frame()\n\n\nggplot(df)\n');
+    });
+  });
+
+  afterEach(() => {
+    document.clear();
+  });
+
+  let init_document_with_Python_and_R = () => {
+    let cm_editor_for_cell_1 = {} as CodeMirror.Editor;
+    let cm_editor_for_cell_2 = {} as CodeMirror.Editor;
+    document.append_code_block(
+      'test line in Python 1\n%R test line in R 1',
+      cm_editor_for_cell_1
+    );
+    document.append_code_block(
+      'test line in Python 2\n%R test line in R 2',
+      cm_editor_for_cell_2
+    );
+  };
+
+  describe('transform_virtual_to_editor', () => {
+    it('transforms positions for the top level document', () => {
+      init_document_with_Python_and_R();
+      // The first (Python) line in the first block
+      let editor_position = document.transform_virtual_to_editor({
+        line: 0,
+        ch: 0
+      } as IVirtualPosition);
+      expect(editor_position.line).to.equal(0);
+      expect(editor_position.ch).to.equal(0);
+
+      // The first (Python) line in the second block
+      editor_position = document.transform_virtual_to_editor({
+        line: 4,
+        ch: 0
+      } as IVirtualPosition);
+      expect(editor_position.line).to.equal(0);
+      expect(editor_position.ch).to.equal(0);
+    });
+
+    it('transforms positions for the nested foreign documents', () => {
+      init_document_with_Python_and_R();
+      let foreign_document = document.document_at_source_position({
+        line: 1,
+        ch: 3
+      } as ISourcePosition);
+      expect(foreign_document).to.not.equal(document);
+
+      // The second (R) line in the first block
+      let editor_position = foreign_document.transform_virtual_to_editor({
+        line: 0,
+        ch: 0
+      } as IVirtualPosition);
+      expect(editor_position.line).to.equal(1);
+      expect(editor_position.ch).to.equal(3);
+
+      // The second (R) line in the second block
+      editor_position = foreign_document.transform_virtual_to_editor({
+        line: 3,
+        ch: 0
+      } as IVirtualPosition);
+      expect(editor_position.line).to.equal(1);
+      expect(editor_position.ch).to.equal(3);
     });
   });
 });

--- a/src/virtual/document.spec.ts
+++ b/src/virtual/document.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import { RegExpForeignCodeExtractor } from '../extractors/regexp';
+import { VirtualDocument } from './document';
+
+let R_LINE_MAGICS = `%R df = data.frame()
+print("df created")
+%R ggplot(df)
+print("plotted")
+`;
+
+describe('RegExpForeignCodeExtractor', () => {
+
+  let r_line_extractor_removing = new RegExpForeignCodeExtractor({
+    language: 'R',
+    pattern: '(^|\n)%R (.*)\n',
+    extract_to_foreign: '$2',
+    keep_in_host: false,
+    is_standalone: false
+  });
+
+  describe('#extract_foreign_code', () => {
+    it('joins non-standalone fragments together for both foreign and host code', () => {
+      let document = new VirtualDocument(
+        'python',
+        'test.ipynb',
+        {},
+        { python: [r_line_extractor_removing] },
+        false
+      );
+
+      let {
+        cell_code_kept,
+        foreign_document_map
+      } = document.extract_foreign_code(R_LINE_MAGICS, null);
+
+      expect(cell_code_kept).to.equal('print("df created")\nprint("plotted")\n');
+      expect(foreign_document_map.size).to.equal(2);
+
+      let r_document = foreign_document_map.get(
+        foreign_document_map.keys().next().value
+      );
+      expect(r_document.language).to.equal('R');
+      expect(r_document.value).to.equal('df = data.frame()\n\n\nggplot(df)\n');
+    });
+  });
+});

--- a/src/virtual/document.spec.ts
+++ b/src/virtual/document.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { RegExpForeignCodeExtractor } from '../extractors/regexp';
 import { VirtualDocument } from './document';
-import CodeMirror = require("codemirror");
-import { ISourcePosition, IVirtualPosition } from "../positioning";
+import CodeMirror = require('codemirror');
+import { ISourcePosition, IVirtualPosition } from '../positioning';
 
 let R_LINE_MAGICS = `%R df = data.frame()
 print("df created")
@@ -31,7 +31,10 @@ describe('RegExpForeignCodeExtractor', () => {
       let {
         cell_code_kept,
         foreign_document_map
-      } = document.extract_foreign_code(R_LINE_MAGICS, null, { line: 0, column: 0 });
+      } = document.extract_foreign_code(R_LINE_MAGICS, null, {
+        line: 0,
+        column: 0
+      });
 
       expect(cell_code_kept).to.equal(
         'print("df created")\nprint("plotted")\n'

--- a/src/virtual/document.spec.ts
+++ b/src/virtual/document.spec.ts
@@ -9,7 +9,6 @@ print("plotted")
 `;
 
 describe('RegExpForeignCodeExtractor', () => {
-
   let r_line_extractor_removing = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '(^|\n)%R (.*)\n',

--- a/src/virtual/document.spec.ts
+++ b/src/virtual/document.spec.ts
@@ -11,7 +11,7 @@ print("plotted")
 describe('RegExpForeignCodeExtractor', () => {
   let r_line_extractor_removing = new RegExpForeignCodeExtractor({
     language: 'R',
-    pattern: '(^|\n)%R (.*)\n',
+    pattern: '(^|\n)%R (.*)\n?',
     extract_to_foreign: '$2',
     keep_in_host: false,
     is_standalone: false
@@ -32,7 +32,9 @@ describe('RegExpForeignCodeExtractor', () => {
         foreign_document_map
       } = document.extract_foreign_code(R_LINE_MAGICS, null);
 
-      expect(cell_code_kept).to.equal('print("df created")\nprint("plotted")\n');
+      expect(cell_code_kept).to.equal(
+        'print("df created")\nprint("plotted")\n'
+      );
       expect(foreign_document_map.size).to.equal(2);
 
       let r_document = foreign_document_map.get(

--- a/src/virtual/document.spec.ts
+++ b/src/virtual/document.spec.ts
@@ -37,7 +37,7 @@ describe('RegExpForeignCodeExtractor', () => {
       );
       expect(foreign_document_map.size).to.equal(2);
 
-      let r_document = foreign_document_map.get(
+      let { virtual_document: r_document } = foreign_document_map.get(
         foreign_document_map.keys().next().value
       );
       expect(r_document.language).to.equal('R');

--- a/src/virtual/document.ts
+++ b/src/virtual/document.ts
@@ -540,40 +540,6 @@ export class VirtualDocument {
     } as ISourcePosition;
   }
 
-  /*
-  shift(pos: CodeMirror.Position): CodeMirror.Position {
-    let transformed = {
-      line: pos.line - this._shift.start.line,
-      ch: pos.ch - (pos.line === 0 ? this._shift.start.column : 0)
-    };
-    if (this.parent) {
-      return this.parent.shift(transformed);
-    }
-    return transformed;
-  }
-
-  unshift(
-    editor_position: IEditorPosition,
-    source_position: ISourcePosition
-  ): IEditorPosition {
-    // TODO: shift and unshift should be done in the offset space?
-    let source_position_ce = PositionConverter.cm_to_ce(source_position);
-    let shift: CodeEditor.IPosition = { line: 0, column: 0 };
-    let block_foreign_documents = this.source_lines.get(source_position.line).foreign_documents_map;
-    for (let range of block_foreign_documents.keys()) {
-      if (is_within_range(source_position_ce, range)) {
-        shift = range.start;
-        break;
-      }
-    }
-    return {
-      ...editor_position,
-      line: editor_position.line + shift.line,
-      ch: editor_position.ch + (editor_position.line === 0 ? shift.column : 0)
-    };
-  }
-   */
-
   get root(): VirtualDocument {
     if (typeof this.parent === 'undefined') {
       return this;

--- a/src/virtual/editor.spec.ts
+++ b/src/virtual/editor.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from 'chai';
+import { VirtualEditor } from './editor';
+import { RegExpForeignCodeExtractor } from '../extractors/regexp';
+import {
+  IEditorPosition,
+  IRootPosition,
+  IVirtualPosition
+} from '../positioning';
+import CodeMirror = require('codemirror');
+
+class VirtualEditorImplementation extends VirtualEditor {
+  get_cm_editor(position: IRootPosition): CodeMirror.Editor {
+    return undefined;
+  }
+
+  get_editor_index(position: IVirtualPosition): number {
+    return 0;
+  }
+
+  transform_editor_to_root(
+    cm_editor: CodeMirror.Editor,
+    position: IEditorPosition
+  ): IRootPosition {
+    return undefined;
+  }
+
+  transform_virtual_to_source(
+    position: CodeMirror.Position
+  ): CodeMirror.Position {
+    return undefined;
+  }
+}
+
+
+describe('VirtualEditor', () => {
+  let r_line_extractor = new RegExpForeignCodeExtractor({
+    language: 'R',
+    pattern: '(^|\n)%R (.*)\n?',
+    extract_to_foreign: '$2',
+    keep_in_host: true,
+    is_standalone: false
+  });
+
+  let editor = new VirtualEditorImplementation(
+    'python',
+    'test.ipynb',
+    {},
+    { python: [r_line_extractor] }
+  );
+  describe('#get_virtual_document()', () => {
+    it('returns correct document', () => {
+      let cm_editor_for_cell_1 = {} as CodeMirror.Editor;
+      let cm_editor_for_cell_2 = {} as CodeMirror.Editor;
+      editor.virtual_document.append_code_block(
+        'test line in Python 1\n%R test line in R 1',
+        cm_editor_for_cell_1
+      );
+      editor.virtual_document.append_code_block(
+        'test line in Python 2\n%R test line in R 2',
+        cm_editor_for_cell_2
+      );
+
+      // The first (Python) line in the first block
+      let { document, virtual_position } = editor.get_virtual_document({
+        line: 0,
+        ch: 0
+      } as IRootPosition);
+      expect(document).to.equal(editor.virtual_document);
+      expect(virtual_position.line).to.equal(0);
+
+      // The second (Python | R) line in the first block - Python fragment
+      ({ document, virtual_position } = editor.get_virtual_document({
+        line: 1,
+        ch: 0
+      } as IRootPosition));
+      expect(document).to.equal(editor.virtual_document);
+      expect(virtual_position.line).to.equal(1);
+
+      // The second (Python | R) line in the first block - R fragment
+      ({ document, virtual_position } = editor.get_virtual_document({
+        line: 1,
+        ch: 3
+      } as IRootPosition));
+      expect(document).to.not.equal(editor.virtual_document);
+      expect(virtual_position.line).to.equal(0);
+
+      // The first (Python) line in the second block
+      ({ document, virtual_position } = editor.get_virtual_document({
+        line: 2,
+        ch: 0
+      } as IRootPosition));
+      expect(document).to.equal(editor.virtual_document);
+      expect(virtual_position.line).to.equal(2 + 2);
+
+      // The second (Python | R) line in the second block - Python fragment
+      ({ document, virtual_position } = editor.get_virtual_document({
+        line: 3,
+        ch: 0
+      } as IRootPosition));
+      expect(document).to.equal(editor.virtual_document);
+      expect(virtual_position.line).to.equal(2 + 2 + 1);
+
+      // The second (Python | R) line in the second block - R fragment
+      ({ document, virtual_position } = editor.get_virtual_document({
+        line: 3,
+        ch: 3
+      } as IRootPosition));
+      expect(document).to.not.equal(editor.virtual_document);
+      // 0 + 1 (next line) + 2 (between-block spacing)
+      expect(virtual_position.line).to.equal(1 + 2);
+    });
+  });
+});

--- a/src/virtual/editor.spec.ts
+++ b/src/virtual/editor.spec.ts
@@ -29,8 +29,12 @@ class VirtualEditorImplementation extends VirtualEditor {
   ): CodeMirror.Position {
     return undefined;
   }
-}
 
+  addEventListener(
+    type: string,
+    listener: EventListener | EventListenerObject
+  ): void {}
+}
 
 describe('VirtualEditor', () => {
   let r_line_extractor = new RegExpForeignCodeExtractor({

--- a/src/virtual/editor.spec.ts
+++ b/src/virtual/editor.spec.ts
@@ -65,50 +65,56 @@ describe('VirtualEditor', () => {
       );
 
       // The first (Python) line in the first block
-      let { document, virtual_position } = editor.get_virtual_document({
-        line: 0,
-        ch: 0
-      } as IRootPosition);
+      let root_position = { line: 0, ch: 0 } as IRootPosition;
+      let document = editor.document_as_root_position(root_position);
+      let virtual_position = editor.root_position_to_virtual_position(
+        root_position
+      );
       expect(document).to.equal(editor.virtual_document);
       expect(virtual_position.line).to.equal(0);
 
       // The second (Python | R) line in the first block - Python fragment
-      ({ document, virtual_position } = editor.get_virtual_document({
-        line: 1,
-        ch: 0
-      } as IRootPosition));
+      root_position = { line: 1, ch: 0 } as IRootPosition;
+      document = editor.document_as_root_position(root_position);
+      virtual_position = editor.root_position_to_virtual_position(
+        root_position
+      );
       expect(document).to.equal(editor.virtual_document);
       expect(virtual_position.line).to.equal(1);
 
       // The second (Python | R) line in the first block - R fragment
-      ({ document, virtual_position } = editor.get_virtual_document({
-        line: 1,
-        ch: 3
-      } as IRootPosition));
+      root_position = { line: 1, ch: 3 } as IRootPosition;
+      document = editor.document_as_root_position(root_position);
+      virtual_position = editor.root_position_to_virtual_position(
+        root_position
+      );
       expect(document).to.not.equal(editor.virtual_document);
       expect(virtual_position.line).to.equal(0);
 
       // The first (Python) line in the second block
-      ({ document, virtual_position } = editor.get_virtual_document({
-        line: 2,
-        ch: 0
-      } as IRootPosition));
+      root_position = { line: 2, ch: 0 } as IRootPosition;
+      document = editor.document_as_root_position(root_position);
+      virtual_position = editor.root_position_to_virtual_position(
+        root_position
+      );
       expect(document).to.equal(editor.virtual_document);
       expect(virtual_position.line).to.equal(2 + 2);
 
       // The second (Python | R) line in the second block - Python fragment
-      ({ document, virtual_position } = editor.get_virtual_document({
-        line: 3,
-        ch: 0
-      } as IRootPosition));
+      root_position = { line: 3, ch: 0 } as IRootPosition;
+      document = editor.document_as_root_position(root_position);
+      virtual_position = editor.root_position_to_virtual_position(
+        root_position
+      );
       expect(document).to.equal(editor.virtual_document);
       expect(virtual_position.line).to.equal(2 + 2 + 1);
 
       // The second (Python | R) line in the second block - R fragment
-      ({ document, virtual_position } = editor.get_virtual_document({
-        line: 3,
-        ch: 3
-      } as IRootPosition));
+      root_position = { line: 3, ch: 3 } as IRootPosition;
+      document = editor.document_as_root_position(root_position);
+      virtual_position = editor.root_position_to_virtual_position(
+        root_position
+      );
       expect(document).to.not.equal(editor.virtual_document);
       // 0 + 1 (next line) + 2 (between-block spacing)
       expect(virtual_position.line).to.equal(1 + 2);

--- a/src/virtual/editor.ts
+++ b/src/virtual/editor.ts
@@ -82,7 +82,7 @@ export abstract class VirtualEditor implements CodeMirror.Editor {
     return this.virtual_document.root.get_editor_at_source_line(root_position);
   }
 
-  transform_root_position_to_editor_position(
+  root_position_to_editor_position(
     root_position: IRootPosition
   ): IEditorPosition {
     return this.virtual_document.root.transform_source_to_editor(root_position);

--- a/src/virtual/editor.ts
+++ b/src/virtual/editor.ts
@@ -20,7 +20,7 @@ export abstract class VirtualEditor implements CodeMirror.Editor {
   overrides_registry: IOverridesRegistry;
   code_extractors: IForeignCodeExtractorsRegistry;
 
-  protected constructor(
+  public constructor(
     language: string,
     path: string,
     overrides_registry: IOverridesRegistry,
@@ -72,9 +72,7 @@ export abstract class VirtualEditor implements CodeMirror.Editor {
   transform_root_position_to_editor_position(
     root_position: IRootPosition
   ): IEditorPosition {
-    return this.virtual_document.root.transform_source_to_editor(
-      root_position
-    );
+    return this.virtual_document.root.transform_source_to_editor(root_position);
   }
 }
 

--- a/src/virtual/editor.ts
+++ b/src/virtual/editor.ts
@@ -54,20 +54,28 @@ export abstract class VirtualEditor implements CodeMirror.Editor {
   ): void;
 
   // TODO .root is not really needed as we are in editor now...
+  // TODO remove this function
   get_virtual_document(
     position: IRootPosition
   ): { document: VirtualDocument; virtual_position: IVirtualPosition } {
+    return {
+      document: this.document_as_root_position(position),
+      virtual_position: this.root_position_to_virtual_position(position)
+    };
+  }
+
+  document_as_root_position(position: IRootPosition): VirtualDocument {
     let root_as_source = position as ISourcePosition;
-    let document = this.virtual_document.root.document_at_source_position(
+    return this.virtual_document.root.document_at_source_position(
       root_as_source
     );
+  }
 
-    return {
-      document: document,
-      virtual_position: this.virtual_document.root.virtual_position_at_document(
-        root_as_source
-      )
-    };
+  root_position_to_virtual_position(position: IRootPosition): IVirtualPosition {
+    let root_as_source = position as ISourcePosition;
+    return this.virtual_document.root.virtual_position_at_document(
+      root_as_source
+    );
   }
 
   get_editor_at_root_position(root_position: IRootPosition) {

--- a/src/virtual/editor.ts
+++ b/src/virtual/editor.ts
@@ -48,6 +48,11 @@ export abstract class VirtualEditor implements CodeMirror.Editor {
 
   abstract get_cm_editor(position: IRootPosition): CodeMirror.Editor;
 
+  abstract addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject
+  ): void;
+
   // TODO .root is not really needed as we are in editor now...
   get_virtual_document(
     position: IRootPosition

--- a/src/virtual/editors/file_editor.ts
+++ b/src/virtual/editors/file_editor.ts
@@ -1,14 +1,15 @@
 import { VirtualEditor } from '../editor';
 import { CodeMirror } from '../../adapters/codemirror';
+import { IEditorPosition, IRootPosition } from '../../positioning';
 
 export class VirtualFileEditor extends VirtualEditor {
   protected cm_editor: CodeMirror.Editor;
 
-  constructor(language: string, cm_editor: CodeMirror.Editor) {
+  constructor(language: string, path: string, cm_editor: CodeMirror.Editor) {
     // TODO: for now the magics and extractors are not used in FileEditor,
     //  although it would make sense to pass extractors (e.g. for CSS in HTML,
     //  or SQL in Python files) in the future.
-    super(language, {}, {});
+    super(language, path, {}, {});
     this.cm_editor = cm_editor;
     let handler = {
       get: function(
@@ -26,22 +27,23 @@ export class VirtualFileEditor extends VirtualEditor {
     return new Proxy(this, handler);
   }
 
-  // duck typing: to enable use of notebook mapper
-  public get transform(): (
+  public transform_virtual_to_source(
     position: CodeMirror.Position
-  ) => CodeMirror.Position {
-    return position => position;
+  ): CodeMirror.Position {
+    return position;
+  }
+  public transform_editor_to_root(
+    cm_editor: CodeMirror.Editor,
+    position: IEditorPosition
+  ): IRootPosition {
+    return (position as unknown) as IRootPosition;
   }
 
   public get_editor_index(position: CodeMirror.Position): number {
     return 0;
   }
 
-  public get get_cell_id(): (position: CodeMirror.Position) => string {
-    return position => '';
-  }
-
-  get_cm_editor(position: CodeMirror.Position): CodeMirror.Editor {
+  get_cm_editor(position: IRootPosition): CodeMirror.Editor {
     return undefined;
   }
 

--- a/src/virtual/editors/file_editor.ts
+++ b/src/virtual/editors/file_editor.ts
@@ -56,4 +56,8 @@ export class VirtualFileEditor extends VirtualEditor {
     );
     return this.virtual_document.value;
   }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    this.cm_editor.getWrapperElement().addEventListener(type, listener);
+  }
 }

--- a/src/virtual/editors/notebook.ts
+++ b/src/virtual/editors/notebook.ts
@@ -8,7 +8,7 @@ import { VirtualEditor } from '../editor';
 import CodeMirror = require('codemirror');
 import {
   IEditorPosition,
-  IRootPosition,
+  IRootPosition, ISourcePosition,
   IVirtualPosition
 } from '../../positioning';
 
@@ -90,7 +90,9 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     };
     return new Proxy(this, handler);
   }
-  public transform_virtual_to_source(position: CodeMirror.Position): CodeMirror.Position {
+  public transform_virtual_to_source(
+    position: IVirtualPosition
+  ): ISourcePosition {
     return this.virtual_document.transform_virtual_to_source(position);
   }
 

--- a/src/virtual/editors/notebook.ts
+++ b/src/virtual/editors/notebook.ts
@@ -4,53 +4,56 @@ import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { ShowHintOptions } from 'codemirror';
 import { IOverridesRegistry } from '../../magics/overrides';
 import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
-import { VirtualDocument } from '../document';
 import { VirtualEditor } from '../editor';
 import CodeMirror = require('codemirror');
+import {
+  IEditorPosition,
+  IRootPosition,
+  IVirtualPosition
+} from '../../positioning';
 
 // @ts-ignore
 class DocDispatcher implements CodeMirror.Doc {
-  notebook_map: VirtualEditorForNotebook;
+  virtual_editor: VirtualEditorForNotebook;
 
-  constructor(notebook_map: VirtualEditorForNotebook) {
-    // TODO
-    this.notebook_map = notebook_map;
+  constructor(virtual_notebook: VirtualEditorForNotebook) {
+    this.virtual_editor = virtual_notebook;
   }
 
   markText(
-    from: CodeMirror.Position,
-    to: CodeMirror.Position,
+    from: IRootPosition,
+    to: IRootPosition,
     options?: CodeMirror.TextMarkerOptions
   ): CodeMirror.TextMarker {
     // TODO: edgecase: from and to in different cells
-    let editor = this.notebook_map.get_editor_at(from);
+    let editor = this.virtual_editor.virtual_document.get_editor_at_source_line(from);
+    let notebook_map = this.virtual_editor;
     return editor
       .getDoc()
-      .markText(this.transform(from), this.transform(to), options);
-  }
-
-  transform(position: CodeMirror.Position) {
-    return this.notebook_map.transform_from_document(position);
+      .markText(
+        notebook_map.transform_from_root_to_editor(from),
+        notebook_map.transform_from_root_to_editor(to),
+        options
+      );
   }
 
   getValue(seperator?: string): string {
-    return this.notebook_map.getValue();
+    return this.virtual_editor.getValue();
   }
 
   getCursor(start?: string): CodeMirror.Position {
-    let cell = this.notebook_map.notebook.activeCell;
+    let cell = this.virtual_editor.notebook.activeCell;
     let active_editor = cell.editor as CodeMirrorEditor;
     let cursor = active_editor.editor.getDoc().getCursor(start);
-    return this.notebook_map.transform_from_notebook(cell, cursor);
+    return this.virtual_editor.transform_from_notebook_to_root(cell, cursor);
   }
 }
 
 export class VirtualEditorForNotebook extends VirtualEditor {
   notebook: Notebook;
   notebook_panel: NotebookPanel;
-  notebook_line_to_virtual_document: Map<number, VirtualDocument>;
 
-  first_line_of_notebook_cell_to_virtual_line: Map<Cell, number>;
+  cell_to_corresponding_source_line: Map<Cell, number>;
   cm_editor_to_cell: Map<CodeMirror.Editor, Cell>;
   language: string;
 
@@ -58,12 +61,13 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     notebook_panel: NotebookPanel,
     language: string,
     overrides_registry: IOverridesRegistry,
-    foreign_code_extractors: IForeignCodeExtractorsRegistry
+    foreign_code_extractors: IForeignCodeExtractorsRegistry,
+    path: string
   ) {
-    super(language, overrides_registry, foreign_code_extractors);
+    super(language, path, overrides_registry, foreign_code_extractors);
     this.notebook_panel = notebook_panel;
     this.notebook = notebook_panel.content;
-    this.first_line_of_notebook_cell_to_virtual_line = new Map();
+    this.cell_to_corresponding_source_line = new Map();
     this.cm_editor_to_cell = new Map();
     this.overrides_registry = overrides_registry;
     this.code_extractors = foreign_code_extractors;
@@ -86,25 +90,47 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     };
     return new Proxy(this, handler);
   }
-  public get transform(): (
-    position: CodeMirror.Position
-  ) => CodeMirror.Position {
-    return position => this.transform_from_document(position);
+  public transform_virtual_to_source(position: CodeMirror.Position): CodeMirror.Position {
+    return this.virtual_document.transform_virtual_to_source(position);
   }
 
-  public get_editor_index(position: CodeMirror.Position): number {
+  transform_from_notebook_to_root(
+    cell: Cell,
+    position: CodeMirror.Position
+  ): IRootPosition {
+    // TODO: if cell is not known, refresh
+    let shift = this.cell_to_corresponding_source_line.get(cell);
+    if (shift === undefined) {
+      throw Error('Cell not found in cell_line_map');
+    }
+    return {
+      ...position,
+      line: position.line + shift
+    } as IRootPosition;
+  }
+
+  public transform_editor_to_root(
+    cm_editor: CodeMirror.Editor,
+    position: IEditorPosition
+  ): IRootPosition {
+    let cell = this.cm_editor_to_cell.get(cm_editor);
+    return this.transform_from_notebook_to_root(cell, position);
+  }
+
+  transform_from_root_to_editor(pos: IRootPosition): CodeMirror.Position {
+    // from notebook to editor space
+    return this.virtual_document.transform_source_to_editor(pos);
+  }
+
+  public get_editor_index(position: IVirtualPosition): number {
     let cell = this.get_cell_at(position);
     return this.notebook.widgets.findIndex(other_cell => {
       return cell === other_cell;
     });
   }
 
-  public get get_cell_id(): (position: CodeMirror.Position) => string {
-    return position => this.get_cell_at(position).id;
-  }
-
-  get_cm_editor(position: CodeMirror.Position) {
-    return this.get_editor_at(position);
+  get_cm_editor(position: IRootPosition) {
+    return this.get_editor_at_root_line(position);
   }
 
   showHint: (options: ShowHintOptions) => void;
@@ -145,25 +171,12 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     return undefined;
   }
 
-  addWidget(
-    pos: CodeMirror.Position,
-    node: HTMLElement,
-    scrollIntoView: boolean
-  ): void {}
-
-  blockComment(
-    from: Position,
-    to: Position,
-    // @ts-ignore
-    options?: CodeMirror.CommentOptions
-  ): void {}
-
   charCoords(
-    pos: CodeMirror.Position,
+    pos: IRootPosition,
     mode?: 'window' | 'page' | 'local'
   ): { left: number; right: number; top: number; bottom: number } {
     try {
-      let editor = this.get_editor_at(pos);
+      let editor = this.get_editor_at_root_line(pos);
       return editor.charCoords(pos, mode);
     } catch (e) {
       console.log(e);
@@ -171,12 +184,10 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     }
   }
 
-  clearGutter(gutterID: string): void {}
-
   coordsChar(
     object: { left: number; top: number },
     mode?: 'window' | 'page' | 'local'
-  ): CodeMirror.Position {
+  ): IRootPosition {
     for (let cell of this.notebook.widgets) {
       // TODO: use some more intelligent strategy to determine editors to test
       let cm_editor = cell.editor as CodeMirrorEditor;
@@ -187,23 +198,8 @@ export class VirtualEditorForNotebook extends VirtualEditor {
         continue;
       }
 
-      return this.transform_from_notebook(cell, pos);
+      return this.transform_from_notebook_to_root(cell, pos);
     }
-  }
-
-  transform_from_notebook(
-    cell: Cell,
-    position: CodeMirror.Position
-  ): CodeMirror.Position {
-    // TODO: if cell is not known, refresh
-    let shift = this.first_line_of_notebook_cell_to_virtual_line.get(cell);
-    if (shift === undefined) {
-      throw Error('Cell not found in cell_line_map');
-    }
-    return {
-      ...position,
-      line: position.line + shift
-    };
   }
 
   cursorCoords(
@@ -211,16 +207,16 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     mode?: 'window' | 'page' | 'local'
   ): { left: number; top: number; bottom: number };
   cursorCoords(
-    where?: CodeMirror.Position | null,
+    where?: IRootPosition | null,
     mode?: 'window' | 'page' | 'local'
   ): { left: number; top: number; bottom: number };
   cursorCoords(
-    where?: boolean | CodeMirror.Position | null,
+    where?: boolean | IRootPosition | null,
     mode?: 'window' | 'page' | 'local'
   ): { left: number; top: number; bottom: number } {
     if (typeof where !== 'boolean') {
-      let editor = this.get_editor_at(where);
-      return editor.cursorCoords(this.transform_from_document(where));
+      let editor = this.get_editor_at_root_line(where);
+      return editor.cursorCoords(this.transform_from_root_to_editor(where));
     }
     return { bottom: 0, left: 0, top: 0 };
   }
@@ -251,104 +247,43 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     }
   }
 
-  findPosH(
-    start: CodeMirror.Position,
-    amount: number,
-    unit: string,
-    visually: boolean
-  ): { line: number; ch: number; hitSide?: boolean } {
-    return { ch: 0, line: 0 };
-  }
-
-  findPosV(
-    start: CodeMirror.Position,
-    amount: number,
-    unit: string
-  ): { line: number; ch: number; hitSide?: boolean } {
-    return { ch: 0, line: 0 };
-  }
-
-  findWordAt(pos: CodeMirror.Position): CodeMirror.Range {
-    return undefined;
-  }
-
-  focus(): void {}
-
   getDoc(): CodeMirror.Doc {
     let dummy_doc = new DocDispatcher(this);
     // @ts-ignore
     return dummy_doc;
   }
 
-  getGutterElement(): HTMLElement {
-    return undefined;
+  get_editor_at_root_line(pos: IRootPosition): CodeMirror.Editor {
+    return this.virtual_document.root.get_editor_at_source_line(pos);
   }
 
-  getInputField(): HTMLTextAreaElement {
-    return undefined;
-  }
-
-  getLineTokens(line: number, precise?: boolean): CodeMirror.Token[] {
-    return [];
-  }
-
-  getModeAt(pos: CodeMirror.Position): any {
-    return this.get_editor_at(pos).getModeAt(this.transform_from_document(pos));
-  }
-
-  getOption(option: string): any {
-    return this.any_editor.getOption(option);
-  }
-
-  getScrollInfo(): CodeMirror.ScrollInfo {
-    return undefined;
-  }
-
-  getScrollerElement(): HTMLElement {
-    return undefined;
-  }
-
-  getStateAfter(line?: number): any {}
-
-  getTokenAt(pos: CodeMirror.Position, precise?: boolean): CodeMirror.Token {
+  getTokenAt(pos: IRootPosition, precise?: boolean): CodeMirror.Token {
     if (pos === undefined) {
       return;
     }
-    let editor = this.get_editor_at(pos);
-    return editor.getTokenAt(this.transform_from_document(pos));
+    let editor = this.get_editor_at_root_line(pos);
+    return editor.getTokenAt(this.transform_from_root_to_editor(pos));
   }
 
-  getTokenTypeAt(pos: CodeMirror.Position): string {
-    let editor = this.get_editor_at(pos);
-    return editor.getTokenTypeAt(this.transform_from_document(pos));
+  getTokenTypeAt(pos: IRootPosition): string {
+    let editor = this.virtual_document.get_editor_at_source_line(pos);
+    return editor.getTokenTypeAt(this.transform_from_root_to_editor(pos));
   }
 
   // TODO: make a mapper class, with mapping function only
-  get_editor_at(pos: CodeMirror.Position): CodeMirror.Editor {
-    return this.virtual_document.virtual_lines.get(pos.line).editor_coordinates
-      .editor;
-  }
 
-  get_cell_at(pos: CodeMirror.Position): Cell {
-    let cm_editor = this.virtual_document.virtual_lines.get(pos.line)
-      .editor_coordinates.editor;
+  get_cell_at(pos: IVirtualPosition): Cell {
+    let cm_editor = this.get_editor_at_virtual_line(pos);
     return this.cm_editor_to_cell.get(cm_editor);
   }
 
-  transform_from_document(pos: CodeMirror.Position): CodeMirror.Position {
-    // from virtual document space to notebook space
-    return {
-      ...pos,
-      line:
-        pos.line -
-        this.virtual_document.virtual_lines.get(pos.line).editor_coordinates
-          .line_shift
-    };
+  get_editor_at_virtual_line(pos: IVirtualPosition): CodeMirror.Editor {
+    return this.virtual_document.get_editor_at_virtual_line(pos);
   }
 
   getValue(seperator?: string): string {
     this.virtual_document.clear();
-    this.first_line_of_notebook_cell_to_virtual_line.clear();
+    this.cell_to_corresponding_source_line.clear();
     this.cm_editor_to_cell.clear();
 
     this.notebook.widgets.every(cell => {
@@ -359,9 +294,9 @@ export class VirtualEditorForNotebook extends VirtualEditor {
       if (cell.model.type === 'code') {
         let cell_code = cm_editor.getValue(seperator);
         // every code cell is placed into the cell-map
-        this.first_line_of_notebook_cell_to_virtual_line.set(
+        this.cell_to_corresponding_source_line.set(
           cell,
-          this.virtual_document.last_line
+          this.virtual_document.last_source_line
         );
 
         this.virtual_document.append_code_block(cell_code, cm_editor);
@@ -372,16 +307,8 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     return this.virtual_document.value;
   }
 
-  getViewport(): { from: number; to: number } {
-    return { from: 0, to: 0 };
-  }
-
   getWrapperElement(): HTMLElement {
     return this.notebook_panel.node;
-  }
-
-  hasFocus(): boolean {
-    return false;
   }
 
   heightAtLine(
@@ -392,45 +319,12 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     return 0;
   }
 
-  indentLine(line: number, dir?: string): void {}
-
   isReadOnly(): boolean {
     return false;
   }
 
   lineAtHeight(height: number, mode?: 'window' | 'page' | 'local'): number {
     return 0;
-  }
-
-  lineComment(
-    from: Position,
-    to: Position,
-    // @ts-ignore
-    options?: CodeMirror.CommentOptions
-  ): void {}
-
-  lineInfo(
-    line: any
-  ): {
-    line: any;
-    handle: any;
-    text: string;
-    gutterMarkers: any;
-    textClass: string;
-    bgClass: string;
-    wrapClass: string;
-    widgets: any;
-  } {
-    return {
-      bgClass: '',
-      gutterMarkers: undefined,
-      handle: undefined,
-      line: undefined,
-      text: '',
-      textClass: '',
-      widgets: undefined,
-      wrapClass: ''
-    };
   }
 
   off(eventName: string, handler: (instance: CodeMirror.Editor) => void): void;
@@ -740,81 +634,5 @@ export class VirtualEditorForNotebook extends VirtualEditor {
         cm_editor.on(eventName, wrapped_handler);
       }
     });
-  }
-
-  operation<T>(fn: () => T): T {
-    return undefined;
-  }
-
-  refresh(): void {}
-
-  removeKeyMap(map: string | CodeMirror.KeyMap): void {}
-
-  removeLineClass(
-    line: any,
-    where: string,
-    class_?: string
-  ): CodeMirror.LineHandle {
-    return undefined;
-  }
-
-  removeOverlay(mode: any): void {}
-
-  scrollIntoView(pos: CodeMirror.Position | null, margin?: number): void;
-  scrollIntoView(
-    pos: { left: number; top: number; right: number; bottom: number },
-    margin?: number
-  ): void;
-  scrollIntoView(pos: { line: number; ch: number }, margin?: number): void;
-  scrollIntoView(
-    pos: { from: CodeMirror.Position; to: CodeMirror.Position },
-    margin?: number
-  ): void;
-  scrollIntoView(
-    pos:
-      | CodeMirror.Position
-      | null
-      | { left: number; top: number; right: number; bottom: number }
-      | { line: number; ch: number }
-      | { from: CodeMirror.Position; to: CodeMirror.Position },
-    margin?: number
-  ): void {}
-
-  scrollTo(x?: number | null, y?: number | null): void {}
-
-  setGutterMarker(
-    line: any,
-    gutterID: string,
-    value: HTMLElement | null
-  ): CodeMirror.LineHandle {
-    return undefined;
-  }
-
-  setOption(option: string, value: any): void {}
-
-  setSize(width: any, height: any): void {}
-
-  setValue(content: string): void {}
-
-  startOperation(): void {}
-
-  swapDoc(doc: CodeMirror.Doc): CodeMirror.Doc {
-    return undefined;
-  }
-
-  // @ts-ignore
-  toggleComment(options?: CodeMirror.CommentOptions): void {}
-
-  toggleOverwrite(value?: boolean): void {}
-
-  triggerOnKeyDown(event: Event): void {}
-
-  uncomment(
-    from: Position,
-    to: Position,
-    // @ts-ignore
-    options?: CodeMirror.CommentOptions
-  ): boolean {
-    return false;
   }
 }


### PR DESCRIPTION
Correctly implements LSP for `%%time`, `%%python` and `%%R` cell magics; allows for the LSP use in nested code for any kernel, providing simple extractor interface to define patterns in the source which should be treated as a foreign language.

Related groundwork, which was backwards compatible, is already in master:
- Add virtual document abstraction: 75fd1b396b7d49071ed425b0dace827c131e2f8e
- Documentation: eb79664ad46ca063dfbdd73d0185cedca072a393, 6282f23b097b5edd3e61b224fc2bcf87c7f9f560, 
- Implement foreign documents connections: bd643b487a4efb8f26c2609b72f4519e869f0820