### PR TITLE
Reload connections after kernel or file name change

### DIFF
--- a/src/adapters/codemirror/features/diagnostics.ts
+++ b/src/adapters/codemirror/features/diagnostics.ts
@@ -75,7 +75,7 @@ export class Diagnostics extends CodeMirrorLSPFeature {
     /* TODO: gutters */
     try {
       // Note: no deep equal for Sets or Maps in JS
-      const markers_to_retain: Set<string> = new Set<string>();
+      const markers_to_retain: Set<string> = new Set();
 
       // add new markers, keep track of the added ones
 
@@ -200,16 +200,26 @@ export class Diagnostics extends CodeMirrorLSPFeature {
       );
 
       // remove the markers which were not included in the new message
-      this.marked_diagnostics.forEach(
-        (marker: CodeMirror.TextMarker, diagnostic_hash: string) => {
-          if (!markers_to_retain.has(diagnostic_hash)) {
-            this.marked_diagnostics.delete(diagnostic_hash);
-            marker.clear();
-          }
-        }
-      );
+      this.remove_unused_diagnostic_markers(markers_to_retain);
     } catch (e) {
       console.warn(e);
     }
+  }
+
+  protected remove_unused_diagnostic_markers(to_retain: Set<string>) {
+    this.marked_diagnostics.forEach(
+      (marker: CodeMirror.TextMarker, diagnostic_hash: string) => {
+        if (!to_retain.has(diagnostic_hash)) {
+          this.marked_diagnostics.delete(diagnostic_hash);
+          marker.clear();
+        }
+      }
+    );
+  }
+
+  remove(): void {
+    // remove all markers
+    this.remove_unused_diagnostic_markers(new Set());
+    super.remove();
   }
 }

