### PR TITLE
Add server status endpoint

### DIFF
--- a/py_src/jupyter_lsp/handlers.py
+++ b/py_src/jupyter_lsp/handlers.py
@@ -10,7 +10,7 @@ from .manager import LanguageServerManager
 
 
 class BaseHandler(IPythonHandler):
-    manager: LanguageServerManager = None
+    manager = None  # type: LanguageServerManager
 
     def initialize(self, manager: LanguageServerManager):
         self.manager = manager
@@ -20,7 +20,7 @@ class LanguageServerWebSocketHandler(WebSocketMixin, WebSocketHandler, BaseHandl
     """ Setup tornado websocket to route to language server sessions
     """
 
-    language: Optional[Text] = None
+    language = None  # type: Optional[Text]
 
     def open(self, language):
         self.language = language

--- a/py_src/jupyter_lsp/handlers.py
+++ b/py_src/jupyter_lsp/handlers.py
@@ -41,12 +41,20 @@ class LanguageServerWebSocketHandler(WebSocketMixin, WebSocketHandler, BaseHandl
 
 
 class LanguageServersHandler(BaseHandler):
+    """ Reports the status of all current servers
+
+        Response should conform to schema in schema/servers.schema.json
+    """
+
     def get(self):
+        """ finish with the JSON representations of the sessions
+        """
         self.finish(
             {
+                "version": 0,
                 "sessions": sorted(
                     [session.to_json() for session in self.manager.sessions.values()],
                     key=lambda session: session["languages"],
-                )
+                ),
             }
         )

--- a/py_src/jupyter_lsp/schema/__init__.py
+++ b/py_src/jupyter_lsp/schema/__init__.py
@@ -1,0 +1,12 @@
+import json
+import pathlib
+
+import jsonschema
+
+HERE = pathlib.Path(__file__).parent
+
+
+def servers_schema():
+    return jsonschema.validators.Draft7Validator(
+        json.loads((HERE / "servers.schema.json").read_text())
+    )

--- a/py_src/jupyter_lsp/schema/__init__.py
+++ b/py_src/jupyter_lsp/schema/__init__.py
@@ -6,7 +6,9 @@ import jsonschema
 HERE = pathlib.Path(__file__).parent
 
 
-def servers_schema():
+def servers_schema() -> jsonschema.validators.Draft7Validator:
+    """ return a JSON Schema Draft 7 validator for the server status API
+    """
     return jsonschema.validators.Draft7Validator(
         json.loads((HERE / "servers.schema.json").read_text())
     )

--- a/py_src/jupyter_lsp/schema/servers.schema.json
+++ b/py_src/jupyter_lsp/schema/servers.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/servers-response",
+  "definitions": {
+    "servers-response": {
+      "type": "object",
+      "properties": {
+        "sessions": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/session" }
+        }
+      },
+      "required": ["sessions"]
+    },
+    "nullable-date-time": {
+      "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
+    },
+    "session": {
+      "additionalProperties": false,
+      "required": [
+        "languages",
+        "handler_count",
+        "status",
+        "last_server_message_at",
+        "last_handler_message_at"
+      ],
+      "properties": {
+        "languages": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true,
+          "minItems": 1
+        },
+        "handler_count": { "type": "integer", "minValue": 0 },
+        "status": {
+          "type": "string",
+          "enum": ["not_started", "starting", "started", "stopping", "stopped"]
+        },
+        "last_server_message_at": {
+          "$ref": "#/definitions/nullable-date-time"
+        },
+        "last_handler_message_at": {
+          "$ref": "#/definitions/nullable-date-time"
+        }
+      }
+    }
+  }
+}

