### PR TITLE
Add Browser Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ venv.bak/
 
 node_modules
 .yarn-packages
+
+atest/output/
+junit.xml
+coverage/

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,5 @@ envs
 **/.ipynb_checkpoints
 **/*.egg-info
 .yarn-packages
+atest
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       language: shell
 
 before_install:
-  - python3 -m pip install -r requirements-test.txt
+  - python3 -m pip install -r requirements-utest.txt
   - python3 -m pip freeze
   - python3 setup.py sdist
   - python3 setup.py bdist_wheel
@@ -30,14 +30,7 @@ script:
   - jlpm test
   - python3 -m jupyter serverextension list
   - python3 -m jupyter serverextension list | grep jupyter_lsp
-  # don't use setup.py test to ensure testing as-packaged
-  - python3 -m pytest
-    --pyargs jupyter_lsp
-    --cov jupyter_lsp
-    --cov-report term-missing:skip-covered
-    -p no:warnings
-    --flake8
-    --cov-fail-under=100
+  - python3 scripts/utest.py
 
 addons:
   apt:

--- a/atest/00_Smoke.robot
+++ b/atest/00_Smoke.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Resource          Keywords.robot
+
+*** Test Cases ***
+Smoke
+    Capture Page Screenshot    00-splash.png

--- a/atest/01_Editor.robot
+++ b/atest/01_Editor.robot
@@ -90,6 +90,8 @@ Editor Should Jump To Definition
     [Arguments]    ${symbol}
     Set Tags    feature:jump-to-definition
     ${sel} =    Set Variable If    "${symbol}".startswith(("xpath", "css"))    ${symbol}    xpath:(//span[@role="presentation"][contains(., "${symbol}")])[last()]
+    Mouse Over    ${sel}
+    Run Keyword If    "${OS}" == "Windows"    Sleep    10s
     Click Element    ${sel}
     Open Context Menu    ${sel}
     ${cursor} =    Measure Cursor Position

--- a/atest/01_Editor.robot
+++ b/atest/01_Editor.robot
@@ -1,0 +1,111 @@
+*** Settings ***
+Force Tags        ui:editor
+Resource          Keywords.robot
+
+*** Variables ***
+${MENU EDITOR}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(., "Editor")]
+${MENU OPEN WITH}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(text(), "Open With")]
+${MENU JUMP}      xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(text(), "Jump to definition")]
+${CM CURSOR}      css:.CodeMirror-cursor
+${CM CURSORS}     css:.CodeMirror-cursors:not([style='visibility: hidden'])
+
+*** Test Cases ***
+Bash
+    Editor Shows Features for Language    Bash    example.sh    Diagnostics=Failed to parse expression    Jump to Definition=fib
+
+CSS
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable-2')][contains(text(), '--some-var')])[last()]
+    Editor Shows Features for Language    CSS    example.css    Diagnostics=Do not use empty rulesets    Jump to Definition=${def}
+
+Docker
+    ${def} =    Set Variable    xpath://span[contains(@class, 'cm-string')][contains(text(), 'PLANET')]
+    Editor Shows Features for Language    Docker    Dockerfile    Diagnostics=Instruction has no arguments    Jump to Definition=${def}
+
+JS
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'fib')])[last()]
+    Editor Shows Features for Language    JS    example.js    Diagnostics=Expression expected    Jump to Definition=${def}
+
+JSON
+    Editor Shows Features for Language    JSON    example.json    Diagnostics=Duplicate object key
+
+JSX
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'hello')])[last()]
+    Editor Shows Features for Language    JSX    example.jsx    Diagnostics=Expression expected    Jump to Definition=${def}
+
+Less
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable-2')][contains(text(), '@width')])[last()]
+    Editor Shows Features for Language    Less    example.less    Diagnostics=Do not use empty rulesets    Jump to Definition=${def}
+
+Python
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'fib')])[last()]
+    Editor Shows Features for Language    Python    example.py    Diagnostics=multiple spaces after keyword    Jump to Definition=${def}
+
+R
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'fib')])[last()]
+    Editor Shows Features for Language    R    example.R    Diagnostics=Put spaces around all infix operators    Jump to Definition=${def}
+
+SCSS
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable-2')][contains(text(), 'primary-color')])[last()]
+    Editor Shows Features for Language    SCSS    example.scss    Diagnostics=Do not use empty rulesets    Jump to Definition=${def}
+
+TSX
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-tag')][contains(text(), 'HelloWorld')])[last()]
+    Editor Shows Features for Language    TSX    example.tsx    Diagnostics=Cannot find module 'react'    Jump to Definition=${def}
+
+TypeScript
+    ${def} =    Set Variable    xpath:(//span[contains(@class, 'cm-variable')][contains(text(), 'inc')])[last()]
+    Editor Shows Features for Language    TypeScript    example.ts    Diagnostics=The left-hand side of an arithmetic    Jump to Definition=${def}
+
+YAML
+    Editor Shows Features for Language    YAML    example.yaml    Diagnostics=duplicate key
+
+*** Keywords ***
+Editor Shows Features for Language
+    [Arguments]    ${Language}    ${file}    &{features}
+    Set Tags    language:${Language.lower()}
+    Set Screenshot Directory    ${OUTPUT DIR}${/}screenshots${/}editor${/}${Language.lower()}
+    Copy File    examples${/}${file}    ${OUTPUT DIR}${/}home${/}${file}
+    Reset Application State
+    Open ${file} in Editor
+    FOR    ${f}    IN    @{features}
+        Run Keyword If    "${f}" == "Diagnostics"    Editor Should Show Diagnostics    ${features["${f}"]}
+        ...    ELSE IF    "${f}" == "Jump to Definition"    Editor Should Jump To Definition    ${features["${f}"]}
+    END
+    [Teardown]    Remove File    ${OUTPUT DIR}${/}home${/}${file}
+
+Open ${file} in Editor
+    Open Context Menu    css:.jp-DirListing-item[title="${file}"]
+    Mouse Over    ${MENU OPEN WITH}
+    Wait Until Page Contains Element    ${MENU EDITOR}
+    Mouse Over    ${MENU EDITOR}
+    Click Element    ${MENU EDITOR}
+
+Editor Should Show Diagnostics
+    [Arguments]    ${diagnostic}
+    Set Tags    feature:diagnostics
+    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${diagnostic}"]    timeout=20s
+    Capture Page Screenshot    diagnostics.png
+
+Editor Should Jump To Definition
+    [Arguments]    ${symbol}
+    Set Tags    feature:jump-to-definition
+    ${sel} =    Set Variable If    "${symbol}".startswith(("xpath", "css"))    ${symbol}    xpath:(//span[@role="presentation"][contains(., "${symbol}")])[last()]
+    Click Element    ${sel}
+    Open Context Menu    ${sel}
+    ${cursor} =    Measure Cursor Position
+    Capture Page Screenshot    jump-to-definition-0.png
+    Mouse Over    ${MENU JUMP}
+    Capture Page Screenshot    jump-to-definition-1.png
+    Click Element    ${MENU JUMP}
+    Wait Until Keyword Succeeds    10 x    1 s    Cursor Should Jump    ${cursor}
+    Capture Page Screenshot    jump-to-definition-2.png
+
+Cursor Should Jump
+    [Arguments]    ${original}
+    ${current} =    Measure Cursor Position
+    Should Not Be Equal    ${original}    ${current}
+
+Measure Cursor Position
+    Wait Until Page Contains Element    ${CM CURSORS}
+    ${position} =    Wait Until Keyword Succeeds    20 x    0.05s    Get Vertical Position    ${CM CURSOR}
+    [Return]    ${position}

--- a/atest/01_Editor.robot
+++ b/atest/01_Editor.robot
@@ -92,8 +92,8 @@ Editor Should Jump To Definition
     ${sel} =    Set Variable If    "${symbol}".startswith(("xpath", "css"))    ${symbol}    xpath:(//span[@role="presentation"][contains(., "${symbol}")])[last()]
     Mouse Over    ${sel}
     Run Keyword If    "${OS}" == "Windows"    Sleep    10s
-    Click Element    ${sel}
-    Open Context Menu    ${sel}
+    Wait Until Keyword Succeeds    10 x    0.1 s    Click Element    ${sel}
+    Wait Until Keyword Succeeds    10 x    0.1 s    Open Context Menu    ${sel}
     ${cursor} =    Measure Cursor Position
     Capture Page Screenshot    jump-to-definition-0.png
     Mouse Over    ${MENU JUMP}

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -67,6 +67,7 @@ Lab Command
     Press Keys  id:main  ${ACCEL}+SHIFT+c
     ${cmd input} =  Set Variable  css:.p-CommandPalette-input
     Wait Until Page Contains Element  ${cmd input}
+    Click Element  ${cmd input}
     Input Text  ${cmd input}   ${cmd}
     ${cmd item} =  Set Variable   css:.p-CommandPalette-item.p-mod-active
     Wait Until Page Contains Element    ${cmd item}

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -1,0 +1,78 @@
+*** Settings ***
+Resource  Variables.robot
+Library   SeleniumLibrary
+Library   OperatingSystem
+Library   Process
+Library   String
+
+
+*** Keywords ***
+Setup Server and Browser
+    ${accel} =  Evaluate    "COMMAND" if "${OS}" == "Darwin" else "CTRL"
+    Set Global Variable  ${ACCEL}  ${accel}
+    ${token} =   Generate Random String
+    Set Global Variable   ${TOKEN}   ${token}
+    ${home} =  Set Variable  ${OUTPUT DIR}${/}home
+    ${root} =  Normalize Path  ${OUTPUT DIR}${/}..${/}..${/}..
+    Create Directory   ${home}
+    ${WORKSPACES DIR} =   Set Variable    ${OUTPUT DIR}${/}workspaces
+    Initialize User Settings
+    ${app args} =   Set Variable   --no-browser --debug --NotebookApp.base_url\='${BASE}' --port\=${PORT} --NotebookApp.token\='${token}'
+    ${path args} =  Set Variable   --LabApp.user_settings_dir='${SETTINGS DIR.replace('\\', '\\\\')}' --LabApp.workspaces_dir\='${WORKSPACES DIR.replace('\\', '\\\\')}'
+    ${ext args} =  Set Variable  --LanguageServerManager.extra_node_roots\="['${root.replace('\\', '\\\\')}']"
+    Set Screenshot Directory   ${OUTPUT DIR}${/}screenshots
+    ${server} =  Start Process  jupyter-lab ${app args} ${path args} ${ext args}
+    ...  shell=yes
+    ...  env:HOME=${home}
+    ...  cwd=${home}
+    ...  stdout=${OUTPUT DIR}${/}lab.log
+    ...  stderr=STDOUT
+    Set Global Variable    ${SERVER}    ${server}
+    Open JupyterLab
+
+Initialize User Settings
+    Set Suite Variable   ${SETTINGS DIR}   ${OUTPUT DIR}${/}user-settings  children=${True}
+    Create File    ${SETTINGS DIR}${/}@jupyterlab${/}codemirror-extension${/}commands.jupyterlab-settings  {"styleActiveLine": true}
+
+Tear Down Everything
+    Close All Browsers
+    Evaluate  __import__("urllib.request").request.urlopen("${URL}api/shutdown?token=${TOKEN}", data=[])
+    Wait For Process   ${SERVER}  timeout=30s
+    Terminate All Processes
+    Terminate All Processes  kill=${True}
+
+Wait For Splash
+    Wait Until Page Contains Element   ${SPLASH}   timeout=180s
+    Wait Until Page Does Not Contain Element   ${SPLASH}
+
+Open JupyterLab
+    Set Environment Variable    MOZ_HEADLESS    ${HEADLESS}
+    ${firefox} =  Which  firefox
+    ${geckodriver} =  Which  geckodriver
+    Create WebDriver    Firefox    executable_path=${geckodriver}    firefox_binary=${firefox}
+    Go To  ${URL}lab?token=${TOKEN}
+    Set Window Size  1024  768
+    Wait For Splash
+    Execute Javascript    window.onbeforeunload \= function (){}
+
+Close JupyterLab
+    Close All Browsers
+
+Reset Application State
+    Lab Command   Reset Application State
+    Wait For Splash
+
+Lab Command
+    [Arguments]  ${cmd}
+    Press Keys  id:main  ${ACCEL}+SHIFT+c
+    ${cmd input} =  Set Variable  css:.p-CommandPalette-input
+    Wait Until Page Contains Element  ${cmd input}
+    Input Text  ${cmd input}   ${cmd}
+    ${cmd item} =  Set Variable   css:.p-CommandPalette-item.p-mod-active
+    Wait Until Page Contains Element    ${cmd item}
+    Click Element  ${cmd item}
+
+Which
+    [Arguments]  ${cmd}
+    ${path} =  Evaluate    __import__("shutil").which("${cmd}")
+    [Return]  ${path}

--- a/atest/Variables.robot
+++ b/atest/Variables.robot
@@ -1,0 +1,6 @@
+*** Variables ***
+${PORT}  18888
+${SPLASH}  id:jupyterlab-splash
+${BASE}   /@est/
+${URL}  http://localhost:${PORT}${BASE}
+${HEADLESS}  1

--- a/atest/__init__.robot
+++ b/atest/__init__.robot
@@ -1,0 +1,6 @@
+*** Settings ***
+Suite Setup       Setup Server and Browser
+Suite Teardown    Tear Down Everything
+Test Setup        Reset Application State
+Force Tags        os:${OS.lower()}    py:${PY}
+Resource          Keywords.robot

--- a/atest/examples/Dockerfile
+++ b/atest/examples/Dockerfile
@@ -1,0 +1,5 @@
+FROM empty
+RUN
+ARG PLANET="earth"
+ENV MY_PLANET="$PLANET"
+RUN echo Hello $MY_PLANET

--- a/atest/examples/example.R
+++ b/atest/examples/example.R
@@ -1,0 +1,6 @@
+fib=function(n,x=c(0,1)) {
+   if (abs(n)>1) for (i in seq(abs(n)-1)) x=c(x[2],sum(x))
+   if (n<0) return(x[2]*(-1)^(abs(n)-1)) else if (n) return(x[2]) else return(0)
+}
+
+sapply(seq(-31,31), fib)

--- a/atest/examples/example.css
+++ b/atest/examples/example.css
@@ -1,0 +1,8 @@
+:root {
+    --some-var: 1px;
+}
+.hello {
+    border: var(--some-var);
+}
+
+.world {}

--- a/atest/examples/example.js
+++ b/atest/examples/example.js
@@ -1,0 +1,7 @@
+function fib(n) {
+  return n<2?n:fib(n-1)+fib(n-2);
+}
+
+fib(5);
+
+window.location /;

--- a/atest/examples/example.json
+++ b/atest/examples/example.json
@@ -1,0 +1,1 @@
+{"hello": "world", "hello": "world"}

--- a/atest/examples/example.jsx
+++ b/atest/examples/example.jsx
@@ -1,0 +1,2 @@
+const hello = <h1>Hello, world!</h1>;
+hello /;

--- a/atest/examples/example.less
+++ b/atest/examples/example.less
@@ -1,0 +1,9 @@
+@width: 10px;
+@height: @width + 10px;
+
+#header {
+  width: @width;
+  height: @height;
+}
+
+hello {}

--- a/atest/examples/example.py
+++ b/atest/examples/example.py
@@ -1,0 +1,31 @@
+'''Fibonacci accumulation'''
+
+from itertools import  (accumulate, chain)
+
+
+# fibs :: Integer :: [Integer]
+def fibs(n):
+    '''An accumulation of the first n integers in
+       the Fibonacci series. The accumulator is a
+       pair of the two preceding numbers.
+    '''
+    def go(ab, _):
+        a, b = ab
+        return (b, a + b)
+
+    return [xy[1] for xy in accumulate(
+        chain(
+            [(0, 1)],
+            range(1, n)
+        ),
+        go
+    )]
+
+
+# MAIN ---
+if __name__ == '__main__':
+    print(
+        'First twenty: ' + repr(
+            fibs(20)
+        )
+    )

--- a/atest/examples/example.scss
+++ b/atest/examples/example.scss
@@ -1,0 +1,9 @@
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+hello {}

--- a/atest/examples/example.sh
+++ b/atest/examples/example.sh
@@ -1,0 +1,19 @@
+fib()
+{
+  if [ $1 -le 0 ]
+  then
+    echo 0
+    return 0
+  fi
+  if [ $1 -le 2 ]
+  then
+    echo 1
+  else
+    a=$(fib $[$1-1])
+    b=$(fib $[$1-2])
+    echo $(($a+$b))
+  fi
+}
+
+
+fib 5

--- a/atest/examples/example.ts
+++ b/atest/examples/example.ts
@@ -1,0 +1,6 @@
+function inc(x: number) {
+    return x + 1;
+}
+
+let y = inc(0) + 'a';
+y / 2;

--- a/atest/examples/example.tsx
+++ b/atest/examples/example.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+
+export class HelloWorld extends React.Component<any, any> {
+    render() {
+        return <div>Hello world!It's from Helloword Component.</div>;
+    }
+}
+
+const hello = <HelloWorld/>;
+
+;hello;

--- a/atest/examples/example.yaml
+++ b/atest/examples/example.yaml
@@ -1,0 +1,3 @@
+greetings:
+    hello:
+    hello:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,3 +15,4 @@ variables:
 
 jobs:
   - template: ci/job.test.yml
+  - template: ci/job.combine.yml

--- a/ci/env-test.yml.in
+++ b/ci/env-test.yml.in
@@ -24,3 +24,7 @@ dependencies:
   - pytest-cov
   - pytest-flake8
   - pytest-runner
+  # browser testing
+  - robotframework-seleniumlibrary
+  - firefox
+  - geckodriver

--- a/ci/job.combine.yml
+++ b/ci/job.combine.yml
@@ -1,0 +1,45 @@
+parameters:
+  platforms:
+    - Linux
+    - MacOSX
+    - Windows
+  pythons:
+    - ThreeSix
+    - ThreeSeven
+
+jobs:
+  - job: Combine
+    dependsOn:
+      - ${{ each platform in parameters.platforms }}:
+          - ${{ each python in parameters.pythons }}:
+              - ${{ platform }}${{ python }}
+    condition: always()
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+      - template: steps.conda.yml
+        parameters:
+          packages: robotframework
+
+      - script: conda install -yc conda-forge robotframework
+        displayName: get robotframework
+
+      - ${{ each platform in parameters.platforms }}:
+          - ${{ each python in parameters.pythons }}:
+              - task: DownloadPipelineArtifact@0
+                condition: always()
+                inputs:
+                  artifactName: Robot ${{ platform }}${{ python }} $(Build.BuildId)
+                  targetPath: atest/output
+                displayName: restore ${{ platform }}${{ python }} output
+
+      - script: python scripts/combine.py
+        condition: always()
+        displayName: combine outputs
+
+      - task: PublishPipelineArtifact@1
+        condition: always()
+        displayName: publish all output
+        inputs:
+          targetPath: atest/output
+          artifactName: All Robot Output $(Build.BuildId)

--- a/ci/job.test.yml
+++ b/ci/job.test.yml
@@ -22,23 +22,9 @@ jobs:
             pool:
               vmImage: ${{ platform.vmImage }}
             steps:
-              - ${{ if eq(platform.name, 'Linux') }}:
-                  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-                    displayName: conda $PATH
-
-              - ${{ if eq(platform.name, 'MacOSX') }}:
-                  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-                    displayName: conda $PATH
-
-                  - bash: sudo chown -R $USER $CONDA
-                    displayName: own conda
-
-              - ${{ if eq(platform.name, 'Windows') }}:
-                  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-                    displayName: conda %PATH%
-
-              - script: conda install -yn base -c conda-forge conda python-libarchive-c
-                displayName: update conda
+              - template: steps.conda.yml
+                parameters:
+                  name: ${{ platform.name }}
 
               - script: ${{ platform.activate }} && cd ci && python env_template.py "${{ python.spec }}"
                 displayName: update environment with python version
@@ -49,11 +35,11 @@ jobs:
               - script: conda info && conda list -n jupyterlab-lsp
                 displayName: list conda packages and info
 
-              - task: CacheBeta@0
-                inputs:
-                  key: yarn | $(Agent.OS) | yarn.lock
-                  path: $(YARN_CACHE_FOLDER)
-                displayName: restore cached yarn packages
+              # - task: CacheBeta@0
+              #   inputs:
+              #     key: yarn | $(Agent.OS) | yarn.lock
+              #     path: $(YARN_CACHE_FOLDER)
+              #   displayName: restore cached yarn packages
 
               - script: ${{ platform.activate }} jupyterlab-lsp && jlpm
                 displayName: install npm dependencies
@@ -73,14 +59,45 @@ jobs:
               - script: ${{ platform.activate }} jupyterlab-lsp && jlpm tslint:check && jlpm test:jest
                 displayName: run frontend unit tests
 
+              - task: PublishTestResults@2
+                displayName: publish frontend test results
+                inputs:
+                  testResultsFiles: junit.xml
+                  testRunTitle: 'Jest ${{ platform.name }}${{ python.name }}'
+                  mergeTestResults: true
+                condition: always()
+
+              - task: PublishCodeCoverageResults@1
+                inputs:
+                  codeCoverageTool: Cobertura
+                  summaryFileLocation: 'coverage/cobertura-coverage.xml'
+
               - script: ${{ platform.activate }} jupyterlab-lsp && jupyter serverextension list
                 displayName: list server extensions
 
-              - script: ${{ platform.activate }} jupyterlab-lsp && python -m pytest --pyargs jupyter_lsp --cov jupyter_lsp --cov-report term-missing:skip-covered -p no:warnings --flake8 --cov-fail-under=100 -vv
+              - script: ${{ platform.activate }} jupyterlab-lsp && python scripts/utest.py --test-run-title="Pytest ${{ platform.name }}${{ python.name }}"
                 displayName: run python tests
 
               - script: ${{ platform.activate }} jupyterlab-lsp && cd dist && jupyter labextension install krassowski-jupyterlab-lsp-$(JLSP_VERSION).tgz @krassowski/jupyterlab_go_to_definition
-                displayName: build lab
+                displayName: install labextensions
 
               - script: ${{ platform.activate }} jupyterlab-lsp && jupyter labextension list
                 displayName: list labextensions
+
+              - script: ${{ platform.activate }} jupyterlab-lsp && python scripts/atest.py
+                displayName: run browser tests
+
+              - task: PublishTestResults@2
+                displayName: publish browser test results
+                inputs:
+                  testResultsFiles: atest/output/*.xunit.xml
+                  testRunTitle: 'Robot ${{ platform.name }}${{ python.name }}'
+                  mergeTestResults: true
+                condition: always()
+
+              - task: PublishPipelineArtifact@0
+                displayName: publish browser test output
+                inputs:
+                  targetPath: atest/output
+                  artifactName: Robot ${{ platform.name }}${{ python.name }} $(Build.BuildId)
+                condition: always()

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -1,0 +1,22 @@
+parameters:
+  name: Linux
+  packages: ''
+
+steps:
+  - ${{ if eq(parameters.name, 'Linux') }}:
+      - bash: echo "##vso[task.prependpath]$CONDA/bin"
+        displayName: conda $PATH
+
+  - ${{ if eq(parameters.name, 'MacOSX') }}:
+      - bash: echo "##vso[task.prependpath]$CONDA/bin"
+        displayName: conda $PATH
+
+      - bash: sudo chown -R $USER $CONDA
+        displayName: own conda
+
+  - ${{ if eq(parameters.name, 'Windows') }}:
+      - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+        displayName: conda %PATH%
+
+  - script: conda install -yn base -c conda-forge conda python-libarchive-c ${{ parameters.packages}}
+    displayName: update conda

--- a/environment-atest.yml
+++ b/environment-atest.yml
@@ -1,0 +1,6 @@
+name: jupyterlab-lsp
+
+dependencies:
+  - robotframework-seleniumlibrary
+  - firefox
+  - geckodriver

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ const reuseFromUpstream = [
   'moduleNameMapper',
   'reporters',
   'setupFiles',
-  'setupFilesAfterEnv',
+  'setupFilesAfterEnv'
 ];
 
 let local = {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,11 @@ const func = require('@jupyterlab/testutils/lib/jest-config');
 const upstream = func('jupyterlab-lsp', __dirname);
 
 const reuseFromUpstream = [
+  'moduleFileExtensions',
   'moduleNameMapper',
-  'setupFilesAfterEnv',
+  'reporters',
   'setupFiles',
-  'moduleFileExtensions'
+  'setupFilesAfterEnv',
 ];
 
 let local = {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tslint": "tslint --fix -c tslint.json --project tsconfig.json '**/*{.ts,.tsx}'",
     "tslint:check": "tslint -c tslint.json --project tsconfig.json '**/*{.ts,.tsx}'",
     "test": "jlpm lint:check && jlpm test:jest",
