### PR TITLE
Add "rename" action

### DIFF
--- a/src/adapters/codemirror/feature.ts
+++ b/src/adapters/codemirror/feature.ts
@@ -18,6 +18,19 @@ export enum CommandEntryPoint {
   FileEditorContextMenu
 }
 
+function toDocumentChanges(changes: {
+  [uri: string]: lsProtocol.TextEdit[];
+}): lsProtocol.TextDocumentEdit[] {
+  let documentChanges = [];
+  for (let uri of Object.keys(changes)) {
+    documentChanges.push({
+      textDocument: { uri },
+      edits: changes[uri]
+    } as lsProtocol.TextDocumentEdit);
+  }
+  return documentChanges;
+}
+
 export interface IFeatureCommand {
   /**
    * The command id; it will be prepended with 'lsp' prefix.
@@ -215,5 +228,41 @@ export class CodeMirrorLSPFeature implements ILSPFeature {
     return range.editor
       .getDoc()
       .markText(range.start, range.end, { className: class_name });
+  }
+
+  protected apply_edit(workspaceEdit: lsProtocol.WorkspaceEdit) {
+    console.log(workspaceEdit);
+    let current_uri = this.connection.getDocumentUri();
+    // Specs: documentChanges are preferred over changes
+    let changes = workspaceEdit.documentChanges
+      ? workspaceEdit.documentChanges.map(
+          change => change as lsProtocol.TextDocumentEdit
+        )
+      : toDocumentChanges(workspaceEdit.changes);
+    for (let change of changes) {
+      let uri = change.textDocument.uri;
+      if (uri !== current_uri) {
+        console.warn('Workspace-wide edits not implemented yet');
+      } else {
+        // TODO: show "Renamed X to Y in {change.edits.length} places" in statusbar;
+        for (let edit of change.edits) {
+          let start = PositionConverter.lsp_to_cm(edit.range.start);
+          let end = PositionConverter.lsp_to_cm(edit.range.end);
+
+          let start_editor = this.virtual_document.get_editor_at_virtual_line(
+            start as IVirtualPosition
+          );
+          let end_editor = this.virtual_document.get_editor_at_virtual_line(
+            end as IVirtualPosition
+          );
+          if (start_editor !== end_editor) {
+            console.log('Edits not implemented for notebooks yet');
+          } else {
+            let doc = start_editor.getDoc();
+            doc.replaceRange(edit.newText, start, end);
+          }
+        }
+      }
+    }
   }
 }

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -5,21 +5,6 @@ import {
   IFeatureCommand
 } from '../feature';
 import { InputDialog } from '@jupyterlab/apputils';
-import { PositionConverter } from '../../../converter';
-import { IVirtualPosition } from '../../../positioning';
-
-function toDocumentChanges(changes: {
-  [uri: string]: lsProtocol.TextEdit[];
-}): lsProtocol.TextDocumentEdit[] {
-  let documentChanges = [];
-  for (let uri of Object.keys(changes)) {
-    documentChanges.push({
-      textDocument: { uri },
-      edits: changes[uri]
-    } as lsProtocol.TextDocumentEdit);
-  }
-  return documentChanges;
-}
 
 export class Rename extends CodeMirrorLSPFeature {
   static commands: Array<IFeatureCommand> = [
@@ -27,11 +12,13 @@ export class Rename extends CodeMirrorLSPFeature {
       id: 'rename-symbol',
       execute: ({ connection, virtual_position, document }) => {
         let old_value = document.getTokenAt(virtual_position).string;
-        InputDialog.getText({ title: 'Rename to', text: old_value }).then(
-          value => {
-            connection.rename(virtual_position, value.value);
-          }
-        );
+        InputDialog.getText({
+          title: 'Rename to',
+          text: old_value,
+          okLabel: 'Rename'
+        }).then(value => {
+          connection.rename(virtual_position, value.value);
+        });
       },
       is_enabled: ({ connection }) => connection.isRenameSupported(),
       label: 'Rename symbol',
@@ -48,38 +35,6 @@ export class Rename extends CodeMirrorLSPFeature {
   }
 
   protected handleRename(workspaceEdit: lsProtocol.WorkspaceEdit) {
-    console.log(workspaceEdit);
-    let current_uri = this.connection.getDocumentUri();
-    // Specs: documentChanges are preferred over changes
-    let changes = workspaceEdit.documentChanges
-      ? workspaceEdit.documentChanges.map(
-          change => change as lsProtocol.TextDocumentEdit
-        )
-      : toDocumentChanges(workspaceEdit.changes);
-    for (let change of changes) {
-      let uri = change.textDocument.uri;
-      if (uri !== current_uri) {
-        console.warn('Workspace-wide rename not implemented yet');
-      } else {
-        // TODO: show "Renamed X to Y in {change.edits.length} places" in statusbar;
-        for (let edit of change.edits) {
-          let start = PositionConverter.lsp_to_cm(edit.range.start);
-          let end = PositionConverter.lsp_to_cm(edit.range.end);
-
-          let start_editor = this.virtual_document.get_editor_at_virtual_line(
-            start as IVirtualPosition
-          );
-          let end_editor = this.virtual_document.get_editor_at_virtual_line(
-            end as IVirtualPosition
-          );
-          if (start_editor !== end_editor) {
-            console.log('Rename not implemented for notebooks yet');
-          } else {
-            let doc = start_editor.getDoc();
-            doc.replaceRange(edit.newText, start, end);
-          }
-        }
-      }
-    }
+    this.apply_edit(workspaceEdit);
   }
 }

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -6,10 +6,13 @@ export class Rename extends CodeMirrorLSPFeature {
   static commands: Array<IFeatureCommand> = [
     {
       id: 'rename-symbol',
-      execute: ({ connection, virtual_position }) => {
-        InputDialog.getText({ title: 'Rename to' }).then(value => {
-          connection.rename(virtual_position, value.value);
-        });
+      execute: ({ connection, virtual_position, document }) => {
+        let old_value = document.getTokenAt(virtual_position).string;
+        InputDialog.getText({ title: 'Rename to', text: old_value }).then(
+          value => {
+            connection.rename(virtual_position, value.value);
+          }
+        );
       },
       is_enabled: ({ connection }) => connection.isRenameSupported(),
       label: 'Rename symbol'

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -21,7 +21,7 @@ export class Rename extends CodeMirrorLSPFeature {
   }
 
   protected handleRename(edit: lsProtocol.WorkspaceEdit) {
-    // TODO: apply the edit as a change in the
-    console.log(edit)
+    // TODO: apply the edit as a change in the CodeMirror editor (and then trigger document update?)
+    console.log(edit);
   }
 }

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -1,5 +1,9 @@
 import * as lsProtocol from 'vscode-languageserver-protocol';
-import { CodeMirrorLSPFeature, IFeatureCommand } from '../feature';
+import {
+  CodeMirrorLSPFeature,
+  CommandEntryPoint,
+  IFeatureCommand
+} from '../feature';
 import { InputDialog } from '@jupyterlab/apputils';
 import { PositionConverter } from '../../../converter';
 import { IVirtualPosition } from '../../../positioning';
@@ -30,7 +34,11 @@ export class Rename extends CodeMirrorLSPFeature {
         );
       },
       is_enabled: ({ connection }) => connection.isRenameSupported(),
-      label: 'Rename symbol'
+      label: 'Rename symbol',
+      attach_to: new Set<CommandEntryPoint>([
+        // notebooks are not supported yet
+        CommandEntryPoint.FileEditorContextMenu
+      ])
     }
   ];
 

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -1,6 +1,8 @@
 import * as lsProtocol from 'vscode-languageserver-protocol';
 import { CodeMirrorLSPFeature, IFeatureCommand } from '../feature';
 import { InputDialog } from '@jupyterlab/apputils';
+import { PositionConverter } from '../../../converter';
+import { IVirtualPosition } from '../../../positioning';
 
 export class Rename extends CodeMirrorLSPFeature {
   static commands: Array<IFeatureCommand> = [
@@ -24,8 +26,33 @@ export class Rename extends CodeMirrorLSPFeature {
     super.register();
   }
 
-  protected handleRename(edit: lsProtocol.WorkspaceEdit) {
+  protected handleRename(workspaceEdit: lsProtocol.WorkspaceEdit) {
     // TODO: apply the edit as a change in the CodeMirror editor (and then trigger document update?)
-    console.log(edit);
+    console.log(workspaceEdit);
+    let current_uri = this.connection.getDocumentUri();
+    for (let change of workspaceEdit.documentChanges) {
+      change = change as lsProtocol.TextDocumentEdit;
+      if (change.textDocument.uri !== current_uri) {
+        console.warn('Workspace-wide rename not implemented yet');
+      } else {
+        for (let edit of change.edits) {
+          let start = PositionConverter.lsp_to_cm(edit.range.start);
+          let end = PositionConverter.lsp_to_cm(edit.range.end);
+
+          let start_editor = this.virtual_document.get_editor_at_virtual_line(
+            start as IVirtualPosition
+          );
+          let end_editor = this.virtual_document.get_editor_at_virtual_line(
+            end as IVirtualPosition
+          );
+          if (start_editor !== end_editor) {
+            console.log('Rename not implemented for notebooks yet');
+          } else {
+            let doc = start_editor.getDoc();
+            doc.replaceRange(edit.newText, start, end);
+          }
+        }
+      }
+    }
   }
 }

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -18,6 +18,7 @@ export class Rename extends CodeMirrorLSPFeature {
 
   register(): void {
     this.connection_handlers.set('renamed', this.handleRename.bind(this));
+    super.register();
   }
 
   protected handleRename(edit: lsProtocol.WorkspaceEdit) {

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -1,0 +1,27 @@
+import * as lsProtocol from 'vscode-languageserver-protocol';
+import { CodeMirrorLSPFeature, IFeatureCommand } from '../feature';
+import { InputDialog } from '@jupyterlab/apputils';
+
+export class Rename extends CodeMirrorLSPFeature {
+  static commands: Array<IFeatureCommand> = [
+    {
+      id: 'rename-symbol',
+      execute: ({ connection, virtual_position }) => {
+        InputDialog.getText({ title: 'Rename to' }).then(value => {
+          connection.rename(virtual_position, value.value);
+        });
+      },
+      is_enabled: ({ connection }) => connection.isRenameSupported(),
+      label: 'Rename symbol'
+    }
+  ];
+
+  register(): void {
+    this.connection_handlers.set('renamed', this.handleRename.bind(this));
+  }
+
+  protected handleRename(edit: lsProtocol.WorkspaceEdit) {
+    // TODO: apply the edit as a change in the
+    console.log(edit)
+  }
+}

--- a/src/adapters/codemirror/features/rename.ts
+++ b/src/adapters/codemirror/features/rename.ts
@@ -4,7 +4,9 @@ import { InputDialog } from '@jupyterlab/apputils';
 import { PositionConverter } from '../../../converter';
 import { IVirtualPosition } from '../../../positioning';
 
-function toDocumentChanges(changes: {[uri: string]: lsProtocol.TextEdit[]}): lsProtocol.TextDocumentEdit[] {
+function toDocumentChanges(changes: {
+  [uri: string]: lsProtocol.TextEdit[];
+}): lsProtocol.TextDocumentEdit[] {
   let documentChanges = [];
   for (let uri of Object.keys(changes)) {
     documentChanges.push({

--- a/src/adapters/jupyterlab/jl_adapter.ts
+++ b/src/adapters/jupyterlab/jl_adapter.ts
@@ -26,6 +26,7 @@ import { CodeMirrorLSPFeature, ILSPFeature } from '../codemirror/feature';
 import { JumpToDefinition } from '../codemirror/features/jump_to';
 import { ICommandContext } from '../../command_manager';
 import { JSONObject } from '@phosphor/coreutils';
+import { Rename } from '../codemirror/features/rename';
 
 export const lsp_features: Array<typeof CodeMirrorLSPFeature> = [
   Completion,
@@ -33,7 +34,8 @@ export const lsp_features: Array<typeof CodeMirrorLSPFeature> = [
   Highlights,
   Hover,
   Signature,
-  JumpToDefinition
+  JumpToDefinition,
+  Rename
 ];
 
 interface IDocumentConnectionData {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -29,6 +29,35 @@ export class LSPConnection extends LspWsConnection {
     this._sendChange([{ text }]);
   }
 
+  public isRenameSupported() {
+    // @ts-ignore
+    return !!(this.serverCapabilities && this.serverCapabilities.renameProvider);
+  }
+
+  public rename(location: IPosition, newName: string) {
+    // @ts-ignore
+    if (!this.isConnected || !this.isRenameSupported()) {
+      return;
+    }
+
+    // @ts-ignore
+    this.connection
+      .sendRequest('textDocument/rename', {
+        textDocument: {
+          // @ts-ignore
+          uri: this.documentInfo.documentUri
+        },
+        position: {
+          line: location.line,
+          character: location.ch
+        },
+        newName: newName
+      } as lsProtocol.RenameParams)
+      .then((result: lsProtocol.WorkspaceEdit | null) => {
+        this.emit('renamed', result);
+      });
+  }
+
   public connect(socket: WebSocket): this {
     super.connect(socket);
 

--- a/src/virtual/document.ts
+++ b/src/virtual/document.ts
@@ -484,6 +484,12 @@ export class VirtualDocument {
     return this.lines.join(lines_padding);
   }
 
+  getTokenAt(position: IVirtualPosition): CodeMirror.Token {
+    let cm_editor = this.get_editor_at_virtual_line(position);
+    let editor_position = this.transform_virtual_to_editor(position);
+    return cm_editor.getTokenAt(editor_position);
+  }
+
   close_expired_documents() {
     for (let document of this.unused_documents.values()) {
       document.remaining_lifetime -= 1;

--- a/src/virtual/document.ts
+++ b/src/virtual/document.ts
@@ -574,7 +574,12 @@ export class VirtualDocument {
   }
 
   get_editor_at_virtual_line(pos: IVirtualPosition): CodeMirror.Editor {
-    return this.virtual_lines.get(pos.line).editor;
+    let line = pos.line;
+    // tolerate overshot by one (the hanging blank line at the end)
+    if (!this.virtual_lines.has(line)) {
+      line -= 1;
+    }
+    return this.virtual_lines.get(line).editor;
   }
 
   get_editor_at_source_line(pos: CodeMirror.Position): CodeMirror.Editor {


### PR DESCRIPTION
General notes:
 - It only works when using absolute paths and not for synced documents (e.g. rope in pyls seems to require the file to exists):
   - we may need to mirror the virtual documents in the file system to allow for seamless integration of rename action. Those files could be hidden; however, there are OS-compatibility, safety and import systems (varying across languages) concerns with such a solution;
  - notebooks are not supported for now as those would require the virtual documents to be saved on the disk (e.g. as hidden files)

TODO:
- [ ] reflect the change in the frontend editor
  - [x] for FileEditor
  - [ ] <s>for Notebook</s> not in this PR
- [x] pre-populate the renaming dialogue with the existing token value
- [ ] <s>make use of the [prepare rename request](https://microsoft.github.io/language-server-protocol/specification#textDocument_prepareRename) to validate the new name</s> not in this PR

This PR does **not** implement workspace-wide edits (rename action fails if multiple files need to be edited). A shared mechanism for opening files in background is needed for this as well as for #41.