### PR TITLE
Remove hard lab dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,23 +156,37 @@ jupyter labextension install @krassowski/jupyterlab-lsp@0.5.0-rc.0
 
 ## Development
 
-For a development install (requires npm version 4 or later), do the following in the repository directory:
+For a development install (requires `nodejs` 8 or later and `jupyterlab` 1.1),
+run the following in the repository directory:
 
 ```bash
-npm install
-npm run build
-jupyter labextension link .
+jlpm
+jlpm build
+jupyter labextension install .
 ```
 
 To rebuild the package and the JupyterLab app:
 
 ```bash
-npm run build
+jlpm build
 jupyter lab build
 ```
 
-To run tests suite:
+To watch the files and build continuously:
 
 ```bash
-npm test
+jlpm watch           # leave this running...
+jupyter lab --watch  # ...in another terminal
+```
+
+To check and fix code style:
+
+```bash
+jlpm lint
+```
+
+To run test the suite:
+
+```bash
+jlpm test
 ```

--- a/py_src/jupyter_lsp/CONTRIBUTING.md
+++ b/py_src/jupyter_lsp/CONTRIBUTING.md
@@ -165,13 +165,22 @@ conda env update -n jupyterlab-lsp --file environment-atest.yml
 pip install -r requirements-atest.txt  # ... and install geckodriver, somehow
 ```
 
-> Also ensure you've `jupyter labextension install .`ed in the root of the repo
+> To use with `jupyterlab-lsp` in JupyterLab, ensure you've
+>
+> ```
+> jlpm
+> jlpm build
+> jupyter labextension install .
+> ```
+
+````
+> in the root of this repo. See the [README](../../README.md#development) for more
 
 Run the tests:
 
 ```bash
 python scripts/atest.py
-```
+````
 
 ### Formatting
 

--- a/py_src/jupyter_lsp/CONTRIBUTING.md
+++ b/py_src/jupyter_lsp/CONTRIBUTING.md
@@ -157,6 +157,15 @@ python scripts/utest.py
 
 ### Browser-based Acceptance Tests
 
+The browser tests will launch JupyterLab on a random port and exercise the
+Language Server features with [Robot Framework][] and [SeleniumLibrary][].
+
+[robot framework]: https://github.com/robotframework/robotframework
+[seleniumlibrary]: https://github.com/robotframework/seleniumlibrary
+
+First, ensure you've prepared JupyterLab for `jupyterlab-lsp`
+[development](../../README.md#development).
+
 Prepare the enviroment:
 
 ```bash
@@ -165,22 +174,20 @@ conda env update -n jupyterlab-lsp --file environment-atest.yml
 pip install -r requirements-atest.txt  # ... and install geckodriver, somehow
 ```
 
-> To use with `jupyterlab-lsp` in JupyterLab, ensure you've
->
-> ```
-> jlpm
-> jlpm build
-> jupyter labextension install .
-> ```
-
-````
-> in the root of this repo. See the [README](../../README.md#development) for more
-
 Run the tests:
 
 ```bash
 python scripts/atest.py
-````
+```
+
+The Robot Framework reports and screenshots will be in `atest/output`, with
+`<operating system>_<python version>.log.html` being the most interesting
+artifacts, e.g.
+
+```
+- linux_37.log.html
+- linux_37.report.html
+```
 
 ### Formatting
 

--- a/py_src/jupyter_lsp/README.md
+++ b/py_src/jupyter_lsp/README.md
@@ -4,7 +4,7 @@
 > `notebook` or `lab` server. For Python 3.5+.
 
 See the parent of this repository, [jupyterlab-lsp](../../README.md) for the
-reference client implementation for [JupyterLab][]
+reference client implementation for [JupyterLab][].
 
 ## batteries expected
 

--- a/requirements-atest.txt
+++ b/requirements-atest.txt
@@ -1,3 +1,3 @@
 # acceptance test dependencies for jupyter_lsp
--r requirements.txt
+-r requirements-lab.txt
 robotframework-seleniumlibrary

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
-# development dependencies for jupyter_lsp for qa
+# development dependencies for jupyter_lsp for qa, with lab
 -r requirements-utest.txt
 pyls-black
 pyls-isort
 pyls-mypy
 pytest-cov
+jupyterlab >=1.1,<1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ pyls-black
 pyls-isort
 pyls-mypy
 pytest-cov
-jupyterlab >=1.1,<1.2

--- a/requirements-lab.txt
+++ b/requirements-lab.txt
@@ -1,0 +1,3 @@
+# the version of jupyterlab
+-r requirements.txt
+jupyterlab >=1.1,<1.2

--- a/requirements-utest.txt
+++ b/requirements-utest.txt
@@ -1,5 +1,5 @@
 # test time dependencies for jupyter_lsp, including one language server
--r requirements.txt
+-r requirements-lab.txt
 flake8 >=3.5
 pytest-asyncio
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-# what is needed to run jupyter_lsp (but no servers)
-jupyterlab>=1.1,<1.2
+# what is needed to run jupyter_lsp (but no servers or lab)
+notebook
 setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,17 +21,16 @@ classifiers =
     Programming Language :: Python
 
 [options]
-install_requires =
-    notebook
 package_dir =
     = py_src
+
 packages = find:
 include_package_data = True
 zip_safe = False
 
-tests_require =
-    pytest
-    pytest-cov
+install_requires =
+    notebook
+    entrypoints
 
 [options.packages.find]
 where =
@@ -42,7 +41,7 @@ jupyter_lsp_spec_v0 =
     bash-language-server = jupyter_lsp.specs:bash
     dockerfile-language-server-nodejs = jupyter_lsp.specs:dockerfile
     javascript-typescript-langserver = jupyter_lsp.specs:ts
-    pyls = jupyter_lsp.specs:py
+    python-language-server = jupyter_lsp.specs:py
     unified-language-server = jupyter_lsp.specs:md
     vscode-css-languageserver-bin = jupyter_lsp.specs:css
     vscode-html-languageserver-bin = jupyter_lsp.specs:html


### PR DESCRIPTION
For #70.

This removes the `jupyterlab` dependency, leaving `notebook` (and adding the missing `setuptools`). Lab will still get installed when following the dev instructions (which I've also revisited a bit).