### PR TITLE
Add rootUri to PageConfig

### DIFF
--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -87,22 +87,20 @@ export class DocumentConnectionManager {
   }
 
   private connect_socket(options: ISocketConnectionOptions): LSPConnection {
-    let { virtual_document, language, server_root, root_path } = options;
+    let { virtual_document, language, root_path } = options;
     console.log(root_path);
 
     // capture just the s?://*
     const wsBase = PageConfig.getBaseUrl().replace(/^http/, '');
+    const rootUri = PageConfig.getOption('rootUri');
     const wsUrl = `ws${wsBase}lsp/${language}`;
     let socket = new WebSocket(wsUrl);
 
     let connection = new LSPConnection({
       serverUri: 'ws://jupyter-lsp/' + language,
       languageId: language,
-      // paths handling needs testing on Windows and with other language servers
-      // TODO: compare against: rootUri: 'file:///' + PathExt.join(server_root, root_path),
-      rootUri: 'file:///' + PathExt.join(server_root),
-      // TODO: compare against: 'file:///' + PathExt.join(server_root, root_path, virtual_document.uri),
-      documentUri: 'file:///' + PathExt.join(server_root, virtual_document.uri),
+      rootUri: rootUri,
+      documentUri: PathExt.join(rootUri, virtual_document.uri),
       documentText: () => {
         // NOTE: Update is async now and this is not really used, as an alternative method
         // which is compatible with async is used.

--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -87,17 +87,15 @@ export class DocumentConnectionManager {
   }
 
   private connect_socket(options: ISocketConnectionOptions): LSPConnection {
-    let { virtual_document, language, root_path } = options;
-    console.log(root_path);
+    let { virtual_document, language } = options;
 
-    // capture just the s?://*
-    const wsBase = PageConfig.getBaseUrl().replace(/^http/, '');
+    const wsBase = PageConfig.getBaseUrl().replace(/^http/, 'ws');
     const rootUri = PageConfig.getOption('rootUri');
-    const wsUrl = `ws${wsBase}lsp/${language}`;
+    const wsUrl = PathExt.join(wsBase, 'lsp', language);
     let socket = new WebSocket(wsUrl);
 
     let connection = new LSPConnection({
-      serverUri: 'ws://jupyter-lsp/' + language,
+      serverUri: PathExt.join('ws://jupyter-lsp', language),
       languageId: language,
       rootUri: rootUri,
       documentUri: PathExt.join(rootUri, virtual_document.uri),

--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -91,13 +91,12 @@ export class DocumentConnectionManager {
 
     const wsBase = PageConfig.getBaseUrl().replace(/^http/, 'ws');
     const rootUri = PageConfig.getOption('rootUri');
-    const wsUrl = PathExt.join(wsBase, 'lsp', language);
-    let socket = new WebSocket(wsUrl);
+    let socket = new WebSocket(PathExt.join(wsBase, 'lsp', language));
 
     let connection = new LSPConnection({
       serverUri: PathExt.join('ws://jupyter-lsp', language),
       languageId: language,
-      rootUri: rootUri,
+      rootUri,
       documentUri: PathExt.join(rootUri, virtual_document.uri),
       documentText: () => {
         // NOTE: Update is async now and this is not really used, as an alternative method

--- a/packages/jupyterlab-lsp/src/utils.ts
+++ b/packages/jupyterlab-lsp/src/utils.ts
@@ -1,6 +1,6 @@
 import { PageConfig } from '@jupyterlab/coreutils';
 
-const RE_PATH_ANCHOR = /^file:\/\/([^\/]+|\/[A-Z]:)\//;
+const RE_PATH_ANCHOR = /^file:\/\/([^\/]+|\/[A-Z]:)/;
 
 export async function sleep(timeout: number) {
   return new Promise(resolve => {

--- a/packages/jupyterlab-lsp/src/utils.ts
+++ b/packages/jupyterlab-lsp/src/utils.ts
@@ -1,6 +1,6 @@
 import { PageConfig } from '@jupyterlab/coreutils';
 
-const RE_WIN_PATH = /^file:\/\/\/[a-z]:\//i;
+const RE_PATH_ANCHOR = /^file:\/\/([^\/]+|\/[A-Z]:)\//;
 
 export async function sleep(timeout: number) {
   return new Promise(resolve => {
@@ -110,14 +110,14 @@ export function uris_equal(a: string, b: string) {
  * grossly detect whether a URI represents a file on a windows drive
  */
 export function is_win_path(uri: string) {
-  return uri.match(RE_WIN_PATH);
+  return uri.match(RE_PATH_ANCHOR);
 }
 
 /**
  * lowercase the drive component of a URI
  */
 export function normalize_win_path(uri: string) {
-  return uri.replace(RE_WIN_PATH, it => it.toLowerCase());
+  return uri.replace(RE_PATH_ANCHOR, it => it.toLowerCase());
 }
 
 export function uri_to_contents_path(child: string, parent?: string) {

--- a/packages/jupyterlab-lsp/src/utils.ts
+++ b/packages/jupyterlab-lsp/src/utils.ts
@@ -89,19 +89,7 @@ export class DefaultMap<K, V> extends Map<K, V> {
 }
 
 export function server_root_uri() {
-  const server_root = PageConfig.getOption('serverRoot');
-  const user_settings = PageConfig.getOption('userSettingsDir');
-  if (server_root.startsWith('~') && user_settings.startsWith('/home/')) {
-    return (
-      'file://' +
-      server_root.replace(
-        '~',
-        user_settings.substring(0, user_settings.indexOf('/', 6))
-      )
-    );
-  } else {
-    return 'file://' + server_root;
-  }
+  return PageConfig.getOption('rootUri');
 }
 
 /**

--- a/py_src/jupyter_lsp/handlers.py
+++ b/py_src/jupyter_lsp/handlers.py
@@ -4,6 +4,7 @@ from typing import Optional, Text
 
 from notebook.base.handlers import IPythonHandler
 from notebook.base.zmqhandlers import WebSocketHandler, WebSocketMixin
+from notebook.utils import url_path_join as ujoin
 from tornado.ioloop import IOLoop
 
 from .manager import LanguageServerManager
@@ -58,3 +59,20 @@ class LanguageServersHandler(BaseHandler):
                 ),
             }
         )
+
+
+def add_handlers(nbapp):
+    """ Add Language Server routes to the notebook server web application
+    """
+    lsp_url = ujoin(nbapp.base_url, "lsp")
+    re_langs = "(?P<language>.*)"
+
+    opts = {"manager": nbapp.language_server_manager}
+
+    nbapp.web_app.add_handlers(
+        ".*",
+        [
+            (lsp_url, LanguageServersHandler, opts),
+            (ujoin(lsp_url, re_langs), LanguageServerWebSocketHandler, opts),
+        ],
+    )

--- a/py_src/jupyter_lsp/paths.py
+++ b/py_src/jupyter_lsp/paths.py
@@ -1,0 +1,11 @@
+import re
+
+RE_WIN_PATH = r"^file:///([A-Z]):/"
+
+
+def normalize_uri(root_uri):
+    if not re.findall(RE_WIN_PATH, root_uri):
+        return root_uri
+    return re.sub(
+        RE_WIN_PATH, lambda m: "file:///{}:/".format(m.group(1).lower()), root_uri
+    )

--- a/py_src/jupyter_lsp/paths.py
+++ b/py_src/jupyter_lsp/paths.py
@@ -1,11 +1,17 @@
+import pathlib
 import re
 
-RE_WIN_PATH = r"^file:///([A-Z]):/"
+RE_PATH_ANCHOR = r"^file://([^/]+|/[A-Z]:)/"
 
 
-def normalize_uri(root_uri):
-    if not re.findall(RE_WIN_PATH, root_uri):
-        return root_uri
-    return re.sub(
-        RE_WIN_PATH, lambda m: "file:///{}:/".format(m.group(1).lower()), root_uri
+def normalized_uri(root_dir):
+    """ Attempt to make an LSP rootUri from a ContentsManager root_dir
+
+        Special care must be taken around windows paths: the canonical form of
+        windows drives and UNC paths is lower case
+    """
+    root_uri = pathlib.Path(root_dir).expanduser().resolve().as_uri()
+    root_uri = re.sub(
+        RE_PATH_ANCHOR, lambda m: "file://{}/".format(m.group(1).lower()), root_uri
     )
+    return root_uri

--- a/py_src/jupyter_lsp/paths.py
+++ b/py_src/jupyter_lsp/paths.py
@@ -1,7 +1,7 @@
 import pathlib
 import re
 
-RE_PATH_ANCHOR = r"^file://([^/]+|/[A-Z]:)/"
+RE_PATH_ANCHOR = r"^file://([^/]+|/[A-Z]:)"
 
 
 def normalized_uri(root_dir):
@@ -12,6 +12,6 @@ def normalized_uri(root_dir):
     """
     root_uri = pathlib.Path(root_dir).expanduser().resolve().as_uri()
     root_uri = re.sub(
-        RE_PATH_ANCHOR, lambda m: "file://{}/".format(m.group(1).lower()), root_uri
+        RE_PATH_ANCHOR, lambda m: "file://{}".format(m.group(1).lower()), root_uri
     )
     return root_uri

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -1,6 +1,7 @@
 """ add language server support to the running jupyter notebook application
 """
 import json
+import os
 import pathlib
 
 import traitlets
@@ -31,10 +32,7 @@ def load_jupyter_server_extension(nbapp):
     contents = nbapp.contents_manager
 
     if hasattr(contents, "root_dir"):
-        root_dir = pathlib.Path(contents.root_dir).resolve()
-        # normalize for windows case
-        if root_dir.drive and root_dir.drive.endswith(":"):  # pragma: no cover
-            root_dir.drive = root_dir.drive.lower()
+        root_dir = pathlib.Path(os.path.normcase(contents.root_dir)).resolve()
         root_uri = root_dir.as_uri()
         web_app.settings.setdefault("page_config_data", {})["rootUri"] = root_uri
     else:  # pragma: no cover

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -1,7 +1,6 @@
 """ add language server support to the running jupyter notebook application
 """
 import json
-import os
 import pathlib
 
 import traitlets
@@ -9,6 +8,7 @@ from notebook.utils import url_path_join as ujoin
 
 from .handlers import LanguageServersHandler, LanguageServerWebSocketHandler
 from .manager import LanguageServerManager
+from .paths import normalize_uri
 
 
 def load_jupyter_server_extension(nbapp):
@@ -32,9 +32,10 @@ def load_jupyter_server_extension(nbapp):
     contents = nbapp.contents_manager
 
     if hasattr(contents, "root_dir"):
-        root_dir = pathlib.Path(os.path.normcase(contents.root_dir)).resolve()
-        root_uri = root_dir.as_uri()
+        root_dir = pathlib.Path(contents.root_dir).resolve()
+        root_uri = normalize_uri(root_dir.as_uri())
         web_app.settings.setdefault("page_config_data", {})["rootUri"] = root_uri
+        nbapp.log.debug("[lsp] rootUri will be %s", root_uri)
     else:  # pragma: no cover
         nbapp.log.warn(
             "[lsp] %s did not appear to have a root_dir, could not set rootUri",

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -32,11 +32,11 @@ def load_jupyter_server_extension(nbapp):
 
     if hasattr(contents, "root_dir"):
         root_uri = pathlib.Path(contents.root_dir).as_uri()
-        web_app.settings["page_config_data"]["rootUri"] = root_uri
+        web_app.settings.setdefault("page_config_data", {})["rootUri"] = root_uri
     else:  # pragma: no cover
         nbapp.log.warn(
             "[lsp] %s did not appear to have a root_dir, could not set rootUri",
-            contents
+            contents,
         )
 
     web_app.add_handlers(

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -31,7 +31,11 @@ def load_jupyter_server_extension(nbapp):
     contents = nbapp.contents_manager
 
     if hasattr(contents, "root_dir"):
-        root_uri = pathlib.Path(contents.root_dir).as_uri()
+        root_dir = pathlib.Path(contents.root_dir).resolve()
+        # normalize for windows case
+        if root_dir.drive and root_dir.drive.endswith(":"):  # pragma: no cover
+            root_dir.drive = root_dir.drive.lower()
+        root_uri = root_dir.as_uri()
         web_app.settings.setdefault("page_config_data", {})["rootUri"] = root_uri
     else:  # pragma: no cover
         nbapp.log.warn(

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ..paths import normalize_uri
+
+
+@pytest.mark.parametrize(
+    "root_uri, normalized",
+    [
+        ["file:///c:/Users/user1", "file:///c:/Users/user1"],
+        ["file:///C:/Users/user1", "file:///c:/Users/user1"],
+    ],
+)
+def test_normalize_path(root_uri, normalized):
+    assert normalize_uri(root_uri) == normalized

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -8,7 +8,7 @@ from ..paths import normalized_uri
 
 WIN = platform.system() == "Windows"
 HOME = pathlib.Path("~").expanduser()
-PY35 = sys.version_info[:2] < (3, 5)
+PY35 = sys.version_info[:2] == (3, 5)
 
 
 @pytest.mark.skipif(WIN, reason="can't test POSIX paths on Windows")

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -1,5 +1,6 @@
 import pathlib
 import platform
+import sys
 
 import pytest
 
@@ -7,8 +8,10 @@ from ..paths import normalized_uri
 
 WIN = platform.system() == "Windows"
 HOME = pathlib.Path("~").expanduser()
+PY35 = sys.version_info[:2] < (3, 5)
 
 
+@pytest.mark.skipif(PY35, reason="can't test non-existant paths on py35")
 @pytest.mark.skipif(WIN, reason="can't test POSIX paths on Windows")
 @pytest.mark.parametrize(
     "root_dir, expected_root_uri",

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -11,17 +11,24 @@ HOME = pathlib.Path("~").expanduser()
 PY35 = sys.version_info[:2] < (3, 5)
 
 
+@pytest.mark.skipif(WIN, reason="can't test POSIX paths on Windows")
+@pytest.mark.parametrize("root_dir, expected_root_uri", [["~", HOME.as_uri()]])
+def test_normalize_posix_path_home(root_dir, expected_root_uri):  # pragma: no cover
+    assert normalized_uri(root_dir) == expected_root_uri
+
+
 @pytest.mark.skipif(PY35, reason="can't test non-existant paths on py35")
 @pytest.mark.skipif(WIN, reason="can't test POSIX paths on Windows")
 @pytest.mark.parametrize(
     "root_dir, expected_root_uri",
     [
-        ["~", HOME.as_uri()],
         # probably need to try some other things
-        [str(HOME / "foo"), (HOME / "foo").as_uri()],
+        [str(HOME / "foo"), (HOME / "foo").as_uri()]
     ],
 )
-def test_normalize_paths(root_dir, expected_root_uri):  # pragma: no cover
+def test_normalize_posix_path_home_subdir(
+    root_dir, expected_root_uri
+):  # pragma: no cover
     assert normalized_uri(root_dir) == expected_root_uri
 
 

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -1,14 +1,38 @@
+import pathlib
+import platform
+
 import pytest
 
-from ..paths import normalize_uri
+from ..paths import normalized_uri
+
+WIN = platform.system == "Windows"
+HOME = pathlib.Path("~").expanduser()
 
 
+@pytest.mark.skipif(WIN, reason="can't test POSIX paths on Windows")
 @pytest.mark.parametrize(
-    "root_uri, normalized",
+    "root_dir, expected_root_uri",
     [
-        ["file:///c:/Users/user1", "file:///c:/Users/user1"],
-        ["file:///C:/Users/user1", "file:///c:/Users/user1"],
+        # probably need to try some other things
+        [str(HOME / "foo"), (HOME / "foo").as_uri()]
     ],
 )
-def test_normalize_path(root_uri, normalized):
-    assert normalize_uri(root_uri) == normalized
+def test_normalize_paths(root_dir, expected_root_uri):  # pragma: no cover
+    """ paths we can easily test on POSIX platforms
+    """
+    assert normalized_uri(root_dir) == expected_root_uri
+
+
+@pytest.mark.skipif(not WIN, reason="can't test Windows paths on POSIX")
+@pytest.mark.parametrize(
+    "root_dir, expected_root_uri",
+    [
+        ["c:\\Users\\user1", "file:///c:/Users/user1"],
+        ["C:\\Users\\user1", "file:///c:/Users/user1"],
+        ["//VBOXSVR/shared-folder", "file://vboxsvr/shared-folder"],
+    ],
+)
+def test_normalize_windows_path_case(root_dir, expected_root_uri):  # pragma: no cover
+    """ paths we can easily test on non-windows platforms
+    """
+    assert normalized_uri(root_dir) == expected_root_uri

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -23,7 +23,6 @@ def test_normalize_paths(root_dir, expected_root_uri):  # pragma: no cover
     assert normalized_uri(root_dir) == expected_root_uri
 
 
-@pytest.mark.skipif(not WIN, reason="can't test Windows paths on POSIX")
 @pytest.mark.parametrize(
     "root_dir, expected_root_uri",
     [

--- a/py_src/jupyter_lsp/tests/test_paths.py
+++ b/py_src/jupyter_lsp/tests/test_paths.py
@@ -5,7 +5,7 @@ import pytest
 
 from ..paths import normalized_uri
 
-WIN = platform.system == "Windows"
+WIN = platform.system() == "Windows"
 HOME = pathlib.Path("~").expanduser()
 
 
@@ -13,16 +13,16 @@ HOME = pathlib.Path("~").expanduser()
 @pytest.mark.parametrize(
     "root_dir, expected_root_uri",
     [
+        ["~", HOME.as_uri()],
         # probably need to try some other things
-        [str(HOME / "foo"), (HOME / "foo").as_uri()]
+        [str(HOME / "foo"), (HOME / "foo").as_uri()],
     ],
 )
 def test_normalize_paths(root_dir, expected_root_uri):  # pragma: no cover
-    """ paths we can easily test on POSIX platforms
-    """
     assert normalized_uri(root_dir) == expected_root_uri
 
 
+@pytest.mark.skipif(~WIN, reason="can't test Windows paths on POSIX")
 @pytest.mark.parametrize(
     "root_dir, expected_root_uri",
     [
@@ -32,6 +32,4 @@ def test_normalize_paths(root_dir, expected_root_uri):  # pragma: no cover
     ],
 )
 def test_normalize_windows_path_case(root_dir, expected_root_uri):  # pragma: no cover
-    """ paths we can easily test on non-windows platforms
-    """
     assert normalized_uri(root_dir) == expected_root_uri


### PR DESCRIPTION
For #91.

This is a lightweight approach which adds a (hopefully) canonical `rootUri` to `page_config`, where it probably belongs in the first place, rather than putting it on something language server specific. This simplifies a lot of behavior... we shall see (especially r on windows)!