### PR TITLE
Capture listener exceptions, avoid expecting method

### DIFF
--- a/py_src/jupyter_lsp/types.py
+++ b/py_src/jupyter_lsp/types.py
@@ -20,7 +20,7 @@ from typing import (
 )
 
 from notebook.transutils import _
-from traitlets import List as List_, Unicode, default
+from traitlets import Instance, List as List_, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 LanguageServerSpec = Dict[Text, Any]
@@ -86,15 +86,31 @@ class MessageListener(object):
         languages: List[Text],
         manager: "HasListeners",
     ) -> None:
-        """ actually dispatch the message to the listener
+        """ actually dispatch the message to the listener and capture any errors
         """
-        await self.listener(
-            scope=scope, message=message, languages=languages, manager=manager
-        )
+        try:
+            await self.listener(
+                scope=scope, message=message, languages=languages, manager=manager
+            )
+        except Exception:  # pragma: no cover
+            manager.log.warn(
+                "[lsp] error in listener %s for message %s",
+                self.listener,
+                message,
+                exc_info=True,
+            )
 
     def wants(self, message: LanguageServerMessage, languages: List[Text]):
-        if self.method and re.match(self.method, message["method"]) is None:
+        """ whether this listener wants a particular message
+
+            `method` is currently the only message content descriminator, but not
+            all messages will have a `method`
+        """
+        method = message.get("method")
+
+        if method and self.method and re.match(self.method, method) is None:
             return False
+
         return self.language is None or any(
             [re.match(self.language, lang) is not None for lang in languages]
         )
@@ -104,6 +120,8 @@ class HasListeners:
     _listeners = {
         str(scope.value): [] for scope in MessageScope
     }  # type: Dict[Text, List[MessageListener]]
+
+    log = Instance("logging.Logger")
 
     @classmethod
     def register_message_listener(

--- a/py_src/jupyter_lsp/types.py
+++ b/py_src/jupyter_lsp/types.py
@@ -106,10 +106,11 @@ class MessageListener(object):
             `method` is currently the only message content descriminator, but not
             all messages will have a `method`
         """
-        method = message.get("method")
+        if self.method:
+            method = message.get("method")
 
-        if method and self.method and re.match(self.method, method) is None:
-            return False
+            if method is None or re.match(self.method, method) is None:
+                return False
 
         return self.language is None or any(
             [re.match(self.language, lang) is not None for lang in languages]


### PR DESCRIPTION
## References

- #111 

## Code changes

Wraps the user-provided listener call in a try/catch block with some logging (message content, traceback).

## User-facing changes

Failing listeners should not break delivery of messages to client.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [ ] changelog entry