--- a/src/adapters/codemirror/features/diagnostics.ts
+++ b/src/adapters/codemirror/features/diagnostics.ts
@@ -72,10 +72,6 @@ export class Diagnostics extends CodeMirrorLSPFeature {
   }
 
   public handleDiagnostic(response: lsProtocol.PublishDiagnosticsParams) {
-    /* TODO: this seems insufficient. perhaps there is a way to  */
-    if (!response.uri.endsWith(this.virtual_document.uri)) {
-      return;
-    }
     /* TODO: gutters */
     try {
       // Note: no deep equal for Sets or Maps in JS

--- a/src/adapters/codemirror/testutils.ts
+++ b/src/adapters/codemirror/testutils.ts
@@ -25,9 +25,9 @@ export class FeatureTestEnvironment implements IFeatureTestEnvironment {
   private connections: Map<CodeMirrorLSPFeature, LSPConnection>;
 
   constructor(
-    protected language = 'python',
-    protected path = 'dummy.py',
-    protected file_extension = 'py'
+    protected language = () => 'python',
+    protected path = () => 'dummy.py',
+    protected file_extension = () => 'py'
   ) {
     const factoryService = new CodeMirrorEditorFactory();
     this.connections = new Map();
@@ -77,7 +77,7 @@ export class FeatureTestEnvironment implements IFeatureTestEnvironment {
 
   public create_dummy_connection() {
     return new LSPConnection({
-      languageId: this.language,
+      languageId: this.language(),
       serverUri: '',
       documentUri: '/' + this.path,
       rootUri: '/',

--- a/src/adapters/jupyterlab/file_editor.ts
+++ b/src/adapters/jupyterlab/file_editor.ts
@@ -73,9 +73,9 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
       console.warn
     );
 
-    this.editor.model.mimeTypeChanged.connect((session, mimeChanged) => {
-      // TODO: trigger didClose and didOpen, as per syncing specification
-    });
+    this.editor.model.mimeTypeChanged.connect(
+      this.reload_connection.bind(this)
+    );
   }
 
   connect_completion() {

--- a/src/adapters/jupyterlab/file_editor.ts
+++ b/src/adapters/jupyterlab/file_editor.ts
@@ -46,7 +46,7 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
     editor_widget: IDocumentWidget<FileEditor>,
     jumper: FileEditorJumper,
     app: JupyterFrontEnd,
-    completion_manager: ICompletionManager,
+    protected completion_manager: ICompletionManager,
     rendermime_registry: IRenderMimeRegistry,
     server_root: string
   ) {
@@ -69,23 +69,25 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
     this.connect_contentChanged_signal();
 
     console.log('LSP: file ready for connection:', this.path);
-    this.connect_document(this.virtual_editor.virtual_document)
-      .then(() => {
-        this.current_completion_connector = new LSPConnector({
-          editor: this.editor.editor,
-          connections: this.connection_manager.connections,
-          virtual_editor: this.virtual_editor
-        });
-        completion_manager.register({
-          connector: this.current_completion_connector,
-          editor: this.editor.editor,
-          parent: editor_widget
-        });
-      })
-      .catch(console.warn);
+    this.connect_document(this.virtual_editor.virtual_document).catch(
+      console.warn
+    );
 
     this.editor.model.mimeTypeChanged.connect((session, mimeChanged) => {
       // TODO: trigger didClose and didOpen, as per syncing specification
+    });
+  }
+
+  connect_completion() {
+    this.current_completion_connector = new LSPConnector({
+      editor: this.editor.editor,
+      connections: this.connection_manager.connections,
+      virtual_editor: this.virtual_editor
+    });
+    this.completion_manager.register({
+      connector: this.current_completion_connector,
+      editor: this.editor.editor,
+      parent: this.widget
     });
   }
 

--- a/src/adapters/jupyterlab/file_editor.ts
+++ b/src/adapters/jupyterlab/file_editor.ts
@@ -61,9 +61,9 @@ export class FileEditorAdapter extends JupyterLabWidgetAdapter {
     this.editor = editor_widget.content;
 
     this.virtual_editor = new VirtualFileEditor(
-      this.language,
-      this.language_file_extension,
-      this.document_path,
+      () => this.language,
+      () => this.language_file_extension,
+      () => this.document_path,
       this.cm_editor
     );
     this.connect_contentChanged_signal();

--- a/src/adapters/jupyterlab/jl_adapter.ts
+++ b/src/adapters/jupyterlab/jl_adapter.ts
@@ -95,6 +95,10 @@ export abstract class JupyterLabWidgetAdapter
     this.adapters = new Map();
     this.connection_manager = new DocumentConnectionManager();
     this.connection_manager.closed.connect((manger, { virtual_document }) => {
+      console.log(
+        'LSP: connection closed, disconnecting adapter',
+        virtual_document.id_path
+      );
       this.disconnect_adapter(virtual_document);
     });
     this.connection_manager.connected.connect((manager, data) => {

--- a/src/adapters/jupyterlab/jl_adapter.ts
+++ b/src/adapters/jupyterlab/jl_adapter.ts
@@ -58,7 +58,9 @@ export interface IJupyterLabComponentsManager {
  */
 const mime_type_language_map: JSONObject = {
   'text/x-rsrc': 'r',
-  'text/x-r-source': 'r'
+  'text/x-r-source': 'r',
+  // currently there are no LSP servers for IPython we are aware of
+  'text/x-ipython': 'python'
 };
 
 /**
@@ -142,6 +144,11 @@ export abstract class JupyterLabWidgetAdapter
   // equivalent to triggering didClose and didOpen, as per syncing specification,
   // but also reloads the connection
   protected reload_connection() {
+    // ignore premature calls (before the editor was initialized)
+    if (typeof this.virtual_editor === 'undefined') {
+      return;
+    }
+
     // disconnect all existing connections
     this.connection_manager.close_all();
     // recreate virtual document using current path and language

--- a/src/adapters/jupyterlab/jl_adapter.ts
+++ b/src/adapters/jupyterlab/jl_adapter.ts
@@ -87,9 +87,7 @@ export abstract class JupyterLabWidgetAdapter
     invoke: string,
     private server_root: string
   ) {
-    this.widget.context.pathChanged.connect(
-      this.reconnect_with_new_path.bind(this)
-    );
+    this.widget.context.pathChanged.connect(this.reload_connection.bind(this));
     this.invoke_command = invoke;
     this.document_connected = new Signal(this);
     this.adapters = new Map();
@@ -141,7 +139,9 @@ export abstract class JupyterLabWidgetAdapter
     return PathExt.dirname(this.document_path);
   }
 
-  private reconnect_with_new_path() {
+  // equivalent to triggering didClose and didOpen, as per syncing specification,
+  // but also reloads the connection
+  protected reload_connection() {
     // disconnect all existing connections
     this.connection_manager.close_all();
     // recreate virtual document using current path and language

--- a/src/adapters/jupyterlab/jl_adapter.ts
+++ b/src/adapters/jupyterlab/jl_adapter.ts
@@ -140,7 +140,9 @@ export abstract class JupyterLabWidgetAdapter
   private reconnect_with_new_path() {
     // disconnect all existing connections
     this.connection_manager.close_all();
-    // reconnect using current path
+    // recreate virtual document using current path and language
+    this.virtual_editor.create_virtual_document();
+    // reconnect
     this.connect_document(this.virtual_editor.virtual_document).catch(
       console.warn
     );

--- a/src/adapters/jupyterlab/notebook.ts
+++ b/src/adapters/jupyterlab/notebook.ts
@@ -81,11 +81,11 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
 
     this.virtual_editor = new VirtualEditorForNotebook(
       this.widget,
-      this.language,
-      this.language_file_extension,
+      () => this.language,
+      () => this.language_file_extension,
       language_specific_overrides,
       foreign_code_extractors,
-      this.document_path
+      () => this.document_path
     );
     this.connect_contentChanged_signal();
 

--- a/src/adapters/jupyterlab/notebook.ts
+++ b/src/adapters/jupyterlab/notebook.ts
@@ -43,6 +43,10 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
     this.init_once_ready()
       .then()
       .catch(console.warn);
+
+    this.widget.context.session.kernelChanged.connect(
+      this.reload_connection.bind(this)
+    );
   }
 
   is_ready() {
@@ -59,6 +63,7 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
   }
 
   get mime_type(): string {
+    // note there is also: this.widget.content.codeMimetype
     let language_metadata = this.widget.model.metadata.get('language_info');
     // @ts-ignore
     return language_metadata.mimetype;

--- a/src/adapters/jupyterlab/notebook.ts
+++ b/src/adapters/jupyterlab/notebook.ts
@@ -79,9 +79,6 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
     await until_ready(this.is_ready.bind(this), -1);
     console.log('LSP:', this.document_path, 'ready for connection');
 
-    // TODO
-    // this.widget.context.pathChanged
-
     this.virtual_editor = new VirtualEditorForNotebook(
       this.widget,
       this.language,
@@ -92,10 +89,9 @@ export class NotebookAdapter extends JupyterLabWidgetAdapter {
     );
     this.connect_contentChanged_signal();
 
-    // register completion connectors on cells
-    this.document_connected.connect(() => this.connect_completion());
-
-    void this.connect_document(this.virtual_editor.virtual_document);
+    this.connect_document(this.virtual_editor.virtual_document).catch(
+      console.warn
+    );
   }
 
   private set_completion_connector(cell: Cell) {

--- a/src/connection_manager.ts
+++ b/src/connection_manager.ts
@@ -77,7 +77,7 @@ export class DocumentConnectionManager {
     this.documents.set(virtual_document.id_path, virtual_document);
   }
 
-  connect_socket(options: ISocketConnectionOptions): LSPConnection {
+  private connect_socket(options: ISocketConnectionOptions): LSPConnection {
     let { virtual_document, language, server_root, root_path } = options;
     console.log(root_path);
 
@@ -107,6 +107,8 @@ export class DocumentConnectionManager {
     }).connect(socket);
 
     connection.on('error', e => {
+      console.warn(e);
+      // TODO invalid now
       let error: Error = e.length && e.length >= 1 ? e[0] : new Error();
       // TODO: those codes may be specific to my proxy client, need to investigate
       if (error.message.indexOf('code = 1005') !== -1) {
@@ -195,5 +197,12 @@ export class DocumentConnectionManager {
     this.connected.emit({ connection, virtual_document });
 
     return connection;
+  }
+
+  public close_all() {
+    for (let connection of this.connections.values()) {
+      connection.close();
+    }
+    this.connections.clear();
   }
 }

--- a/src/connection_manager.ts
+++ b/src/connection_manager.ts
@@ -200,8 +200,11 @@ export class DocumentConnectionManager {
   }
 
   public close_all() {
-    for (let connection of this.connections.values()) {
+    for (let [id_path, connection] of this.connections.entries()) {
+      let virtual_document = this.documents.get(id_path);
       connection.close();
+      // TODO: close() should trigger the closed event, but it does not seem to work, hence manual trigger below:
+      this.closed.emit({ connection, virtual_document });
     }
     this.connections.clear();
   }

--- a/src/virtual/editor.spec.ts
+++ b/src/virtual/editor.spec.ts
@@ -49,9 +49,9 @@ describe('VirtualEditor', () => {
   });
 
   let editor = new VirtualEditorImplementation(
-    'python',
-    'py',
-    'test.ipynb',
+    () => 'python',
+    () => 'py',
+    () => 'test.ipynb',
     {},
     { python: [r_line_extractor] }
   );

--- a/src/virtual/editor.ts
+++ b/src/virtual/editor.ts
@@ -24,7 +24,6 @@ export abstract class VirtualEditor implements CodeMirror.Editor {
   // TODO: getValue could be made private in the virtual editor and the virtual editor
   //  could stop exposing the full implementation of CodeMirror but rather hide it inside.
   virtual_document: VirtualDocument;
-  overrides_registry: IOverridesRegistry;
   code_extractors: IForeignCodeExtractorsRegistry;
   /**
    * Signal emitted by the editor that triggered the update, providing the root document of the updated documents.
@@ -32,22 +31,26 @@ export abstract class VirtualEditor implements CodeMirror.Editor {
   private documents_updated: Signal<VirtualEditor, VirtualDocument>;
 
   public constructor(
-    language: string,
-    file_extension: string,
-    path: string,
-    overrides_registry: IOverridesRegistry,
-    foreign_code_extractors: IForeignCodeExtractorsRegistry
+    protected language: () => string,
+    protected file_extension: () => string,
+    protected path: () => string,
+    protected overrides_registry: IOverridesRegistry,
+    protected foreign_code_extractors: IForeignCodeExtractorsRegistry
   ) {
-    this.virtual_document = new VirtualDocument(
-      language,
-      path,
-      overrides_registry,
-      foreign_code_extractors,
-      false,
-      file_extension
-    );
+    this.create_virtual_document();
     this.documents_updated = new Signal<VirtualEditor, VirtualDocument>(this);
     this.documents_updated.connect(this.on_updated.bind(this));
+  }
+
+  create_virtual_document() {
+    this.virtual_document = new VirtualDocument(
+      this.language(),
+      this.path(),
+      this.overrides_registry,
+      this.foreign_code_extractors,
+      false,
+      this.file_extension()
+    );
   }
 
   /**

--- a/src/virtual/editors/file_editor.ts
+++ b/src/virtual/editors/file_editor.ts
@@ -10,9 +10,9 @@ export class VirtualFileEditor extends VirtualEditor {
   protected cm_editor: CodeMirror.Editor;
 
   constructor(
-    language: string,
-    file_extension: string,
-    path: string,
+    language: () => string,
+    file_extension: () => string,
+    path: () => string,
     cm_editor: CodeMirror.Editor
   ) {
     // TODO: for now the magics and extractors are not used in FileEditor,

--- a/src/virtual/editors/notebook.ts
+++ b/src/virtual/editors/notebook.ts
@@ -57,15 +57,14 @@ export class VirtualEditorForNotebook extends VirtualEditor {
 
   cell_to_corresponding_source_line: Map<Cell, number>;
   cm_editor_to_cell: Map<CodeMirror.Editor, Cell>;
-  language: string;
 
   constructor(
     notebook_panel: NotebookPanel,
-    language: string,
-    file_extension: string,
+    language: () => string,
+    file_extension: () => string,
     overrides_registry: IOverridesRegistry,
     foreign_code_extractors: IForeignCodeExtractorsRegistry,
-    path: string
+    path: () => string
   ) {
     super(
       language,


### PR DESCRIPTION
This also fixes init problems #39
- [x] observe if kernel changed for notebook (where language can be changed without changing the filename)

### Manual test / demo:
 - [x] old diagnostics are removed upon file name change
 - [x] correct diagnostics for renamed file are displayed
![demo_rename](https://user-images.githubusercontent.com/5832902/66153582-b6f83e00-e613-11e9-93b1-e65d21228ea9.gif)