### PR TITLE
Add an empty properties to settings schema

### DIFF
--- a/atest/00_Smoke.robot
+++ b/atest/00_Smoke.robot
@@ -1,6 +1,17 @@
 *** Settings ***
+Suite Setup       Set Screenshot Directory    ${OUTPUT DIR}${/}screenshots${/}smoke
 Resource          Keywords.robot
 
 *** Test Cases ***
 Smoke
     Capture Page Screenshot    00-splash.png
+
+Settings
+    [Setup]    Reset Application State
+    Lab Command    Advanced Settings Editor
+    Capture Page Screenshot    01-settings-all.png
+    ${sel} =    Set Variable    css:[data-id="@krassowski/jupyterlab-lsp:plugin"]
+    Wait Until Page Contains Element    ${sel}
+    Click Element    ${sel}
+    Wait Until Page Contains    System Defaults
+    Capture Page Screenshot    02-settings-lsp.png

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,6 +1,6 @@
 {
   "title": "Language Server",
-  "description": "Language Server Protocol settings.",
+  "description": "Language Server Protocol settings",
   "type": "object",
   "properties": {},
   "jupyter.lab.shortcuts": [

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,6 +2,7 @@
   "title": "Language Server",
   "description": "Language Server Protocol settings.",
   "type": "object",
+  "properties": {},
   "jupyter.lab.shortcuts": [
     {
       "command": "lsp:jump-to-definition-notebook",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,6 +1,6 @@
 {
   "title": "Language Server",
-  "description": "Language Server Protocol settings",
+  "description": "Language Server Protocol settings.",
   "type": "object",
   "properties": {},
   "jupyter.lab.shortcuts": [


### PR DESCRIPTION
Even though we don't have any settings to configure, we need an empty `properties` so that the settings editor can draw it without failing (and mucking up the UI).

Will also add a test...