### PR TITLE
More work on R/conda/binder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE README.md
-recursive-include py_src *.json
+recursive-include py_src *.json *.R

--- a/environment.yml
+++ b/environment.yml
@@ -5,24 +5,24 @@ channels:
   - defaults
 
 dependencies:
+  # runtime dependencies
+  - python >=3.7,<3.8.0a0
+  - jupyterlab >=1.1,<1.2
+  # build dependencies
+  - nodejs
+  # for python language server (and development)
   - black
   - flake8 >=3.5
   - isort
-  - jupyterlab >=1.1,<1.2
   - mypy
-  - nodejs
   - pip
   - pylint
-  - python >=3.7,<3.8.0a0
   - python-language-server
-  # for R:
-  - libcurl
-  - r-base
-  - r-remotes
-  - r-curl
-  - r-languageserver
-  - r-irkernel
-  - pip:
+  - pip: # not-yet-appearing-in-conda-forge
       - pyls-black
       - pyls-isort
       - pyls-mypy
+  # for R language server and kernel
+  - rpy2
+  - r-languageserver
+  - r-irkernel

--- a/py_src/jupyter_lsp/CONTRIBUTING.md
+++ b/py_src/jupyter_lsp/CONTRIBUTING.md
@@ -59,8 +59,8 @@ A spec is a python function that accepts a single argument, the
 
 The spec should only be advertised if the command _could actually_ be run:
 
-- its runtime (e.g. `julia`, `nodejs`, `ruby`, `python`, `r`) is installed
-- the language server itself is installed (e.g. `python-language-sever`)
+- its runtime (e.g. `julia`, `nodejs`, `python`, `r`, `ruby`) is installed
+- the language server itself is installed (e.g. `python-language-server`)
 
 #### Common Concerns
 
@@ -70,6 +70,9 @@ The spec should only be advertised if the command _could actually_ be run:
 - because of its VSCode heritage, many language servers use `nodejs`
   - `LanguageServerManager.nodejs` will provide the location of our best
     guess at where a user's `nodejs` might be found
+- some language servers are hard to start purely from the command line
+  - use a helper script to encapsulate some complexity.
+    - See the [r spec](./specs/r_languageserver.py) for an example
 
 #### Example: making a pip-installable `cool-language-server` spec
 

--- a/py_src/jupyter_lsp/jsonrpc.py
+++ b/py_src/jupyter_lsp/jsonrpc.py
@@ -6,6 +6,7 @@ Parts of this code are derived from:
 > > MIT License   https://github.com/palantir/python-jsonrpc-server/blob/0.2.0/LICENSE
 > > Copyright 2018 Palantir Technologies, Inc.
 """
+# pylint: disable=broad-except
 
 import json
 
@@ -25,9 +26,9 @@ class Writer(JsonRpcStreamWriter):
         TODO: propose upstream change (with tests)
     """
 
-    def write(self, message):  # pragma: no cover
+    def write(self, message):
         with self._wfile_lock:
-            if self._wfile.closed:
+            if self._wfile.closed:  # pragma: no cover
                 return
             try:
                 body = json.dumps(message, **self._json_dumps_args)
@@ -43,5 +44,5 @@ class Writer(JsonRpcStreamWriter):
 
                 self._wfile.write(response.encode("utf-8"))
                 self._wfile.flush()
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  # pragma: no cover
                 log.exception("Failed to write message to output file %s", message)

--- a/py_src/jupyter_lsp/jsonrpc.py
+++ b/py_src/jupyter_lsp/jsonrpc.py
@@ -1,0 +1,47 @@
+""" Custom subclasses of python-jsonrpc-server components
+
+Parts of this code are derived from:
+
+> https://github.com/palantir/python-jsonrpc-server/blob/0.2.0/pyls_jsonrpc/streams.py#L83   # noqa
+> > MIT License   https://github.com/palantir/python-jsonrpc-server/blob/0.2.0/LICENSE
+> > Copyright 2018 Palantir Technologies, Inc.
+"""
+
+import json
+
+from pyls_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter, log
+
+
+class Reader(JsonRpcStreamReader):
+    """ Custom subclass of reader. Doesn't do much yet.
+    """
+
+    pass
+
+
+class Writer(JsonRpcStreamWriter):
+    """ Custom subclass for writer. Handles some inconsistencies vs the spec
+
+        TODO: propose upstream change (with tests)
+    """
+
+    def write(self, message):  # pragma: no cover
+        with self._wfile_lock:
+            if self._wfile.closed:
+                return
+            try:
+                body = json.dumps(message, **self._json_dumps_args)
+
+                # Ensure we get the byte length, not the character length
+                content_length = (
+                    len(body) if isinstance(body, bytes) else len(body.encode("utf-8"))
+                )
+
+                response = "Content-Length: {}\r\n\r\n" "{}".format(
+                    content_length, body
+                )
+
+                self._wfile.write(response.encode("utf-8"))
+                self._wfile.flush()
+            except Exception:  # pylint: disable=broad-except
+                log.exception("Failed to write message to output file %s", message)

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -1,5 +1,6 @@
 """ add language server support to the running jupyter notebook application
 """
+import json
 
 import traitlets
 from notebook.utils import url_path_join as ujoin
@@ -12,8 +13,13 @@ def load_jupyter_server_extension(nbapp):
     """ create a LanguageServerManager and add handlers
     """
     nbapp.add_traits(language_server_manager=traitlets.Instance(LanguageServerManager))
