### PR TITLE
Add message listener API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## `jupyter-lsp` (unreleased)
+
+- features
+  - adds a language server status endpoint (
+    [#81](https://github.com/krassowski/jupyterlab-lsp/pull/81)
+    )
+  - adds more descriptive information to the language server spec (
+    [#90](https://github.com/krassowski/jupyterlab-lsp/pulls/100)
+    )
+  - adds an extensible listener API (
+    [#99](https://github.com/krassowski/jupyterlab-lsp/issues/99),
+    [#100](https://github.com/krassowski/jupyterlab-lsp/pulls/100)
+    )
+
 ## `@krassowski/jupyterlab-lsp 0.6.1`
 
 - features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,14 @@ You can contribute to the project through:
     and its various distributions
     - these are great first issues, as you might not need to know any python or
       javascript
+- proposing parts of the architecture that can be [extended](./EXTENDING.md)
 - improving [documentation](#Documentation)
 - tackling Big Issues from the [future roadmap](./ROADMAP.md)
 - improving [testing](#Testing)
 - reviewing pull requests
+
+[jupyterlab-lsp]: https://github.com/krassowski/jupyterlab-lsp.git
+[code-of-conduct]: https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
 
 ## Set up the environment
 
@@ -168,9 +172,6 @@ black py_src
 >
 > - sphinx
 > - one of the sphinx/ipynb connectors
-
-[jupyterlab-lsp]: https://github.com/krassowski/jupyterlab-lsp.git
-[code-of-conduct]: https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
 
 ### Specs
 

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -20,7 +20,15 @@ as many Language Servers work out of the box as possible, consider
 Message listeners may choose to receive LSP messages immediately after being
 received from the client (e.g. `jupyterlab-lsp`) or a language server. All
 listeners of a message are scheduled concurrently, and the message is passed
-along once all processing has completed.
+along **once all listeners return** (or fail). This allows listeners to, for example,
+modify files on disk before the language server reads them.
+
+If a listener is going to perform an expensive activity that _shouldn't_ block
+delivery of a message, a non-blocking technique like
+[IOLoop.add_callback][add_callback] and/or a
+[queue](https://www.tornadoweb.org/en/stable/queues.html) should be used.
+
+[add_callback]: https://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.add_callback
 
 #### Add a Listener with `entry_points`
 

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -1,0 +1,55 @@
+# Extend jupyterlab-lsp and jupyter-lsp
+
+## jupyterlab-lsp
+
+> At present, `jupyterlab-lsp` is still in very early development, and does not
+> expose any runtime extension points. The [roadmap](./ROADMAP.md) lists several
+> potential points of extension, but will require some refactoring to achieve.
+
+## jupyter-lsp
+
+### Language Server Specs
+
+Language Server Specs can be [configured](./LANGUAGESERVERS.ms) by Jupyter users,
+or distributed by third parties as python or JSON files. Since we'd like to see
+as many Language Servers work out of the box as possible, consider
+[contributing a spec](./CONTRIBUTING.md#specs), if it works well for you!
+
+### Message Listeners
+
+Message listeners may choose to receive LSP messages immediately after being
+received from the client (e.g. `jupyterlab-lsp`) or a language server. All
+listeners of a message are scheduled concurrently, and the message is passed
+along once all processing has completed.
+
+#### Python API
+
+This listener receives _all_ messages from the client and server, and prints them
+out.
+
+```python
+from jupyter_lsp import lsp_message_listener
+
+@lsp_message_listener("all")
+async def my_listener(scope, message, languages, manager):
+    print("received a {} {} message about {}".format(
+      scope, message["method"], languages
+    ))
+```
+
+#### Listener options
+
+Fine-grained controls are available as part of the python API, which can be
+accessed as part of a `serverextension`
+
+- `scope`: one of `client`, `server` or `all`
+- `languages`: a regular expression of languages
+- `method`: a regular expression of LSP JSON-RPC method names
+
+#### Listener entry_points
+
+> TBD
+
+#### Listener traitlets
+
+> TBD

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -52,4 +52,14 @@ accessed as part of a `serverextension`
 
 #### Listener traitlets
 
-> TBD
+Like Language Servers Listeners can be added via `traitlets` configuration, e.g.
+
+```json
+{
+  "LanguageServerManager": {
+    "all_listeners": ["some_module.some_function"],
+    "client_listeners": ["some_module.some_other_function"],
+    "server_listeners": ["some_module.yet_some_function"]
+  }
+}
+```

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -24,7 +24,7 @@ along once all processing has completed.
 
 #### Add a Listener with `entry_points`
 
-Listeners can be added via `entry_points` by a package installed in the same
+Listeners can be added via [entry_points][] by a package installed in the same
 environment as `notebook`:
 
 ```toml
@@ -32,12 +32,17 @@ environment as `notebook`:
 
 [options.entry_points]
 jupyter_lsp_listener_all_v1 =
-  some-function = some.module:some_function
+  some-unique-name = some.module:some_function
 jupyter_lsp_listener_client_v1 =
-  some-other-function = some.module:some_other_function
+  some-other-unique-name = some.module:some_other_function
 jupyter_lsp_listener_server_v1 =
-  yet-another-function = some.module:yet_another_function
+  yet-another-unique-name = some.module:yet_another_function
 ```
+
+At present, the entry point names generally have no impact on functionality
+aside from logging in the event of an error on import.
+
+[entry_points]: https://packaging.python.org/specifications/entry-points/
 
 #### Add a Listener with Jupyter Configuration
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > _This project is in its early days, but you are welcome to check it out, leave feedback and/or a PR_
 
-Quick Links: **[Installation](#installation) | [Language Servers](./LANGUAGESERVERS.md) | [Updating](#updating) | [Changelog](./CHANGELOG.md) | [Roadmap](./ROADMAP.md) | [Contributing](./CONTRIBUTING.md)**
+Quick Links: **[Installation](#installation) | [Language Servers](./LANGUAGESERVERS.md) | [Updating](#updating) | [Changelog](./CHANGELOG.md) | [Roadmap](./ROADMAP.md) | [Contributing](./CONTRIBUTING.md) | [Extending](./EXTENDING.md)**
 
 ## Features
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ pr:
 
 variables:
   PYTHONUNBUFFERED: 1
+  ATEST_RETRIES: 3
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
 
   PY_JLSP_VERSION: 0.6.0b0

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   # runtime dependencies
   - python >=3.7,<3.8.0a0
   - jupyterlab >=1.1,<1.2
+  - notebook >=4.3.1
   # build dependencies
   - nodejs
   # for python language server (and development)

--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -1,7 +1,7 @@
 import { VirtualDocument } from './virtual/document';
 import { LSPConnection } from './connection';
 import { Signal } from '@phosphor/signaling';
-import { PageConfig, PathExt } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { sleep, until_ready } from './utils';
 
 export interface IDocumentConnectionData {
@@ -91,13 +91,15 @@ export class DocumentConnectionManager {
 
     const wsBase = PageConfig.getBaseUrl().replace(/^http/, 'ws');
     const rootUri = PageConfig.getOption('rootUri');
-    let socket = new WebSocket(PathExt.join(wsBase, 'lsp', language));
+    const documentUri = URLExt.join(rootUri, virtual_document.uri);
+    const serverUri = URLExt.join('ws://jupyter-lsp', language);
+    let socket = new WebSocket(URLExt.join(wsBase, 'lsp', language));
 
     let connection = new LSPConnection({
-      serverUri: PathExt.join('ws://jupyter-lsp', language),
       languageId: language,
+      serverUri,
       rootUri,
-      documentUri: PathExt.join(rootUri, virtual_document.uri),
+      documentUri,
       documentText: () => {
         // NOTE: Update is async now and this is not really used, as an alternative method
         // which is compatible with async is used.

--- a/py_src/jupyter_lsp/__init__.py
+++ b/py_src/jupyter_lsp/__init__.py
@@ -9,6 +9,9 @@ from .types import (
     LanguageServerSpec,
 )
 
+# the listener decorator
+lsp_message_listener = LanguageServerManager.register_message_listener  # noqa
+
 
 def _jupyter_server_extension_paths():
     return [{"module": "jupyter_lsp"}]

--- a/py_src/jupyter_lsp/constants.py
+++ b/py_src/jupyter_lsp/constants.py
@@ -1,5 +1,10 @@
 """ special constants used throughout jupyter_lsp
 """
 
-# the current entry_point to use for python-based spec finders
+# the current `entry_point` to use for python-based spec finders
 EP_SPEC_V1 = "jupyter_lsp_spec_v1"
+
+# the current `entry_point`s to use for python-based listeners
+EP_LISTENER_ALL_V1 = "jupyter_lsp_listener_all_v1"
+EP_LISTENER_CLIENT_V1 = "jupyter_lsp_listener_client_v1"
+EP_LISTENER_SERVER_V1 = "jupyter_lsp_listener_server_v1"

--- a/py_src/jupyter_lsp/handlers.py
+++ b/py_src/jupyter_lsp/handlers.py
@@ -30,7 +30,7 @@ class LanguageServerWebSocketHandler(WebSocketMixin, WebSocketHandler, BaseHandl
 
     async def on_message(self, message):
         self.log.debug("[{}] Handling a message".format(self.language))
-        await self.manager.on_handler_message(message, self)
+        await self.manager.on_client_message(message, self)
 
     def on_close(self):
         self.manager.unsubscribe(self)

--- a/py_src/jupyter_lsp/handlers.py
+++ b/py_src/jupyter_lsp/handlers.py
@@ -5,7 +5,6 @@ from typing import Optional, Text
 from notebook.base.handlers import IPythonHandler
 from notebook.base.zmqhandlers import WebSocketHandler, WebSocketMixin
 from notebook.utils import url_path_join as ujoin
-from tornado.ioloop import IOLoop
 
 from .manager import LanguageServerManager
 from .schema import SERVERS_RESPONSE
@@ -27,19 +26,15 @@ class LanguageServerWebSocketHandler(WebSocketMixin, WebSocketHandler, BaseHandl
     def open(self, language):
         self.language = language
         self.manager.subscribe(self)
-        self.log.debug("[{0: >16}] Opened a handler".format(self.language))
+        self.log.debug("[{}] Opened a handler".format(self.language))
 
-    def on_message(self, message):
-        def send(message):
-            self.log.debug("[{0: >16}] Handling a message".format(self.language))
-            self.manager.on_message(message, self)
-            self.log.debug("[{0: >16}] Handled a message".format(self.language))
-
-        IOLoop.current().spawn_callback(send, message)
+    async def on_message(self, message):
+        self.log.debug("[{}] Handling a message".format(self.language))
+        await self.manager.on_handler_message(message, self)
 
     def on_close(self):
         self.manager.unsubscribe(self)
-        self.log.debug("[{0: >16}] Closed a handler".format(self.language))
+        self.log.debug("[{}] Closed a handler".format(self.language))
 
 
 class LanguageServersHandler(BaseHandler):

--- a/py_src/jupyter_lsp/manager.py
+++ b/py_src/jupyter_lsp/manager.py
@@ -1,7 +1,5 @@
 """ A configurable frontend for stdio-based Language Servers
 """
-import asyncio
-import json
 from typing import Dict, Text, Tuple
 
 import pkg_resources
@@ -93,20 +91,6 @@ class LanguageServerManager(LanguageServerManagerAPI):
         if sessions:
             for session in sessions:
                 session.handlers = set([handler]) | session.handlers
-
-    async def wait_for_listeners(self, scope, message, languages) -> None:
-        listeners = self._listeners[scope] + self._listeners["all"]
-        if listeners:
-            message_dict = json.loads(message)
-
-            futures = [
-                listener(scope, message=message_dict, languages=languages, manager=self)
-                for listener in listeners
-                if listener.wants(message_dict, languages)
-            ]
-
-            if futures:
-                await asyncio.gather(*futures)
 
     async def on_client_message(self, message, handler):
         await self.wait_for_listeners("client", message, [handler.language])

--- a/py_src/jupyter_lsp/manager.py
+++ b/py_src/jupyter_lsp/manager.py
@@ -10,7 +10,12 @@ from .constants import EP_SPEC_V1
 from .schema import LANGUAGE_SERVER_SPEC_MAP
 from .session import LanguageServerSession
 from .trait_types import Schema
-from .types import KeyedLanguageServerSpecs, LanguageServerManagerAPI, SpecMaker
+from .types import (
+    KeyedLanguageServerSpecs,
+    LanguageServerManagerAPI,
+    MessageScope,
+    SpecMaker,
+)
 
 
 class LanguageServerManager(LanguageServerManagerAPI):
@@ -93,13 +98,15 @@ class LanguageServerManager(LanguageServerManagerAPI):
                 session.handlers = set([handler]) | session.handlers
 
     async def on_client_message(self, message, handler):
-        await self.wait_for_listeners("client", message, [handler.language])
+        await self.wait_for_listeners(MessageScope.CLIENT, message, [handler.language])
 
         for session in self.sessions_for_handler(handler):
             session.write(message)
 
     async def on_server_message(self, message, session):
-        await self.wait_for_listeners("server", message, session.spec["languages"])
+        await self.wait_for_listeners(
+            MessageScope.SERVER, message, session.spec["languages"]
+        )
 
         for handler in session.handlers:
             handler.write_message(message)

--- a/py_src/jupyter_lsp/session.py
+++ b/py_src/jupyter_lsp/session.py
@@ -184,5 +184,5 @@ class LanguageServerSession(LoggingConfigurable):
         """
         async for message in self.from_lsp:
             self.last_server_message_at = self.now()
-            await self.parent.on_session_message(message, self)
+            await self.parent.on_server_message(message, self)
             self.from_lsp.task_done()

--- a/py_src/jupyter_lsp/session.py
+++ b/py_src/jupyter_lsp/session.py
@@ -182,8 +182,7 @@ class LanguageServerSession(LoggingConfigurable):
         """ loop for reading messages from the queue of messages from the language
             server
         """
-        async for msg in self.from_lsp:
+        async for message in self.from_lsp:
             self.last_server_message_at = self.now()
-            for handler in self.handlers:
-                handler.write_message(msg)
+            await self.parent.on_session_message(message, self)
             self.from_lsp.task_done()

--- a/py_src/jupyter_lsp/specs/utils.py
+++ b/py_src/jupyter_lsp/specs/utils.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from typing import List, Text
 
 from ..schema import SPEC_VERSION
-from ..types import KeyedLanguageServerSpecs, LanguageServerManagerAPI
+from ..types import (
+    KeyedLanguageServerSpecs,
+    LanguageServerManagerAPI,
+    LanguageServerSpec,
+)
 
 # helper scripts for known tricky language servers
 HELPERS = Path(__file__).parent / "helpers"
@@ -16,9 +20,8 @@ class SpecBase:
     key = ""
     languages = []  # type: List[Text]
     args = []  # type: List[Text]
-    spec = {}
+    spec = {}  # type: LanguageServerSpec
 
-    @classmethod
     def __call__(
         self, mgr: LanguageServerManagerAPI
     ) -> KeyedLanguageServerSpecs:  # pragma: no cover

--- a/py_src/jupyter_lsp/tests/conftest.py
+++ b/py_src/jupyter_lsp/tests/conftest.py
@@ -88,7 +88,7 @@ def app():
 
 # mocks
 class MockWebsocketHandler(LanguageServerWebSocketHandler):
-    _messages_wrote = None
+    _messages_wrote = None  # type: Queue
 
     def __init__(self):
         pass

--- a/py_src/jupyter_lsp/tests/listener.py
+++ b/py_src/jupyter_lsp/tests/listener.py
@@ -1,0 +1,2 @@
+async def dummy_listener(scope, message, languages, manager):
+    pass

--- a/py_src/jupyter_lsp/tests/test_listener.py
+++ b/py_src/jupyter_lsp/tests/test_listener.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import pytest
+from tornado.queues import Queue
+
+
+@pytest.mark.asyncio
+async def test_listeners(handlers, jsonrpc_init_msg):
+    """ will a handler listener listen?
+    """
+    handler, ws_handler = handlers
+    manager = handler.manager
+
+    manager.initialize()
+
+    handler_listened = Queue()
+    server_listened = Queue()
+
+    @manager.register_handler_listener(language=r".*", method=r".*")
+    async def handler_listener(message, manager):
+        await handler_listened.put(message)
+
+    @manager.register_handler_listener(method=r"not-a-method")
+    async def other_handler_listener(message, manager):  # pragma: no cover
+        raise NotImplementedError("shouldn't get here")
+
+    assert len(manager._handler_listeners) == 2
+
+    @manager.register_session_listener(language=None, method=None)
+    async def session_listener(message, manager):
+        await server_listened.put(message)
+
+    @manager.register_session_listener(language=r"not-a-language")
+    async def other_session_listener(message, manager):  # pragma: no cover
+        raise NotImplementedError("shouldn't get here")
+
+    assert len(manager._session_listeners) == 2
+
+    ws_handler.open("python")
+
+    await ws_handler.on_message(jsonrpc_init_msg)
+
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(handler_listened.get(), server_listened.get()), 10
+        )
+        handler_listened.task_done()
+        server_listened.task_done()
+    finally:
+        ws_handler.on_close()
+
+    manager.unregister_handler_listener(handler_listener)
+    manager.unregister_handler_listener(other_handler_listener)
+    manager.unregister_session_listener(session_listener)
+    manager.unregister_session_listener(other_session_listener)
+
+    assert not manager._handler_listeners
+    assert not manager._session_listeners

--- a/py_src/jupyter_lsp/tests/test_listener.py
+++ b/py_src/jupyter_lsp/tests/test_listener.py
@@ -5,7 +5,7 @@ from tornado.queues import Queue
 
 
 @pytest.mark.asyncio
-async def test_listeners(handlers, jsonrpc_init_msg):
+async def test_listeners(known_language, handlers, jsonrpc_init_msg):
     """ will a handler listener listen?
     """
     handler, ws_handler = handlers
@@ -16,7 +16,7 @@ async def test_listeners(handlers, jsonrpc_init_msg):
     handler_listened = Queue()
     server_listened = Queue()
 
-    @manager.register_handler_listener(language=r".*", method=r".*")
+    @manager.register_handler_listener(language=known_language, method="initialize")
     async def handler_listener(message, manager):
         await handler_listened.put(message)
 
@@ -36,13 +36,13 @@ async def test_listeners(handlers, jsonrpc_init_msg):
 
     assert len(manager._session_listeners) == 2
 
-    ws_handler.open("python")
+    ws_handler.open(known_language)
 
     await ws_handler.on_message(jsonrpc_init_msg)
 
     try:
         await asyncio.wait_for(
-            asyncio.gather(handler_listened.get(), server_listened.get()), 10
+            asyncio.gather(handler_listened.get(), server_listened.get()), 20
         )
         handler_listened.task_done()
         server_listened.task_done()

--- a/py_src/jupyter_lsp/tests/test_session.py
+++ b/py_src/jupyter_lsp/tests/test_session.py
@@ -38,7 +38,7 @@ async def test_start_known(known_language, handlers, jsonrpc_init_msg):
 
     assert_status_set(handler, {"started"}, known_language)
 
-    ws_handler.on_message(jsonrpc_init_msg)
+    await ws_handler.on_message(jsonrpc_init_msg)
 
     try:
         await asyncio.wait_for(ws_handler._messages_wrote.get(), 20)
@@ -69,7 +69,7 @@ async def test_start_unknown(known_unknown_language, handlers, jsonrpc_init_msg)
 
     assert_status_set(handler, {"not_started"})
 
-    ws_handler.on_message(jsonrpc_init_msg)
+    await ws_handler.on_message(jsonrpc_init_msg)
     assert_status_set(handler, {"not_started"})
     ws_handler.on_close()
 

--- a/py_src/jupyter_lsp/tests/test_session.py
+++ b/py_src/jupyter_lsp/tests/test_session.py
@@ -22,7 +22,7 @@ def assert_status_set(handler, expected_statuses, language=None):
 
 @pytest.mark.asyncio
 async def test_start_known(known_language, handlers, jsonrpc_init_msg):
-    """ will a process start for a known language if a handler starts listening?
+    """ will a process start for a known language if a handler starts?
     """
     handler, ws_handler = handlers
     manager = handler.manager
@@ -56,7 +56,7 @@ async def test_start_known(known_language, handlers, jsonrpc_init_msg):
 
 @pytest.mark.asyncio
 async def test_start_unknown(known_unknown_language, handlers, jsonrpc_init_msg):
-    """ will a process not start for an unknown if a handler starts listening?
+    """ will a process not start for an unknown if a handler starts?
     """
     handler, ws_handler = handlers
     manager = handler.manager

--- a/py_src/jupyter_lsp/trait_types.py
+++ b/py_src/jupyter_lsp/trait_types.py
@@ -24,7 +24,7 @@ class Schema(traitlets.Any):
 
 
 class LoadableCallable(traitlets.TraitType):
-    """A trait which loads a callable."""
+    """A trait which (maybe) loads a callable."""
 
     info_text = "a loadable callable"
 

--- a/py_src/jupyter_lsp/trait_types.py
+++ b/py_src/jupyter_lsp/trait_types.py
@@ -1,3 +1,4 @@
+import six
 import traitlets
 
 
@@ -20,3 +21,21 @@ class Schema(traitlets.Any):
                 )
             )
         return value
+
+
+class LoadableCallable(traitlets.TraitType):
+    """A trait which loads a callable."""
+
+    info_text = "a loadable callable"
+
+    def validate(self, obj, value):
+        if isinstance(value, str):
+            try:
+                value = traitlets.import_item(value)
+            except ModuleNotFoundError:
+                value = None
+
+        if six.callable(value):
+            return value
+        else:
+            self.error(obj, value)

--- a/py_src/jupyter_lsp/trait_types.py
+++ b/py_src/jupyter_lsp/trait_types.py
@@ -32,8 +32,8 @@ class LoadableCallable(traitlets.TraitType):
         if isinstance(value, str):
             try:
                 value = traitlets.import_item(value)
-            except ModuleNotFoundError:
-                value = None
+            except Exception:
+                self.error(obj, value)
 
         if six.callable(value):
             return value

--- a/py_src/jupyter_lsp/types.py
+++ b/py_src/jupyter_lsp/types.py
@@ -113,6 +113,7 @@ class HasListeners:
         """
 
         def inner(listener: "HandlerListenerCallback") -> "HandlerListenerCallback":
+            cls.unregister_message_listener(listener)
             cls._listeners[scope].append(
                 MessageListener(listener=listener, language=language, method=method)
             )

--- a/py_src/jupyter_lsp/types.py
+++ b/py_src/jupyter_lsp/types.py
@@ -112,7 +112,7 @@ class HasListeners:
         """ register a listener for language server protocol messages
         """
 
-        def inner(listener: HandlerListenerCallback) -> HandlerListenerCallback:
+        def inner(listener: "HandlerListenerCallback") -> "HandlerListenerCallback":
             cls._listeners[scope].append(
                 MessageListener(listener=listener, language=language, method=method)
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # what is needed to run jupyter_lsp (but no servers or lab)
-notebook
+notebook >=4.3.1
 setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,3 +72,39 @@ multi_line_output = 3
 [pycodestyle]
 ignore = E203,W503
 max-line-length = 88
+
+[mypy-traitlets.*]
+ignore_missing_imports = True
+
+[mypy-notebook]
+ignore_missing_imports = True
+
+[mypy-jupyterlab.*]
+ignore_missing_imports = True
+
+[mypy-notebook.*]
+ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-setuptools]
+ignore_missing_imports = True
+
+[mypy-ctypes.*]
+ignore_missing_imports = True
+
+[mypy-robot.*]
+ignore_missing_imports = True
+
+[mypy-jsonschema]
+ignore_missing_imports = True
+
+[mypy-ruamel.*]
+ignore_missing_imports = True
+
+[mypy-ruamel_yaml]
+ignore_missing_imports = True
+
+[mypy-jupyter_lsp.non_blocking]
+ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ include_package_data = True
 zip_safe = False
 
 install_requires =
-    notebook
-    entrypoints
+    notebook >=4.3.1
+    setuptools
 
 [options.packages.find]
 where =


### PR DESCRIPTION
This adds a listener API, mostly following #99.

- [x] decorators for (un)listening to session and handler messages
- [x] tests
- [x] configurablity?
  - [x] traitlets?
  - [x] entry_point?
- [x] docs
- [x] changelog

Definitely need to chew on this a bit more, but wanted to get it out there once it (apparently) started working. ~~For example, there's a lot of duplicated code for the two types of listeners... there could be a single decorator with a `sender="session"`, with a default of listening to _all_ messages, which would have its advantages, I suppose. I _don't_ anticipate actually adding any listeners on this PR, or at least not any that would run by default.~~

Fixes #102.