### PR TITLE
use PEP 440 version specs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 variables:
   PYTHONUNBUFFERED: 1
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-  PY_JLSP_VERSION: 0.6.0b
+  PY_JLSP_VERSION: 0.6.0b0
   JS_JLLSP_VERSION: 0.5.0
 
 jobs:

--- a/py_src/jupyter_lsp/_version.py
+++ b/py_src/jupyter_lsp/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_lsp version
 """
-__version__ = "0.6.0b"
+__version__ = "0.6.0b0"


### PR DESCRIPTION
Adds trailing `0` to the python version specs.

The PEP 440 [pre-release spec](https://www.python.org/dev/peps/pep-0440/#pre-releases) looks like
```
X.YaN   # Alpha release
X.YbN   # Beta release
X.YrcN  # Release Candidate
X.Y     # Final release
```