### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,60 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!--
+Welcome! Before creating a new issue:
+* Search for relevant issues
+* Follow the issue reporting guidelines:
+https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
+-->
+
+## Description
+
+<!--Describe the bug clearly and concisely. Include screenshots if possible-->
+
+## Reproduce
+
+<!--Describe step-by-step instructions to reproduce the behavior-->
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error '...'
+
+<!--Describe how you diagnosed the issue. See the guidelines at
+ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html -->
+
+## Expected behavior
+
+<!--Describe what you expected to happen-->
+
+## Context
+
+<!--Complete the following for context, and add any other relevant context-->
+
+- Operating System and version:
+- Browser and version:
+- JupyterLab version:
+- `jupyter-lsp` version:
+- `@krassowski/jupyterlab-lsp` version:
+
+<details><summary>Troubleshoot Output</summary>
+<pre>
+Paste the output from running `jupyter troubleshoot` from the command line here.
+You may want to sanitize the paths in the output.
+</pre>
+</details>
+
+<details><summary>Command Line Output</summary>
+<pre>
+Paste the output from your command line running `jupyter lab` here, use `--debug` if possible.
+</pre>
+</details>
+
+<details><summary>Browser Output</summary>
+<pre>
+Paste the output from your browser Javascript console here.
+</pre>
+</details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,23 @@
+---
+name: Documentation request
+about: Ask for clarification in jupyter(lab)-lsp documentation
+---
+
+<!--
+Welcome! Before creating a new issue:
+* Search for relevant issues
+* Follow the issue reporting guidelines:
+https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
+-->
+
+## What I am trying to do...
+
+<!-- Describe what you are trying to do, and how the current docs aren't helping you achieve it-->
+
+## How I would like to learn how to do it...
+
+<!--Describe what would help you understand what you are trying to do, e.g. tutorials, code comments, screencasts, etc.-->
+
+## How the project might keep the docs accurate...
+
+<!--Describe how this documentation can be kept up-to-date: testing, link checking, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,10 +12,13 @@ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
 -->
 
 ## Elevator Pitch
+
 <!-- In no more than three sentences, what would you like to see implemented? -->
 
 ## Motivation
+
 <!-- Why do you want this feature? -->
 
 ## Design Ideas
+
 <!-- Share any kind of design ideas (e.g. ASCII art, links, screenshots) that might help us understand -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Request a Future Roadmap item
+about: Help us build future features
+---
+
+<!--
+Welcome! Before creating a new issue:
+* Search for relevant issues
+* Look at ROADMAP.md to make sure we don't already want the same thing
+* Follow the issue reporting guidelines:
+https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
+-->
+
+## Elevator Pitch
+<!-- In no more than three sentences, what would you like to see implemented? -->
+
+## Motivation
+<!-- Why do you want this feature? -->
+
+## Design Ideas
+<!-- Share any kind of design ideas (e.g. ASCII art, links, screenshots) that might help us understand -->

--- a/.github/ISSUE_TEMPLATE/intent_to_implement.md
+++ b/.github/ISSUE_TEMPLATE/intent_to_implement.md
@@ -1,0 +1,36 @@
+---
+name: Intent to Implement
+about: Announce that you're going to do some work
+---
+
+<!--
+Welcome! Before creating a new issue:
+* Search for relevant issues
+* Look at ROADMAP.md to make sure we don't already want the same thing
+* Follow the issue reporting guidelines:
+https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
+-->
+
+
+## What are you trying to do?
+<!--Articulate your objectives using absolutely no jargon.-->
+
+## How is it done today, and what are the limits of current practice?
+<!--Does another Language Server client already implement this feature?-->
+
+## What is new in your approach and why do you think it will be successful?
+
+## Who cares? If you are successful, what difference will it make?
+
+## What are the risks?
+
+## How much will it cost?
+
+<!-- Development time aside, what will the review time, CI resources, and future maintenance burden be? -->
+
+## How long will it take?
+
+## What are the mid-term and final “exams” to check for success?
+
+
+<!-- adapted from "The Heilmeier Catechism": https://www.darpa.mil/work-with-us/heilmeier-catechism -->

--- a/.github/ISSUE_TEMPLATE/intent_to_implement.md
+++ b/.github/ISSUE_TEMPLATE/intent_to_implement.md
@@ -11,11 +11,12 @@ Welcome! Before creating a new issue:
 https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
 -->
 
-
 ## What are you trying to do?
+
 <!--Articulate your objectives using absolutely no jargon.-->
 
 ## How is it done today, and what are the limits of current practice?
+
 <!--Does another Language Server client already implement this feature?-->
 
 ## What is new in your approach and why do you think it will be successful?
@@ -31,6 +32,5 @@ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
 ## How long will it take?
 
 ## What are the mid-term and final “exams” to check for success?
-
 
 <!-- adapted from "The Heilmeier Catechism": https://www.darpa.mil/work-with-us/heilmeier-catechism -->