--- a/py_src/jupyter_lsp/schema/servers.schema.json
+++ b/py_src/jupyter_lsp/schema/servers.schema.json
@@ -1,21 +1,32 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$ref": "#/definitions/servers-response",
+  "title": "jupyter_lsp server status response",
+  "description": "describes the current state of (potentially) running language servers",
   "definitions": {
     "servers-response": {
       "type": "object",
       "properties": {
         "sessions": {
           "type": "array",
+          "description": "a list of servers that are, could be, or were running",
           "items": { "$ref": "#/definitions/session" }
+        },
+        "version": {
+          "type": "integer",
+          "description": "the version of the schema",
+          "enum": [0]
         }
       },
-      "required": ["sessions"]
+      "required": ["sessions", "version"]
     },
     "nullable-date-time": {
+      "description": "a date/time that might not have been recorded",
       "oneOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }]
     },
     "session": {
+      "title": "Language Server Session",
+      "description": "a language server session",
       "additionalProperties": false,
       "required": [
         "languages",
@@ -26,20 +37,29 @@
       ],
       "properties": {
         "languages": {
+          "description": "languages supported by this Language Server",
           "type": "array",
-          "items": {"type": "string"},
+          "items": { "type": "string" },
           "uniqueItems": true,
           "minItems": 1
         },
-        "handler_count": { "type": "integer", "minValue": 0 },
+        "handler_count": {
+          "title": "handler count",
+          "description": "the count of currently-connected WebSocket handlers",
+          "type": "integer",
+          "minValue": 0
+        },
         "status": {
+          "description": "a string describing the current state of the server",
           "type": "string",
           "enum": ["not_started", "starting", "started", "stopping", "stopped"]
         },
         "last_server_message_at": {
+          "description": "date-time of last seen message from the language server",
           "$ref": "#/definitions/nullable-date-time"
         },
         "last_handler_message_at": {
+          "description": "date-time of last seen message from a WebSocket handler",
           "$ref": "#/definitions/nullable-date-time"
         }
       }

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -5,7 +5,7 @@ import json
 import traitlets
 from notebook.utils import url_path_join as ujoin
 
-from .handlers import LanguageServerWebSocketHandler
+from .handlers import LanguageServersHandler, LanguageServerWebSocketHandler
 from .manager import LanguageServerManager
 
 
@@ -20,13 +20,16 @@ def load_jupyter_server_extension(nbapp):
             json.dumps(manager.language_servers, indent=2, sort_keys=True)
         )
     )
+
+    lsp_url = ujoin(nbapp.base_url, "lsp")
+    re_langs = "(?P<language>.*)"
+
+    opts = {"manager": nbapp.language_server_manager}
+
     nbapp.web_app.add_handlers(
         ".*",
         [
-            (
-                ujoin(nbapp.base_url, "lsp", "(?P<language>.*)"),
-                LanguageServerWebSocketHandler,
-                {"manager": nbapp.language_server_manager},
-            )
+            (lsp_url, LanguageServersHandler, opts),
+            (ujoin(lsp_url, re_langs), LanguageServerWebSocketHandler, opts),
         ],
     )

--- a/py_src/jupyter_lsp/tests/test_session.py
+++ b/py_src/jupyter_lsp/tests/test_session.py
@@ -2,42 +2,69 @@ import asyncio
 
 import pytest
 
+from .conftest import SERVERS_SCHEMA
+
+
+def assert_status_set(handler, expected_statuses, language=None):
+    handler.get()
+    payload = handler._payload
+
+    SERVERS_SCHEMA.validate(payload)
+
+    statuses = {
+        s["status"]
+        for s in payload["sessions"]
+        if language is None or language in s["languages"]
+    }
+    assert statuses == expected_statuses
+
 
 @pytest.mark.asyncio
-async def test_start_known(known_language, handler, jsonrpc_init_msg):
+async def test_start_known(known_language, handlers, jsonrpc_init_msg):
     """ will a process start for a known language if a handler starts listening?
     """
+    handler, ws_handler = handlers
     manager = handler.manager
+
     manager.initialize()
-    handler.open(known_language)
-    sessions = list(manager.sessions_for_handler(handler))
+
+    assert_status_set(handler, {"not_started"})
+
+    ws_handler.open(known_language)
+    sessions = list(manager.sessions_for_handler(ws_handler))
     session = sessions[0]
     assert session.process is not None
 
-    handler.on_message(jsonrpc_init_msg)
+    assert_status_set(handler, {"started"}, known_language)
+
+    ws_handler.on_message(jsonrpc_init_msg)
 
     try:
-        await asyncio.wait_for(handler._messages_wrote.get(), 20)
-        handler._messages_wrote.task_done()
+        await asyncio.wait_for(ws_handler._messages_wrote.get(), 20)
+        ws_handler._messages_wrote.task_done()
     finally:
-        handler.on_close()
+        ws_handler.on_close()
 
-    assert not list(manager.sessions_for_handler(handler))
+    assert not list(manager.sessions_for_handler(ws_handler))
     assert not session.handlers
     assert not session.process
 
+    assert_status_set(handler, {"stopped"}, known_language)
+    assert_status_set(handler, {"stopped", "not_started"})
+
 
 @pytest.mark.asyncio
-async def test_start_unknown(known_unknown_language, handler, jsonrpc_init_msg):
+async def test_start_unknown(known_unknown_language, handlers, jsonrpc_init_msg):
     """ will a process not start for an unknown if a handler starts listening?
     """
+    handler, ws_handler = handlers
     manager = handler.manager
     manager.initialize()
-    handler.open(known_unknown_language)
-    assert not list(manager.sessions_for_handler(handler))
+    ws_handler.open(known_unknown_language)
+    assert not list(manager.sessions_for_handler(ws_handler))
 
-    handler.on_message(jsonrpc_init_msg)
+    ws_handler.on_message(jsonrpc_init_msg)
 
-    handler.on_close()
+    ws_handler.on_close()
 
-    assert not list(manager.sessions_for_handler(handler))
+    assert not list(manager.sessions_for_handler(ws_handler))

--- a/py_src/jupyter_lsp/types.py
+++ b/py_src/jupyter_lsp/types.py
@@ -1,5 +1,6 @@
 """ API used by spec finders and manager
 """
+import enum
 import pathlib
 import shutil
 import sys
@@ -12,6 +13,17 @@ from traitlets.config import LoggingConfigurable
 # TODO: TypedDict?
 LanguageServerSpec = Dict[Text, List[Text]]
 KeyedLanguageServerSpecs = Dict[Text, LanguageServerSpec]
+
+
+class SessionStatus(enum.Enum):
+    """ States in which a language server session can be
+    """
+
+    NOT_STARTED = "not_started"
+    STARTING = "starting"
+    STARTED = "started"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
 
 
 class LanguageServerManagerAPI(LoggingConfigurable):


### PR DESCRIPTION
For https://github.com/krassowski/jupyterlab-lsp/pull/78#issuecomment-546907659

This adds a REST-ish (whatever) JSON endpoint for getting the current state of the server sessions at `/lsp` (no trailing slash).

<details>
<summary>example response</summary>
<pre>
{
  "version": 0,
  "sessions": [
    {
      "languages": [
        "bash",
        "sh"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "css",
        "less",
        "scss"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "dockerfile"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "html"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "javascript",
        "jsx",
        "typescript",
        "typescript-jsx"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "json"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "markdown",
        "ipythongfm"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "python"
      ],
      "handler_count": 1,
      "status": "started",
      "last_server_message_at": "2019-10-30T04:30:53.069124+00:00",
      "last_handler_message_at": "2019-10-30T04:30:52.219183+00:00"
    },
    {
      "languages": [
        "r"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    },
    {
      "languages": [
        "yaml"
      ],
      "handler_count": 0,
      "status": "not_started",
      "last_server_message_at": null,
      "last_handler_message_at": null
    }
  ]
}
</pre>
</details>

Not sure what else we're looking for at this point.

There is a JSON schema (for testing, not presently hot validating) which we could generate typescript with, if that helps.

Everything it reports is already evented through `traitlets`, so this could relatively easily be Yet Another WebSocket, but we'll cross that bridge when we have to, I suppose, as it would require a breaking change to the URL schema, probably. Perhaps `lsp/server/python` and `lsp/servers` or something.

It also currently doesn't detect error states in a meaningful way, but we could potentially infer them by looking at the queue lengths, perhaps.