### PR TITLE
Implement a UX workaround for rope/pyls rename issue

### DIFF
--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
@@ -34,7 +34,7 @@ export class Rename extends CodeMirrorLSPFeature {
             status = `Rename failed: ${error}`;
           }
 
-          rename_feature.status_message.set(status, 5 * 1000);
+          rename_feature.status_message.set(status, 7.5 * 1000);
         };
 
         InputDialog.getText({

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
@@ -86,8 +86,8 @@ export class Rename extends CodeMirrorLSPFeature {
 }
 
 /**
- * In #115 a with rename for Python (when using pyls) was identified:
- * it was failing with an obscure message when the source code could
+ * In #115 an issue with rename for Python (when using pyls) was identified:
+ * rename was failing with an obscure message when the source code could
  * not be parsed correctly by rope (due to a user's syntax error).
  *
  * This function detects such a condition using diagnostics feature

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
@@ -5,16 +5,36 @@ import {
   IFeatureCommand
 } from '../feature';
 import { InputDialog } from '@jupyterlab/apputils';
+import { Diagnostics } from './diagnostics';
+import { VirtualEditor } from '../../../virtual/editor';
+import { VirtualEditorForNotebook } from '../../../virtual/editors/notebook';
 
 export class Rename extends CodeMirrorLSPFeature {
   static commands: Array<IFeatureCommand> = [
     {
       id: 'rename-symbol',
-      execute: ({ connection, virtual_position, document, features }) => {
+      execute: ({
+        editor,
+        connection,
+        virtual_position,
+        document,
+        features
+      }) => {
         let old_value = document.getTokenAt(virtual_position).string;
         let handle_failure = (error: any) => {
-          let feature = features.get('Rename') as Rename;
-          feature.status_message.set(`Rename failed: ${error}`, 5 * 1000);
+          let rename_feature = features.get('Rename') as Rename;
+          let diagnostics_feature = features.get('Diagnostics') as Diagnostics;
+
+          let status = ux_workaround_for_rope_limitation(
+            error,
+            diagnostics_feature,
+            editor
+          );
+          if (!status) {
+            status = `Rename failed: ${error}`;
+          }
+
+          rename_feature.status_message.set(status, 5 * 1000);
         };
 
         InputDialog.getText({
@@ -63,4 +83,59 @@ export class Rename extends CodeMirrorLSPFeature {
       })
       .catch(console.warn);
   }
+}
+
+/**
+ * In #115 a with rename for Python (when using pyls) was identified:
+ * it was failing with an obscure message when the source code could
+ * not be parsed correctly by rope (due to a user's syntax error).
+ *
+ * This function detects such a condition using diagnostics feature
+ * and provides a nice error message to the user.
+ */
+function ux_workaround_for_rope_limitation(
+  error: any,
+  diagnostics_feature: Diagnostics,
+  editor: VirtualEditor
+): string {
+  let has_index_error = false;
+  try {
+    has_index_error = error.message.includes('IndexError');
+  } catch (e) {
+    return null;
+  }
+  if (!has_index_error) {
+    return null;
+  }
+  let dire_python_errors = (diagnostics_feature.diagnostics_db || []).filter(
+    diagnostic =>
+      diagnostic.diagnostic.message.includes('invalid syntax') ||
+      diagnostic.diagnostic.message.includes('SyntaxError') ||
+      diagnostic.diagnostic.message.includes('IndentationError')
+  );
+
+  if (dire_python_errors.length === 0) {
+    return null;
+  }
+
+  let dire_errors = [
+    ...new Set(
+      dire_python_errors.map(diagnostic => {
+        let message = diagnostic.diagnostic.message;
+        let start = diagnostic.range.start;
+        if (editor.has_cells) {
+          let notebook_editor = editor as VirtualEditorForNotebook;
+          let { cell_id } = notebook_editor.find_cell_by_editor(
+            diagnostic.editor
+          );
+          let cell_nr = cell_id + 1;
+          // TODO: should we show "code cell" numbers, or just cell number?
+          return `${message} in cell ${cell_nr} at line ${start.line}`;
+        } else {
+          return `${message} at line ${start.line}`;
+        }
+      })
+    )
+  ].join(', ');
+  return `Syntax error(s) prevent rename: ${dire_errors}`;
 }

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
@@ -390,12 +390,17 @@ export abstract class JupyterLabWidgetAdapter
   get_context_from_context_menu(): ICommandContext {
     let root_position = this.get_position_from_context_menu();
     let document = this.virtual_editor.document_at_root_position(root_position);
-    let connection = this.connection_manager.connections.get(document.id_path);
     let virtual_position = this.virtual_editor.root_position_to_virtual_position(
       root_position
     );
-    let features = this.get_features(document);
-    return { document, connection, virtual_position, root_position, features };
+    return {
+      document,
+      connection: this.connection_manager.connections.get(document.id_path),
+      virtual_position,
+      root_position,
+      features: this.get_features(document),
+      editor: this.virtual_editor
+    };
   }
 
   public create_tooltip(

--- a/packages/jupyterlab-lsp/src/command_manager.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.ts
@@ -13,6 +13,7 @@ import { INotebookTracker } from '@jupyterlab/notebook';
 import { VirtualDocument } from './virtual/document';
 import { LSPConnection } from './connection';
 import { IRootPosition, IVirtualPosition } from './positioning';
+import { VirtualEditor } from './virtual/editor';
 
 export const file_editor_adapters: Map<string, FileEditorAdapter> = new Map();
 export const notebook_adapters: Map<string, NotebookAdapter> = new Map();
@@ -158,4 +159,5 @@ export interface ICommandContext {
   virtual_position: IVirtualPosition;
   root_position: IRootPosition;
   features: Map<string, ILSPFeature>;
+  editor: VirtualEditor;
 }

--- a/packages/jupyterlab-lsp/src/virtual/editors/notebook.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editors/notebook.ts
@@ -38,10 +38,6 @@ class DocDispatcher implements CodeMirror.Doc {
       );
   }
 
-  // getValue(seperator?: string): string {
-  //  return this.virtual_editor.getValue();
-  // }
-
   getCursor(start?: string): CodeMirror.Position {
     let cell = this.virtual_editor.notebook.activeCell;
     let active_editor = cell.editor as CodeMirrorEditor;
@@ -358,6 +354,26 @@ export class VirtualEditorForNotebook extends VirtualEditor {
           callback(cm_editor);
         }
       });
+    }
+  }
+
+  /**
+   * Find a cell in notebook which uses given CodeMirror editor.
+   * This function is O(n) - when looking up many cells
+   * using a hashmap based approach may be more efficient.
+   * @param cm_editor
+   */
+  find_cell_by_editor(cm_editor: CodeMirror.Editor) {
+    let cells = this.notebook.widgets;
+    for (let i = 0; i < cells.length; i++) {
+      let cell = cells[i];
+      let cell_editor = (cell.editor as CodeMirrorEditor).editor;
+      if (cell_editor === cm_editor) {
+        return {
+          cell_id: i,
+          cell: cell
+        };
+      }
     }
   }
 }


### PR DESCRIPTION
Implement a UX workaround for rope/pyls rename issue for the case of syntax errors in the source code.

In #115 an issue with rename for Python (when using pyls) was identified:
rename was failing with an obscure message when the source code could not be parsed correctly by rope (due to a user's syntax error).

This workaround detects such a condition using diagnostics feature provides a nice error message to the user (UX first).

## References

#115

## Code changes

`ICommandContext` now includes `VirtualEditor`. `Diagnostics` feature got a new, public database of diagnostics (`diagnostics_db: IEditorDiagnostic[]`) which will be also used to implement the diagnostics Panel widget (#42).

## User-facing changes

![Screenshot from 2020-01-04 22-02-53](https://user-images.githubusercontent.com/5832902/71772261-7674cd00-2f40-11ea-8043-7b1b3542a278.png)

Note: the error is in the 4th cell (1-based indexing) because above the code cells there are two markdown cells; we could change the code to display the ordinal number for code cells only (but not sure how it would work in future if we decide to analyze markdown cells too).

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
