### PR TITLE
Prevent wrapping of server headers and the statusbar item

### DIFF
--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/statusbar.tsx
@@ -235,6 +235,7 @@ export class LSPStatus extends VDomRenderer<LSPStatus.Model> {
     super();
     this.model = new LSPStatus.Model();
     this.addClass(interactiveItem);
+    this.addClass('lsp-statusbar-item');
     this.title.caption = 'LSP status';
   }
 

--- a/packages/jupyterlab-lsp/style/statusbar.css
+++ b/packages/jupyterlab-lsp/style/statusbar.css
@@ -40,6 +40,7 @@ h5 .lsp-language-server-name {
 .lsp-servers-menu h5 {
   font-weight: normal;
   font-size: 100%;
+  white-space: nowrap;
 }
 
 .lsp-servers-lists {
@@ -106,4 +107,9 @@ h5 {
 
 .lsp-collapsible-list.lsp-collapsed div {
   display: none;
+}
+
+.lsp-statusbar-item {
+  overflow: hidden;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## References

Mentioned in #115 

## Code changes

None

## User-facing changes

Before:
![Screenshot from 2019-12-15 13-36-25](https://user-images.githubusercontent.com/5832902/70863445-1f329c80-1f40-11ea-8cf3-55af4631feba.png)

After:
![Screenshot from 2019-12-15 13-37-29](https://user-images.githubusercontent.com/5832902/70863446-235eba00-1f40-11ea-89c5-43b1df5329f4.png)


Before:
![Screenshot from 2019-12-15 13-35-55](https://user-images.githubusercontent.com/5832902/70863449-278ad780-1f40-11ea-98d5-5b86b6ef27da.png)

After:
![Screenshot from 2019-12-15 13-34-56](https://user-images.githubusercontent.com/5832902/70863450-2ce82200-1f40-11ea-8bcf-8ba60006dca1.png)


## Backwards-incompatible changes

None