-    "test:jest": "jlpm jest"
+    "test:jest": "jlpm jest --coverage --coverageReporters=cobertura --coverageReporters=html --coverageReporters=text-summary"
   },
   "dependencies": {
     "@krassowski/jupyterlab_go_to_definition": "^0.7.1",
@@ -76,21 +76,22 @@
     "events": "^3.0.0",
     "javascript-typescript-langserver": "^2.11.3",
     "jest": "^24.7.1",
+    "jest-junit": "^8.0.0",
     "jsonrpc-ws-proxy": "0.0.5",
     "prettier": "^1.18.2",
     "react": "~16.8.4",
     "rimraf": "^2.6.1",
     "ts-jest": "^24.0.2",
+    "tslint": "^5.15.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
     "tslint-react": "^4.0.0",
-    "tslint": "^5.15.0",
     "typescript": "~3.4.5",
     "unified-language-server": "^0.3.0",
     "vscode-css-languageserver-bin": "^1.4.0",
     "vscode-html-languageserver-bin": "^1.4.0",
     "vscode-json-languageserver-bin": "^1.0.1",
-    "yaml-language-server": "^0.5.7"
+    "yaml-language-server": "^0.4.0"
   },
   "peerDependencies": {
     "@jupyterlab/application": "~1.1.3",

--- a/py_src/jupyter_lsp/CONTRIBUTING.md
+++ b/py_src/jupyter_lsp/CONTRIBUTING.md
@@ -29,8 +29,8 @@ You can contribute to `jupyter-lsp` by:
 
 ## Future Roadmap Items
 
-- add hook system to allow serverextensions to modify, inspect and react to
-  LSP messages
+- add hook system to allow serverextensions/kernels to modify, inspect and
+  react to LSP messages
 
 ## Specs
 
@@ -125,7 +125,7 @@ setuptools.setup(
 
 Test it!
 
-```
+```bash
 python -m pip install -e .
 ```
 
@@ -140,9 +140,11 @@ python setup.py sdist bdist_wheel
 ### Set up the environment
 
 ```bash
-pip install -r requirements-dev.txt  # in a virtualenv
+conda env update -n jupyterlab-lsp   # create a conda env
+source activate jupyterlab-lsp       # activate it
 # or...
-conda env update                     # in a conda env
+pip install -r requirements-dev.txt  # in a virtualenv, probably
+                                     # ... and install nodejs, somehow
 ```
 
 ## Testing `jupyter-lsp`
@@ -150,7 +152,25 @@ conda env update                     # in a conda env
 ### Unit & Code Style Tests
 
 ```bash
-python setup.py test
+python scripts/utest.py
+```
+
+### Browser-based Acceptance Tests
+
+Prepare the enviroment:
+
+```bash
+conda env update -n jupyterlab-lsp --file environment-atest.yml
+# or
+pip install -r requirements-atest.txt  # ... and install geckodriver, somehow
+```
+
+> Also ensure you've `jupyter labextension install .`ed in the root of the repo
+
+Run the tests:
+
+```bash
+python scripts/atest.py
 ```
 
 ### Formatting
@@ -159,7 +179,7 @@ Minimal code style is enforced with `flake8` during unit testing. If installed,
 `pytest-black` and `pytest-isort` can help find potential problems, and lead to
 cleaner commits, but are not enforced during CI.
 
-You can clean up your code using the projects style guide in:
+You can clean up your code using the project's style guide with:
 
 ```bash
 isort -y -rc py_src
@@ -169,7 +189,6 @@ black py_src
 > TBD
 >
 > - hypothesis
-> - conda/docker
 > - mypy
 
 ## Documentation

--- a/py_src/jupyter_lsp/README.md
+++ b/py_src/jupyter_lsp/README.md
@@ -22,17 +22,18 @@ Don't see an implementation for the language server you want? You can
 > Please consider [contributing your language server spec](./CONTRIBUTING.md#spec)
 > to `jupyter-lsp`!
 
-| language<br>`/lsp/...`    | `pip install ...`        | `npm install (-g) ...` <br/>`yarn/jlpm add (-g) ...` |
-| ------------------------- | ------------------------ | :--------------------------------------------------: |
-| bash                      |                          |                `bash-language-server`                |
-| css<br/>less<br/>css      |                          |           `vscode-css-languageserver-bin`            |
-| docker                    |                          |         `dockerfile-language-server-nodejs`          |
-| html                      |                          |           `vscode-html-languageserver-bin`           |
-| javascript<br/>typescript |                          |          `javascript-typescript-langserver`          |
-| json                      |                          |           `vscode-json-languageserver-bin`           |
-| markdown                  |                          |              `unified-language-server`               |
-| python                    | `python-language-server` |                                                      |
-| yaml                      |                          |                `yaml-language-server`                |
+| language                  | `npm install (-g)` <br/>`yarn/jlpm add (-g)` |      `pip install`       | `conda install -c conda-forge` | `Rscript -e 'install.packages()'` |
+| ------------------------- | :------------------------------------------: | :----------------------: | :----------------------------: | :-------------------------------: |
+| bash                      |            `bash-language-server`            |                          |                                |                                   |
+| css<br/>less<br/>css      |       `vscode-css-languageserver-bin`        |                          |                                |                                   |
+| docker                    |     `dockerfile-language-server-nodejs`      |                          |                                |                                   |
+| html                      |       `vscode-html-languageserver-bin`       |                          |                                |                                   |
+| javascript<br/>typescript |      `javascript-typescript-langserver`      |                          |                                |                                   |
+| json                      |       `vscode-json-languageserver-bin`       |                          |                                |                                   |
+| markdown                  |          `unified-language-server`           |                          |                                |                                   |
+| python                    |                                              | `python-language-server` |    `python-language-server`    |                                   |
+| r                         |                                              |                          |       `r-languageserver`       |         `languageserver`          |
+| yaml                      |            `yaml-language-server`            |                          |                                |                                   |
 
 [language-server]: https://microsoft.github.io/language-server-protocol/specification
 [jupyter-server-proxy]: https://github.com/jupyterhub/jupyter-server-proxy

--- a/py_src/jupyter_lsp/README.md
+++ b/py_src/jupyter_lsp/README.md
@@ -13,8 +13,9 @@ them if they _are_ installed and we know about them.
 
 > You can disable this behavior by configuring [`autodetect`](#autodetect)
 
-Use a package manager to install a [language server][lsp-implementations].
-from the table below. These implementations are tested to work with `jupyter-lsp`.
+Use a package manager to install a [language server][lsp-implementations]
+(also [this list][langserver]) from the table below: these implementations are
+tested to work with `jupyter-lsp`.
 
 Don't see an implementation for the language server you want? You can
 [bring your own language server](#bring-your-own-language-server).
@@ -36,6 +37,7 @@ Don't see an implementation for the language server you want? You can
 | yaml                      |            `yaml-language-server`            |                          |                                |                                   |
 
 [language-server]: https://microsoft.github.io/language-server-protocol/specification
+[langserver]: https://langserver.org
 [jupyter-server-proxy]: https://github.com/jupyterhub/jupyter-server-proxy
 [lsp-implementations]: https://microsoft.github.io/language-server-protocol/implementors/servers
 [jupyter-lsp]: https://github.com/krassowski/jupyterlab-lsp.git
@@ -67,13 +69,13 @@ They will be merged from bottom to top, and the directory where you launch your
 # $PREFIX/etc/jupyter/jupyter_notebook_config.d/a-language-server-implementation.json
 {
   "LanguageServerManager": {
-      "language_servers": {
-          "a-language-server-implementation": {
-              "argv": ["/absolute/path/to/a-language-server", "--stdio"],
-              "languages": ["a-language"]
-            }
-        }
+    "language_servers": {
+      "a-language-server-implementation": {
+        "argv": ["/absolute/path/to/a-language-server", "--stdio"],
+        "languages": ["a-language"]
+      }
     }
+  }
 }
 ```
 
@@ -95,7 +97,6 @@ c.LanguageServerManager.language_servers = {
         "argv": [shutil.which("another-language-interpreter"), "another-language-server"],
         "languages": ["another-language"]
     }
-  }
 }
 ```
 

--- a/py_src/jupyter_lsp/manager.py
+++ b/py_src/jupyter_lsp/manager.py
@@ -101,7 +101,14 @@ class LanguageServerManager(LanguageServerManagerAPI):
                 yield session
 
     def _autodetect_language_servers(self):
-        for ep in pkg_resources.iter_entry_points(EP_SPEC_V0):
+        entry_points = []
+
+        try:
+            entry_points = list(pkg_resources.iter_entry_points(EP_SPEC_V0))
+        except Exception:  # pragma: no cover
+            self.log.exception("Failed to load entry_points")
+
+        for ep in entry_points:
             try:
                 spec_finder = ep.load()  # type: SpecMaker
             except Exception as err:  # pragma: no cover

--- a/py_src/jupyter_lsp/session.py
+++ b/py_src/jupyter_lsp/session.py
@@ -29,8 +29,8 @@ class LanguageServerSession(LoggingConfigurable):
     process = Instance(
         subprocess.Popen, help="the language server subprocess", allow_none=True
     )
-    writer = Instance(stdio.Writer, help="the JSON-RPC writer", allow_none=True)
-    reader = Instance(stdio.Reader, help="the JSON-RPC reader", allow_none=True)
+    writer = Instance(stdio.LspStdIoWriter, help="the JSON-RPC writer", allow_none=True)
+    reader = Instance(stdio.LspStdIoReader, help="the JSON-RPC reader", allow_none=True)
     from_lsp = Instance(
         Queue, help="a queue for string messages from the server", allow_none=True
     )
@@ -50,6 +50,11 @@ class LanguageServerSession(LoggingConfigurable):
         """
         super().__init__(*args, **kwargs)
         atexit.register(self.stop)
+
+    def __repr__(self):  # pragma: no cover
+        return "<LanguageServerSession(languages={}, argv={})>".format(
+            self.languages, self.argv
+        )
 
     def initialize(self):
         """ (re)initialize a language server session
@@ -112,14 +117,14 @@ class LanguageServerSession(LoggingConfigurable):
     def init_reader(self):
         """ create the stdout reader (from the language server)
         """
-        self.reader = stdio.Reader(
+        self.reader = stdio.LspStdIoReader(
             stream=self.process.stdout, queue=self.from_lsp, parent=self
         )
 
     def init_writer(self):
         """ create the stdin writer (to the language server)
         """
-        self.writer = stdio.Writer(
+        self.writer = stdio.LspStdIoWriter(
             stream=self.process.stdin, queue=self.to_lsp, parent=self
         )
 

--- a/py_src/jupyter_lsp/specs/javascript_typescript_langserver.py
+++ b/py_src/jupyter_lsp/specs/javascript_typescript_langserver.py
@@ -4,4 +4,4 @@ from .utils import NodeModuleSpec
 class JavascriptTypescriptLanguageServer(NodeModuleSpec):
     node_module = key = "javascript-typescript-langserver"
     script = ["lib", "language-server-stdio.js"]
-    languages = ["typescript", "javascript"]
+    languages = ["javascript", "jsx", "typescript", "typescript-jsx"]

--- a/py_src/jupyter_lsp/stdio.py
+++ b/py_src/jupyter_lsp/stdio.py
@@ -111,7 +111,10 @@ class LspStdIoReader(LspStdIoBase):
                 raw = None
                 retries = 5
                 while raw is None and retries:
-                    raw = self.stream.read(content_length)
+                    try:
+                        raw = self.stream.read(content_length)
+                    except OSError:  # pragma: no cover
+                        raw = None
                     if raw is None:  # pragma: no cover
                         self.log.warning(
                             "%s failed to read message of length %s",

--- a/py_src/jupyter_lsp/tests/conftest.py
+++ b/py_src/jupyter_lsp/tests/conftest.py
@@ -20,10 +20,12 @@ KNOWN_LANGUAGES = [
     "ipythongfm",
     "javascript",
     "json",
+    "jsx",
     "less",
     "markdown",
     "python",
     "scss",
+    "typescript-jsx",
     "typescript",
     "yaml",
 ]

--- a/py_src/jupyter_lsp/types.py
+++ b/py_src/jupyter_lsp/types.py
@@ -33,10 +33,22 @@ class LanguageServerManagerAPI(LoggingConfigurable):
     def find_node_module(self, *path_frag):
         """ look through the node_module roots to find the given node module
         """
-        for candidate_root in self.extra_node_roots + self.node_roots:
+        all_roots = self.extra_node_roots + self.node_roots
+        found = None
+
+        for candidate_root in all_roots:
             candidate = pathlib.Path(candidate_root, "node_modules", *path_frag)
+            self.log.debug("Checking for %s", candidate)
             if candidate.exists():
-                return str(candidate)
+                found = str(candidate)
+                break
+
+        if found is None:  # pragma: no cover
+            self.log.debug(
+                "%s not found in node_modules of %s", pathlib.Path(path_frag), all_roots
+            )
+
+        return found
 
     @default("nodejs")
     def _default_nodejs(self):

--- a/requirements-atest.txt
+++ b/requirements-atest.txt
@@ -1,0 +1,3 @@
+# acceptance test dependencies for jupyter_lsp
+-r requirements.txt
+robotframework-seleniumlibrary

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
-# extended development-time dependencies for jupyter_lsp for qa
--r requirements-test.txt
-hypothesis
+# development dependencies for jupyter_lsp for qa
+-r requirements-utest.txt
 pyls-black
 pyls-isort
 pyls-mypy

--- a/requirements-utest.txt
+++ b/requirements-utest.txt
@@ -1,5 +1,4 @@
 # test time dependencies for jupyter_lsp, including one language server
-# nodejs >=8
 -r requirements.txt
 flake8 >=3.5
 pytest-asyncio

--- a/scripts/atest.py
+++ b/scripts/atest.py
@@ -1,0 +1,44 @@
+import os
+import platform
+import shutil
+import sys
+from pathlib import Path
+
+import robot
+
+ROOT = Path(__file__).parent.parent.resolve()
+ATEST = ROOT / "atest"
+OUT = ATEST / "output"
+
+OS = platform.system()
+PY = "".join(map(str, sys.version_info[:2]))
+
+STEM = "_".join([OS, PY]).replace(".", "_").lower()
+
+args = [
+    "--name",
+    f"{OS}{PY}",
+    "--outputdir",
+    OUT / STEM,
+    "--output",
+    OUT / f"{STEM}.robot.xml",
+    "--log",
+    OUT / f"{STEM}.log.html",
+    "--report",
+    OUT / f"{STEM}.report.html",
+    "--xunit",
+    OUT / f"{STEM}.xunit.xml",
+    "--variable",
+    f"OS:{OS}",
+    "--variable",
+    f"PY:{PY}",
+    *sys.argv[1:],
+    ATEST,
+]
+
+if __name__ == "__main__":
+    if (OUT / STEM).exists():
+        shutil.rmtree(OUT / STEM)
+
+    os.chdir(ATEST)
+    sys.exit(robot.run_cli(list(map(str, args))))

--- a/scripts/combine.py
+++ b/scripts/combine.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+from robot.rebot import rebot_cli
+
+ROOT = Path(__file__).parent.parent.resolve()
+ATEST = ROOT / "atest"
+OUT = ATEST / "output"
+
+args = [
+    "--outputdir",
+    OUT,
+    "--output",
+    "output.xml",
+    *sys.argv[1:],
+    *OUT.glob("*.robot.xml"),
+]
+
+
+if __name__ == "__main__":
+    rebot_cli(args, exit=False)

--- a/scripts/utest.py
+++ b/scripts/utest.py
@@ -1,0 +1,20 @@
+import sys
+
+import pytest
+
+args = [
+    "--pyargs",
+    "jupyter_lsp",
+    "--cov",
+    "jupyter_lsp",
+    "--cov-report",
+    "term-missing:skip-covered",
+    "-p",
+    "no:warnings",
+    "--flake8",
+    "--cov-fail-under=100",
+    "-vv",
+] + list(sys.argv[1:])
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(args))

--- a/src/adapters/codemirror/features/jump_to.ts
+++ b/src/adapters/codemirror/features/jump_to.ts
@@ -24,8 +24,14 @@ export class JumpToDefinition extends CodeMirrorLSPFeature {
     return this.jupyterlab_components.jumper;
   }
 
-  async handle_jump(locations: lsProtocol.Location[]) {
+  async handle_jump(
+    location_or_locations: lsProtocol.Location | lsProtocol.Location[]
+  ) {
     let connection = this.connection;
+    // some language servers appear to return a single object
+    const locations = Array.isArray(location_or_locations)
+      ? location_or_locations
+      : [location_or_locations];
 
     // TODO: implement selector for multiple locations
     //  (like when there are multiple definitions or usages)

--- a/src/adapters/codemirror/features/jump_to.ts
+++ b/src/adapters/codemirror/features/jump_to.ts
@@ -2,7 +2,7 @@ import { CodeMirrorLSPFeature, IFeatureCommand } from '../feature';
 import * as lsProtocol from 'vscode-languageserver-protocol';
 import { PositionConverter } from '../../../converter';
 import { IVirtualPosition } from '../../../positioning';
-import { uri_to_contents_path } from '../../../utils';
+import { uri_to_contents_path, uris_equal } from '../../../utils';
 
 export class JumpToDefinition extends CodeMirrorLSPFeature {
   static commands: Array<IFeatureCommand> = [
@@ -51,7 +51,7 @@ export class JumpToDefinition extends CodeMirrorLSPFeature {
       location.range.start
     ) as IVirtualPosition;
 
-    if (uri === current_uri) {
+    if (uris_equal(uri, current_uri)) {
       let editor_index = this.virtual_editor.get_editor_index(virtual_position);
       // if in current file, transform from the position within virtual document to the editor position:
       let editor_position = this.virtual_editor.transform_virtual_to_editor(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,6 +102,34 @@ export function server_root_uri() {
   }
 }
 
+/**
+ * compare two URIs, discounting:
+ * - drive capitalization
+ * TODO: probably use vscode-uri
+ */
+export function uris_equal(a: string, b: string) {
+  const win_paths = is_win_path(a) && is_win_path(b);
+  if (win_paths) {
+    return normalize_win_path(a) === normalize_win_path(b);
+  } else {
+    return a === b;
+  }
+}
+
+/**
+ * grossly detect whether a URI represents a file on a windows drive
+ */
+export function is_win_path(uri: string) {
+  return uri.match(/^file:\/\/\/[a-z]:\//);
+}
+
+/**
+ * lowercase the drive component of a URI
+ */
+export function normalize_win_path(uri: string) {
+  return uri.replace(/^file:\/\/\/[a-z]:/i, it => it.toLowerCase());
+}
+
 export function uri_to_contents_path(child: string, parent?: string) {
   parent = parent || server_root_uri();
   if (parent == null) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { PageConfig } from '@jupyterlab/coreutils';
 
+const RE_WIN_PATH = /^file:\/\/\/[a-z]:\//i;
+
 export async function sleep(timeout: number) {
   return new Promise(resolve => {
     setTimeout(() => {
@@ -120,14 +122,14 @@ export function uris_equal(a: string, b: string) {
  * grossly detect whether a URI represents a file on a windows drive
  */
 export function is_win_path(uri: string) {
-  return uri.match(/^file:\/\/\/[a-z]:\//);
+  return uri.match(RE_WIN_PATH);
 }
 
 /**
  * lowercase the drive component of a URI
  */
 export function normalize_win_path(uri: string) {
-  return uri.replace(/^file:\/\/\/[a-z]:/i, it => it.toLowerCase());
+  return uri.replace(RE_WIN_PATH, it => it.toLowerCase());
 }
 
 export function uri_to_contents_path(child: string, parent?: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,6 +3456,16 @@ jest-jasmine2@^24.9.0:
     pretty-format "^24.9.0"
     throat "^4.0.0"
 
+jest-junit@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-8.0.0.tgz#d4f7ff67e292a5426dc60bc38694c9f77cb94178"
+  integrity sha512-cuD2XM2youMjrOxOu/7H2pLfsO8LfAG4D3WsBxd9fFyI9U0uPpmr/CORH64kbIyZ47X5x1Rbzb9ovUkAEvhEEA==
+  dependencies:
+    jest-validate "^24.0.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
@@ -3621,7 +3631,7 @@ jest-util@^24.9.0:
     slash "^2.0.0"
     source-map "^0.6.0"
 
-jest-validate@^24.9.0:
+jest-validate@^24.0.0, jest-validate@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.9.0.tgz#0775c55360d173cd854e40180756d4ff52def8ab"
   integrity sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
@@ -3759,12 +3769,12 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@^1.0.0:
+jsonc-parser@^1.0.0, jsonc-parser@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-1.0.3.tgz#1d53d7160e401a783dbceabaad82473f80e6ad7e"
   integrity sha512-hk/69oAeaIzchq/v3lS50PXuzn5O2ynldopMC+SWBql7J2WtdptfB9dy8Y7+Og5rPkTCpn83zTiO8FMcqlXJ/g==
 
-jsonc-parser@^2.1.0, jsonc-parser@^2.1.1:
+jsonc-parser@^2.0.0-next.1, jsonc-parser@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.1.1.tgz#83dc3d7a6e7186346b889b1280eefa04446c6d3e"
   integrity sha512-VC0CjnWJylKB1iov4u76/W/5Ef0ydDkjtYWxoZ9t3HdWlSnZQwZL5MgFikaB/EtQ4RmMEw3tmQzuYnZA2/Ja1g==
@@ -4631,7 +4641,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.18.2:
+prettier@^1.15.2, prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
@@ -5438,7 +5448,7 @@ replace-ext@1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
-request-light@^0.2.1, request-light@^0.2.4:
+request-light@^0.2.1, request-light@^0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.2.4.tgz#3cea29c126682e6bcadf7915353322eeba01a755"
   integrity sha512-pM9Fq5jRnSb+82V7M97rp8FE9/YNeP2L9eckB4Szd7lyeclSIx02aIpPO/6e4m6Dy31+FBN/zkFMTd2HkNO3ow==
@@ -6605,7 +6615,17 @@ vscode-json-languageserver-bin@^1.0.1:
     vscode-nls "^2.0.2"
     vscode-uri "^1.0.1"
 
-vscode-json-languageservice@^3.0.1, vscode-json-languageservice@^3.3.0:
+vscode-json-languageservice@3.0.12:
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.0.12.tgz#85258632f2f7718028fbdfbb95b4ad009107b821"
+  integrity sha512-XSgRVY/vsPqOa//ZwLD5DWx1wzTQGgeZfsOlVqFlLya10dpimSnd27kbuL45hzxh4B+MvmHZtZeWQKjSYnNF0A==
+  dependencies:
+    jsonc-parser "^2.0.0-next.1"
+    vscode-languageserver-types "^3.6.1"
+    vscode-nls "^3.2.1"
+    vscode-uri "^1.0.3"
+
+vscode-json-languageservice@^3.0.1:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.3.4.tgz#4ff67580491d3a5dc469f4a78643f20adff0278d"
   integrity sha512-/nuI4uDBfxyVyeGtBdYwP/tIaXYKOoymUOSozYKLzsmrDmu555gZpzc11LrARa96z92wSaa5hfjTtNMAoM2mxw==
@@ -6657,7 +6677,7 @@ vscode-languageserver-protocol@3.5.1:
     vscode-jsonrpc "3.5.0"
     vscode-languageserver-types "3.5.0"
 
-vscode-languageserver-types@3.14.0, vscode-languageserver-types@^3.0.3, vscode-languageserver-types@^3.10.0, vscode-languageserver-types@^3.13.0, vscode-languageserver-types@^3.14.0, vscode-languageserver-types@^3.5.0, vscode-languageserver-types@^3.7.2:
+vscode-languageserver-types@3.14.0, vscode-languageserver-types@^3.0.3, vscode-languageserver-types@^3.10.0, vscode-languageserver-types@^3.13.0, vscode-languageserver-types@^3.14.0, vscode-languageserver-types@^3.5.0, vscode-languageserver-types@^3.6.1, vscode-languageserver-types@^3.7.2:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
   integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
@@ -6685,7 +6705,7 @@ vscode-languageserver@^3.5.0:
     vscode-languageserver-protocol "3.5.1"
     vscode-uri "^1.0.1"
 
-vscode-languageserver@^4.1.3:
+vscode-languageserver@^4.0.0, vscode-languageserver@^4.1.3:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-4.4.2.tgz#600ae9cc7a6ff1e84d93c7807840c2cb5b22821b"
   integrity sha512-61y8Raevi9EigDgg9NelvT9cUAohiEbUl1LOwQQgOCAaNX62yKny/ddi0uC+FUTm4CzsjhBu+06R+vYgfCYReA==
@@ -6706,7 +6726,7 @@ vscode-nls@^2.0.2:
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-2.0.2.tgz#808522380844b8ad153499af5c3b03921aea02da"
   integrity sha1-gIUiOAhEuK0VNJmvXDsDkhrqAto=
 
-vscode-nls@^3.2.2:
+vscode-nls@^3.2.1, vscode-nls@^3.2.2:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-3.2.5.tgz#25520c1955108036dec607c85e00a522f247f1a4"
   integrity sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw==
@@ -6878,6 +6898,11 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
+
 xorshift@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/xorshift/-/xorshift-0.2.1.tgz#fcd82267e9351c13f0fb9c73307f25331d29c63a"
@@ -6903,22 +6928,21 @@ yaml-ast-parser-custom-tags@0.0.43:
   resolved "https://registry.yarnpkg.com/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz#46968145ce4e24cb03c3312057f0f141b93a7d02"
   integrity sha512-R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ==
 
-yaml-language-server@^0.5.7:
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/yaml-language-server/-/yaml-language-server-0.5.8.tgz#2f0ba1582e99be8b2470f906040ba72137e66d00"
-  integrity sha512-IDPHRXJJz3W7MIksFGwQ9GweY+n064MSsiC3LpoxURdafNQ+6OcBAuVwfJdItRTGSB96l2soQB5UfjiqVBeggQ==
+yaml-language-server@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/yaml-language-server/-/yaml-language-server-0.4.1.tgz#746655bd1db0a109e0a5c74408983cf3c57329ee"
+  integrity sha512-KBGu6CvInpp2sZbAWiEqd0No7DKx8VKCvihKCcBQPIFM+eC8t02CnscsEaoMQMdvi5ceqcVzKkTgJdWPo6qi3Q==
   dependencies:
-    js-yaml "^3.13.1"
-    jsonc-parser "^2.1.0"
-    request-light "^0.2.4"
-    vscode-json-languageservice "^3.3.0"
-    vscode-languageserver "^5.2.1"
-    vscode-languageserver-types "^3.14.0"
-    vscode-nls "^4.1.1"
-    vscode-uri "^2.0.3"
+    js-yaml "^3.12.0"
+    jsonc-parser "^1.0.3"
+    prettier "^1.15.2"
+    request-light "^0.2.3"
+    vscode-json-languageservice "3.0.12"
+    vscode-languageserver "^4.0.0"
+    vscode-languageserver-types "^3.6.1"
+    vscode-nls "^3.2.2"
+    vscode-uri "^1.0.6"
     yaml-ast-parser-custom-tags "0.0.43"
-  optionalDependencies:
-    prettier "^1.18.2"
 
 yargs-parser@10.x:
   version "10.1.0"


### PR DESCRIPTION
This adds acceptance tests with screenshots for diagnostics and jump features. It uses [Robot](https://robotframework.org/) Firefox ESR and geckodriver from conda-forge. The overall runtime of course increases, but I feel there's a lot of value being delivered.

Other things:
- increases instrumentation, uploading more coverage/test reports from jest and acceptance tests
  - the coverage reports are still a touch wonky
- found some more issues introduced by the reader/writer implementation from #58
- add support for jsx/tsx
- some minor frontend fixes without unit tests
  - normalize case of drives on windows paths
  - handle non-list jump targets (observed with css)
  - can move these to a separate PR if desired

Caveats:
- markdown is not tested. I haven't dug into what's going on.
- browser/selenium flake is inevitable... still researching things to make it more robust (rather than just slower)
- again, probably a squash merge (even after i discarded a lot of trial-and-error commits)
- i haven't tried doing a "hard" install of all these things without conda (mostly because i help maintain all of the stuff there)
- i swear i'll calm down and stop making such large PRs