-    nbapp.language_server_manager = LanguageServerManager(parent=nbapp)
-    nbapp.language_server_manager.initialize()
+    manager = nbapp.language_server_manager = LanguageServerManager(parent=nbapp)
+    manager.initialize()
+    nbapp.log.debug(
+        "The following Language Servers will be available: {}".format(
+            json.dumps(manager.language_servers, indent=2, sort_keys=True)
+        )
+    )
     nbapp.web_app.add_handlers(
         ".*",
         [

--- a/py_src/jupyter_lsp/specs/__init__.py
+++ b/py_src/jupyter_lsp/specs/__init__.py
@@ -5,13 +5,12 @@ from .bash_language_server import BashLanguageServer
 from .dockerfile_language_server_nodejs import DockerfileLanguageServerNodeJS
 from .javascript_typescript_langserver import JavascriptTypescriptLanguageServer
 from .pyls import PythonLanguageServer
+from .r_languageserver import RLanguageServer
 from .unified_language_server import UnifiedLanguageServer
 from .vscode_css_languageserver import VSCodeCSSLanguageServer
 from .vscode_html_languageserver import VSCodeHTMLLanguageServer
 from .vscode_json_languageserver import VSCodeJSONLanguageServer
 from .yaml_language_server import YAMLLanguageServer
-from .r_languageserver import RLanguageServer
-
 
 bash = BashLanguageServer()
 css = VSCodeCSSLanguageServer()

--- a/py_src/jupyter_lsp/specs/helpers/languageserver.R
+++ b/py_src/jupyter_lsp/specs/helpers/languageserver.R
@@ -1,0 +1,2 @@
+# a helper script for launching languageserver
+languageserver::run(debug = TRUE)

--- a/py_src/jupyter_lsp/specs/languageserver.R
+++ b/py_src/jupyter_lsp/specs/languageserver.R
@@ -1,1 +1,0 @@
-languageserver::run(debug=TRUE)

--- a/py_src/jupyter_lsp/specs/r_languageserver.py
+++ b/py_src/jupyter_lsp/specs/r_languageserver.py
@@ -1,10 +1,8 @@
-from pathlib import Path
-
-from .utils import ShellSpec
+from .utils import HELPERS, ShellSpec
 
 
 class RLanguageServer(ShellSpec):
     key = "r-languageserver"
     cmd = "Rscript"
-    args = ["--slave", (Path(__file__).parent / "languageserver.R").as_posix()]
+    args = ["--slave", (HELPERS / "languageserver.R").as_posix()]
     languages = ["r"]

--- a/py_src/jupyter_lsp/specs/utils.py
+++ b/py_src/jupyter_lsp/specs/utils.py
@@ -1,7 +1,11 @@
 import shutil
+from pathlib import Path
 from typing import List, Text
 
 from ..types import KeyedLanguageServerSpecs, LanguageServerManagerAPI
+
+# helper scripts for known tricky language servers
+HELPERS = Path(__file__).parent / "helpers"
 
 
 class SpecBase:

--- a/py_src/jupyter_lsp/tests/conftest.py
+++ b/py_src/jupyter_lsp/tests/conftest.py
@@ -20,6 +20,8 @@ KNOWN_LANGUAGES = [
     "less",
     "markdown",
     "python",
+    # TODO: test r once we can get the environment built in CI
+    # "r",
     "scss",
     "typescript",
     "yaml",

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,7 @@ setuptools.setup(
     data_files=[
         (
             "etc/jupyter/jupyter_notebook_config.d",
-            [
-                "py_src/jupyter_lsp/etc/jupyter-lsp-serverextension.json",
-                "py_src/jupyter_lsp/specs/languageserver.R"
-            ],
+            ["py_src/jupyter_lsp/etc/jupyter-lsp-serverextension.json"],
         )
     ],
 )

--- a/src/adapters/jupyterlab/file_editor.ts
+++ b/src/adapters/jupyterlab/file_editor.ts
@@ -10,12 +10,10 @@ import { ICompletionManager } from '@jupyterlab/completer';
 import { LSPConnector } from './components/completion';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { VirtualFileEditor } from '../../virtual/editors/file_editor';
-import { LSPConnection } from '../../connection';
 
 export class FileEditorAdapter extends JupyterLabWidgetAdapter {
   editor: FileEditor;
   jumper: FileEditorJumper;
-  main_connection: LSPConnection;
   virtual_editor: VirtualFileEditor;
   protected current_completion_connector: LSPConnector;
 

--- a/src/adapters/jupyterlab/jl_adapter.ts
+++ b/src/adapters/jupyterlab/jl_adapter.ts
@@ -138,12 +138,6 @@ export abstract class JupyterLabWidgetAdapter
     });
   }
 
-  get main_connection(): LSPConnection {
-    return this.connection_manager.connections.get(
-      this.virtual_editor.virtual_document.id_path
-    );
-  }
-
   protected async on_connected(data: IDocumentConnectionData) {
     let { virtual_document } = data;
 


### PR DESCRIPTION
![Screenshot from 2019-10-03 21-45-23](https://user-images.githubusercontent.com/45380/66175336-2cb9d500-e627-11e9-8f90-86821f1920b7.png)

Builds on the upstream, apparently works. [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/jupyterlab-lsp/full_conda?urlpath=lab) is solid.

Also applied the python formatters, etc. And, because `r-lintr` was working, I even linted the helper script, without even knowing r! Hooray dogfood!

As I was perusing upstream, i see that `r-languageserver` also supports rmarkdown. Definitely a nice value proposition, but apparently codemirror isn't telling anybody, so it comes back `plain`. 

I'm not sure what ordering of things made a difference but it just started working against my local dev env (also linux on conda).

Let's squash merge this, if we get it working!