--- a/.github/ISSUE_TEMPLATE/language_server_builtin.md
+++ b/.github/ISSUE_TEMPLATE/language_server_builtin.md
@@ -1,0 +1,64 @@
+---
+name: Auto-detected Language Server Support
+about: Help us improve the existing auto-detected language servers
+---
+
+<!--
+Welcome! Before creating a new issue:
+* Search for relevant issues
+* Ensure your language server is supported in LANGUAGESERVERS.md
+* Follow the issue reporting guidelines:
+https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
+-->
+
+## Description
+
+<!--Describe the bug clearly and concisely. Clearly indicate the language -->
+
+## Reproduce
+
+<!--Describe step-by-step instructions to reproduce the behavior-->
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error '...'
+
+<!--Describe how you diagnosed the issue. See the guidelines at
+ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html -->
+
+## Expected behavior
+
+<!--Describe what you expected to happen-->
+
+## Context
+
+<!--Complete the following for context, and add any other relevant context-->
+
+- Operating System and version:
+- Browser and version:
+- JupyterLab version:
+- `jupyter-lsp` version:
+- `@krassowski/jupyterlab-lsp` version:
+- Language Server:
+- Language Server version:
+- Language Server installed with: <!-- e.g. system package manager, app package manager -->
+
+<details><summary>Troubleshoot Output</summary>
+<pre>
+Paste the output from running `jupyter troubleshoot` from the command line here.
+You may want to sanitize the paths in the output.
+</pre>
+</details>
+
+<details><summary>Command Line Output</summary>
+<pre>
+Paste the output from your command line running `jupyter lab` here, use `--debug` if possible.
+</pre>
+</details>
+
+<details><summary>Browser Output</summary>
+<pre>
+Paste the output from your browser Javascript console here.
+</pre>
+</details>

--- a/.github/ISSUE_TEMPLATE/language_server_byo.md
+++ b/.github/ISSUE_TEMPLATE/language_server_byo.md
@@ -44,6 +44,7 @@ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
 - Language Server version:
 - Language Server installed with: <!-- e.g. system package manager, app package manager -->
 - Language Server Spec
+
 ```python
 # jupyter_notebook_config.json
 {

--- a/.github/ISSUE_TEMPLATE/language_server_byo.md
+++ b/.github/ISSUE_TEMPLATE/language_server_byo.md
@@ -1,0 +1,78 @@
+---
+name: Request Bring-your-own Language Server Support
+about: Help us improve language servers we don't know about
+---
+
+<!--
+Welcome! Before creating a new issue:
+* Search for relevant issues
+* Ensure your language server is not supported in LANGUAGESERVERS.md
+* Follow the issue reporting guidelines:
+https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
+-->
+
+## Description
+
+<!--Describe the bug clearly and concisely. Clearly indicate the language -->
+
+## Reproduce
+
+<!--Describe step-by-step instructions to reproduce the behavior-->
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error '...'
+
+<!--Describe how you diagnosed the issue. See the guidelines at
+ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html -->
+
+## Expected behavior
+
+<!--Describe what you expected to happen-->
+
+## Context
+
+<!--Complete the following for context, and add any other relevant context-->
+
+- Operating System and version:
+- Browser and version:
+- JupyterLab version:
+- `jupyter-lsp` version:
+- `@krassowski/jupyterlab-lsp` version:
+- Language Server:
+- Language Server version:
+- Language Server installed with: <!-- e.g. system package manager, app package manager -->
+- Language Server Spec
+```python
+# jupyter_notebook_config.json
+{
+  "LanguageServerManager": {
+    "language_servers": {
+      "my-language-server": {
+        "languages": ["my-language"],
+        "argv": ["echo"]
+      }
+    }
+  }
+}
+```
+
+<details><summary>Troubleshoot Output</summary>
+<pre>
+Paste the output from running `jupyter troubleshoot` from the command line here.
+You may want to sanitize the paths in the output.
+</pre>
+</details>
+
+<details><summary>Command Line Output</summary>
+<pre>
+Paste the output from your command line running `jupyter lab` here, use `--debug` if possible.
+</pre>
+</details>
+
+<details><summary>Browser Output</summary>
+<pre>
+Paste the output from your browser Javascript console here.
+</pre>
+</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,8 +25,8 @@ https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
 
 <!-- Describe any backwards-incompatible changes to public APIs. -->
 
-
 ## Chores
+
 - [ ] linted
 - [ ] tested
 - [ ] documented

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!--
+Thanks for contributing to jupyterlab-lsp!
+Please fill out the following items to submit a pull request.
+See the contributing guidelines for more information:
+https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
+-->
+
+## References
+
+<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
+
+<!-- Note any other pull requests that address this issue and how this pull request is different. -->
+
+## Code changes
+
+<!-- Describe the code changes and how they address the issue. -->
+
+## User-facing changes
+
+<!-- Describe any visual or user interaction changes and how they address the issue. -->
+
+<!-- For visual changes, include before and after screenshots here. -->
+
+## Backwards-incompatible changes
+
+<!-- Describe any backwards-incompatible changes to public APIs. -->
+
+
+## Chores
+- [ ] linted
+- [ ] tested
+- [ ] documented
+- [ ] changelog entry


### PR DESCRIPTION
Just to get the ball rolling... 

## References
#96

## Code changes

N/A

## User-facing changes

Contributors/end users will see a little more UI when making PRs/Issues: https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates

## Backwards-incompatible changes

N/A

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry