### PR TITLE
Migrate from lsp-editor-adapter to (stripped) lsp-ws-connection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "eslint-plugin-prettier": "^3.0.1",
     "husky": "^3.0.9",
     "javascript-typescript-langserver": "^2.11.3",
-    "jsonrpc-ws-proxy": "0.0.5",
     "lerna": "^3.13.2",
     "precise-commits": "^1.0.2",
     "prettier": "^1.18.2",

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@krassowski/jupyterlab_go_to_definition": "^0.7.1",
-    "lsp-ws-connection": "~0.1.0"
+    "lsp-ws-connection": "~0.1.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.3",

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@krassowski/jupyterlab_go_to_definition": "^0.7.1",
-    "lsp-editor-adapter": "0.0.10"
+    "lsp-ws-connection": "~0.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.3",

--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -8,7 +8,7 @@ import {
   IPosition,
   ITokenInfo,
   LspWsConnection
-} from 'lsp-editor-adapter';
+} from 'lsp-ws-connection';
 import { CompletionTriggerKind } from './lsp';
 import { until_ready } from './utils';
 

--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -30,24 +30,19 @@ export class LSPConnection extends LspWsConnection {
   }
 
   public isRenameSupported() {
-    // prettier-ignore
     return !!(
-      // @ts-ignore
       this.serverCapabilities && this.serverCapabilities.renameProvider
     );
   }
 
   public rename(location: IPosition, newName: string) {
-    // @ts-ignore
     if (!this.isConnected || !this.isRenameSupported()) {
       return;
     }
 
-    // @ts-ignore
     this.connection
       .sendRequest('textDocument/rename', {
         textDocument: {
-          // @ts-ignore
           uri: this.documentInfo.documentUri
         },
         position: {
@@ -65,14 +60,10 @@ export class LSPConnection extends LspWsConnection {
     super.connect(socket);
 
     until_ready(() => {
-      // @ts-ignore
       return this.isConnected;
     }, -1)
       .then(() => {
-        // @ts-ignore
-        let connection = this.connection;
-        connection.onClose(() => {
-          // @ts-ignore
+        this.connection.onClose(() => {
           this.isConnected = false;
           this.emit('close', this.closing_manually);
         });
@@ -97,26 +88,20 @@ export class LSPConnection extends LspWsConnection {
   private _sendChange(
     changeEvents: lsProtocol.TextDocumentContentChangeEvent[]
   ) {
-    // @ts-ignore
     if (!this.isConnected) {
       return;
     }
-    // @ts-ignore
-    let documentInfo = this.documentInfo;
     const textDocumentChange: lsProtocol.DidChangeTextDocumentParams = {
       textDocument: {
-        uri: documentInfo.documentUri,
-        // @ts-ignore
+        uri: this.documentInfo.documentUri,
         version: this.documentVersion
       } as lsProtocol.VersionedTextDocumentIdentifier,
       contentChanges: changeEvents
     };
-    // @ts-ignore
     this.connection.sendNotification(
       'textDocument/didChange',
       textDocumentChange
     );
-    // @ts-ignore
     this.documentVersion++;
   }
 
@@ -126,24 +111,19 @@ export class LSPConnection extends LspWsConnection {
     triggerCharacter: string,
     triggerKind: CompletionTriggerKind
   ): Promise<lsProtocol.CompletionItem[]> {
-    // @ts-ignore
     if (!this.isConnected) {
       return;
     }
     if (
-      // @ts-ignore
       !(this.serverCapabilities && this.serverCapabilities.completionProvider)
     ) {
       return;
     }
 
-    // @ts-ignore
-    let connection = this.connection;
     return new Promise<lsProtocol.CompletionItem[]>(resolve => {
-      connection
+      this.connection
         .sendRequest('textDocument/completion', {
           textDocument: {
-            // @ts-ignore
             uri: this.documentInfo.documentUri
           },
           position: {

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -12,11 +12,11 @@ import { IDocumentManager } from '@jupyterlab/docmanager';
 import { FileEditorJumper } from '@krassowski/jupyterlab_go_to_definition/lib/jumpers/fileeditor';
 import { NotebookJumper } from '@krassowski/jupyterlab_go_to_definition/lib/jumpers/notebook';
 
-import 'codemirror/addon/hint/show-hint.css';
-import 'codemirror/addon/hint/show-hint';
+// TODO: make use of it for jump target selection (requires to be added to package.json)?
+// import 'codemirror/addon/hint/show-hint.css';
+// import 'codemirror/addon/hint/show-hint';
 import '../style/index.css';
 
-import 'lsp-editor-adapter/lib/codemirror-lsp.css';
 import { ICompletionManager } from '@jupyterlab/completer';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { NotebookAdapter } from './adapters/jupyterlab/notebook';

--- a/packages/jupyterlab-lsp/src/virtual/editors/notebook.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editors/notebook.ts
@@ -1,7 +1,6 @@
 import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
 import { Cell } from '@jupyterlab/cells';
 import { CodeMirrorEditor } from '@jupyterlab/codemirror';
-import { ShowHintOptions } from 'codemirror';
 import { IOverridesRegistry } from '../../magics/overrides';
 import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 import { VirtualEditor } from '../editor';
@@ -138,7 +137,6 @@ export class VirtualEditorForNotebook extends VirtualEditor {
     return this.get_editor_at_root_line(position);
   }
 
-  showHint: (options: ShowHintOptions) => void;
   state: any;
 
   addKeyMap(map: string | CodeMirror.KeyMap, bottom?: boolean): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,13 +2142,6 @@
     "@phosphor/signaling" "^1.3.1"
     "@phosphor/virtualdom" "^1.2.0"
 
-"@sourcegraph/vscode-ws-jsonrpc@0.0.3-fork":
-  version "0.0.3-fork"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.0.3-fork.tgz#83728a14616ef0587298e7849d960b61853a9954"
-  integrity sha512-EJLq/ni66glk3xYyOZtUIEbjTCw8kMI6RvO0YQtPd+4um2+aTSM1LfN4NrsiVrRkG7EG/U2OkFlKqT8mGo6w4Q==
-  dependencies:
-    vscode-jsonrpc "^4.0.0"
-
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -5718,16 +5711,6 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonrpc-ws-proxy@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/jsonrpc-ws-proxy/-/jsonrpc-ws-proxy-0.0.5.tgz#e77c4fb4cbeda51a3865eb6314f8deafa8103655"
-  integrity sha512-Gz3Njkc4LdJ+wEtrgG5acZWKTH78kYRHCYwN/QKzoJjdQw1jEepwkWTXLRa3JifcIpxh+WjA6OJw8A8RvejzXw==
-  dependencies:
-    "@sourcegraph/vscode-ws-jsonrpc" "0.0.3-fork"
-    js-yaml "^3.12.0"
-    minimist "^1.2.0"
-    ws "^6.1.0"
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -5868,11 +5851,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.11:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -6005,12 +5983,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lsp-editor-adapter@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/lsp-editor-adapter/-/lsp-editor-adapter-0.0.10.tgz#eaaa89e46c71e6856de11fe8cf403b0fbd15c08c"
-  integrity sha512-jfAQoakF/K2S0hpN4kQZWRH44Wu7UX0OqJGoUEcm52pBkQxKtCgmRC4EusRHX/wgzDCAJc8zi5fBwYlcqEjwBg==
+lsp-ws-connection@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/lsp-ws-connection/-/lsp-ws-connection-0.1.0.tgz#a5587d47f7f804f5c3c3a84e743b2b227849d447"
+  integrity sha512-0vQcRxBHnDDJ7dx/8Gaijo3IYt+d0he5zyreFZtW2JV9KmqBUuNVtPbA85Iz3Nfj7QxrL0nnswZ/gttLStjD5Q==
   dependencies:
-    lodash-es "^4.17.11"
     vscode-jsonrpc "^4.0.0"
     vscode-languageclient "^5.2.1"
     vscode-languageserver-protocol "^3.14.1"
@@ -9991,13 +9968,6 @@ ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
-  dependencies:
-    async-limiter "~1.0.0"
-
-ws@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5983,15 +5983,16 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lsp-ws-connection@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lsp-ws-connection/-/lsp-ws-connection-0.1.0.tgz#a5587d47f7f804f5c3c3a84e743b2b227849d447"
-  integrity sha512-0vQcRxBHnDDJ7dx/8Gaijo3IYt+d0he5zyreFZtW2JV9KmqBUuNVtPbA85Iz3Nfj7QxrL0nnswZ/gttLStjD5Q==
+lsp-ws-connection@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/lsp-ws-connection/-/lsp-ws-connection-0.1.1.tgz#5e259a5079aa91f9bb55453d03df14f3e526fa6b"
+  integrity sha512-JLGsBbJc5NlNkvo8hyjVqOG2jZrCtXnz65d1pPPnp6mRl++J3pa0M0e2/jOGeDx+emDNk31/pUlLDOSHhphE4w==
   dependencies:
     vscode-jsonrpc "^4.0.0"
     vscode-languageclient "^5.2.1"
     vscode-languageserver-protocol "^3.14.1"
     vscode-languageserver-types "^3.14.0"
+    vscode-ws-jsonrpc "0.1.1"
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -9680,6 +9681,11 @@ vscode-jsonrpc@^4.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
   integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
 
+vscode-jsonrpc@^4.1.0-next:
+  version "4.1.0-next.3"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz#05fe742959a2726020d4d0bfbc3d3c97873c7fde"
+  integrity sha512-Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==
+
 vscode-languageclient@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz#7cfc83a294c409f58cfa2b910a8cfeaad0397193"
@@ -9780,6 +9786,13 @@ vscode-uri@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.0.tgz#475a4269e63edbc13914b40c84bc1416e3398156"
   integrity sha512-3voe44nOhb6OdKlpZShVsmVvY2vFQHMe6REP3Ky9RVJuPyM/XidsjH6HncCIDdSmbcF5YQHrTC/Q+Q2loJGkOw==
+
+vscode-ws-jsonrpc@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.1.1.tgz#163ff05662635b4fd161ed132e112cec4d83f126"
+  integrity sha512-1O/FUORbb8dZAvh9AFF6HViLJ0Ja0RbF+sFRnUsoqkuKIRsXDDiiJpwYwT6fmglCLefE5afGPw9NoHvDVN/5yw==
+  dependencies:
+    vscode-jsonrpc "^4.1.0-next"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This allows us to:
- remove some dependencies, especially conflicting CodeMirror versions
- remove lots of unused code, since we got the adapter part rewritten
- start customizing the connection behavior to our liking

Here is the link to the repo: https://github.com/krassowski/lsp-ws-connection. We may want to pull this in as a package, though there is a slight difference in the license (ISC), so not sure about this.

I also removed `jsonrpc-ws-proxy` - high time to have the transition finished off.