### PR TITLE
Diagnostics panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - add 'rename' function for notebooks, using shadow filesystem (
   [#115](https://github.com/krassowski/jupyterlab-lsp/pull/115)
   )
+- add a widget panel with diagnostics (inspections), allowing to
+  sort and explore diagnostics, and to go-to the respective location
+  in code (on click); accessible from the context menu (
+  [#129](https://github.com/krassowski/jupyterlab-lsp/pull/129)
+  )
 
 ## `lsp-ws-connection` (unreleased)
 

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/feature.spec.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/feature.spec.ts
@@ -226,8 +226,8 @@ describe('Feature', () => {
         environment.dispose();
       });
 
-      function synchronizeContent() {
-        synchronize_content(environment, adapter);
+      async function synchronizeContent() {
+        await synchronize_content(environment, adapter);
       }
 
       it('applies edit across cells', async () => {

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/feature.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/feature.ts
@@ -112,7 +112,7 @@ export class CodeMirrorLSPFeature implements ILSPFeature {
   public is_registered: boolean;
   protected readonly editor_handlers: Map<string, CodeMirrorHandler>;
   protected readonly connection_handlers: Map<string, any>;
-  protected readonly wrapper_handlers: Map<string, any>;
+  protected readonly wrapper_handlers: Map<keyof HTMLElementEventMap, any>;
   protected wrapper: HTMLElement;
 
   constructor(

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.spec.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.spec.ts
@@ -1,19 +1,29 @@
 import { expect } from 'chai';
 import { TextMarker } from 'codemirror';
-import { Diagnostics } from './diagnostics';
-import { FileEditorFeatureTestEnvironment } from '../testutils';
+import { Diagnostics, diagnostics_panel } from './diagnostics';
+import {
+  code_cell,
+  FileEditorFeatureTestEnvironment,
+  NotebookFeatureTestEnvironment,
+  set_notebook_content,
+  showAllCells
+} from '../testutils';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 
 describe('Diagnostics', () => {
-  let env: FileEditorFeatureTestEnvironment;
+  let feature: Diagnostics;
 
-  beforeEach(() => (env = new FileEditorFeatureTestEnvironment()));
-  afterEach(() => env.dispose());
+  describe('FileEditor integration', () => {
+    let env: FileEditorFeatureTestEnvironment;
 
-  describe('Works with VirtualFileEditor', () => {
-    let feature: Diagnostics;
-
-    beforeEach(() => (feature = env.init_feature(Diagnostics)));
-    afterEach(() => env.dispose_feature(feature));
+    beforeEach(() => {
+      env = new FileEditorFeatureTestEnvironment();
+      feature = env.init_feature(Diagnostics);
+    });
+    afterEach(() => {
+      env.dispose();
+      env.dispose_feature(feature);
+    });
 
     it('calls parent register()', () => {
       feature.register();
@@ -30,7 +40,7 @@ describe('Diagnostics', () => {
       expect(markers.length).to.equal(0);
 
       feature.handleDiagnostic({
-        uri: 'file://foo/dummy.py',
+        uri: env.path(),
         diagnostics: [
           {
             range: {
@@ -44,6 +54,113 @@ describe('Diagnostics', () => {
 
       let marks = env.ce_editor.editor.getDoc().getAllMarks();
       expect(marks.length).to.equal(1);
+    });
+  });
+
+  describe('Notebook integration', () => {
+    let env: NotebookFeatureTestEnvironment;
+
+    beforeEach(() => {
+      env = new NotebookFeatureTestEnvironment();
+      feature = env.init_feature(Diagnostics);
+    });
+    afterEach(() => {
+      env.dispose();
+      env.dispose_feature(feature);
+    });
+
+    it('renders inspections across cells', async () => {
+      set_notebook_content(env.notebook, [
+        code_cell(['x =1\n', 'test']),
+        code_cell(['    '])
+      ]);
+      showAllCells(env.notebook);
+      await env.virtual_editor.update_documents();
+
+      let document = env.virtual_editor.virtual_document;
+      let uri = env.virtual_editor.virtual_document.uri;
+
+      feature.handleDiagnostic({
+        uri: uri,
+        diagnostics: [
+          {
+            source: 'pyflakes',
+            range: {
+              start: { line: 1, character: 0 },
+              end: { line: 1, character: 5 }
+            },
+            message: "undefined name 'test'",
+            severity: 1
+          },
+          {
+            source: 'pycodestyle',
+            range: {
+              start: { line: 0, character: 3 },
+              end: { line: 0, character: 5 }
+            },
+            message: 'E225 missing whitespace around operator',
+            code: 'E225',
+            severity: 2
+          },
+          {
+            source: 'pycodestyle',
+            range: {
+              start: { line: 4, character: 0 },
+              end: { line: 4, character: 5 }
+            },
+            message: 'W391 blank line at end of file',
+            code: 'W391',
+            severity: 2
+          },
+          {
+            source: 'pycodestyle',
+            range: {
+              start: { line: 4, character: 0 },
+              end: { line: 4, character: 5 }
+            },
+            message: 'W293 blank line contains whitespace',
+            code: 'W293',
+            severity: 2
+          },
+          {
+            source: 'mypy',
+            range: {
+              start: { line: 1, character: 0 },
+              end: { line: 1, character: 4 }
+            },
+            message: "Name 'test' is not defined",
+            severity: 1
+          }
+        ]
+      });
+
+      let cm_editors = env.virtual_editor.notebook.widgets.map(
+        cell => (cell.editor as CodeMirrorEditor).editor
+      );
+      let marks_cell_1 = cm_editors[0].getDoc().getAllMarks();
+      // test from mypy, test from pyflakes, whitespace around operator from pycodestyle
+      expect(marks_cell_1.length).to.equal(3);
+
+      // W391 and W293 should get merged into a single diagnostic (same range)
+      let marks_cell_2 = cm_editors[1].getDoc().getAllMarks();
+      expect(marks_cell_2.length).to.equal(1);
+
+      let mark_cell_2 = marks_cell_2[0];
+      let merged_mark_title = (mark_cell_2 as any).title;
+      expect(merged_mark_title).to.contain('W391');
+      expect(merged_mark_title).to.contain('W293');
+      // should be separated by new line
+      expect(merged_mark_title).to.contain('\n');
+
+      expect(feature.diagnostics_db.size).to.equal(1);
+      expect(feature.diagnostics_db.get(document).length).to.equal(5);
+
+      feature.switchDiagnosticsPanelSource();
+      diagnostics_panel.widget.content.update();
+      // the panel should contain all 5 diagnostics
+      let db = diagnostics_panel.content.model.diagnostics;
+      expect(db.size).to.equal(1);
+      expect(db.get(document).length).to.equal(5);
     });
   });
 });

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+import * as CodeMirror from 'codemirror';
+import { IEditorPosition } from '../../../positioning';
+import { VirtualEditor } from '../../../virtual/editor';
+import { VirtualEditorForNotebook } from '../../../virtual/editors/notebook';
+import { VirtualDocument } from '../../../virtual/document';
+
+import '../../../../style/diagnostics_listing.css';
+import { Cell } from '@jupyterlab/cells';
+import { diagnosticSeverityNames } from '../../../lsp';
+
+/**
+ * Diagnostic which is localized at a specific editor (cell) within a notebook
+ * (if used in the context of a FileEditor, then there is just a single editor)
+ */
+export interface IEditorDiagnostic {
+  diagnostic: lsProtocol.Diagnostic;
+  editor: CodeMirror.Editor;
+  range: {
+    start: IEditorPosition;
+    end: IEditorPosition;
+  };
+}
+
+export class DiagnosticsDatabase extends Map<
+  VirtualDocument,
+  IEditorDiagnostic[]
+> {
+  get all(): Array<IEditorDiagnostic> {
+    return [].concat.apply([], this.values());
+  }
+}
+
+function focus_on(node: HTMLElement) {
+  if (!node) {
+    return;
+  }
+  node.scrollIntoView();
+  node.focus();
+}
+
+function DocumentLocator(props: {
+  document: VirtualDocument;
+  editor: VirtualEditor;
+}) {
+  let { document, editor } = props;
+  let ancestry = document.ancestry;
+  let target_cell: Cell = null;
+  let breadcrumbs: any = ancestry.map(document => {
+    if (!document.parent) {
+      let path = document.path;
+      if (
+        !editor.has_lsp_supported_file &&
+        path.endsWith(document.file_extension)
+      ) {
+        path = path.slice(0, -document.file_extension.length - 1);
+      }
+      return <span key={document.uri}>{path}</span>;
+    }
+    if (!document.virtual_lines.size) {
+      return <span key={document.uri}>Empty document</span>;
+    }
+    try {
+      if (editor.has_cells) {
+        let first_line = document.virtual_lines.get(0);
+        let last_line = document.virtual_lines.get(
+          document.last_virtual_line - 1
+        );
+        let notebook_editor = editor as VirtualEditorForNotebook;
+        let { cell_id: first_cell, cell } = notebook_editor.find_cell_by_editor(
+          first_line.editor
+        );
+        let { cell_id: last_cell } = notebook_editor.find_cell_by_editor(
+          last_line.editor
+        );
+        target_cell = cell;
+
+        let cell_locator =
+          first_cell === last_cell
+            ? `cell ${first_cell + 1}`
+            : `cells: ${first_cell + 1}-${last_cell + 1}`;
+
+        return (
+          <span key={document.uri}>
+            {document.language} ({cell_locator})
+          </span>
+        );
+      }
+    } catch (e) {
+      console.warn('LSP: could not display document cell location', e);
+    }
+    return <span key={document.uri}>{document.language}</span>;
+  });
+  return (
+    <div
+      className={'lsp-document-locator'}
+      onClick={() => focus_on(target_cell ? target_cell.node : null)}
+    >
+      {breadcrumbs}
+    </div>
+  );
+}
+
+interface IDiagnosticsRow {
+  data: IEditorDiagnostic;
+  key: string;
+  document: VirtualDocument;
+  cell_nr?: number;
+}
+
+const sorters: Record<
+  string,
+  (a: IDiagnosticsRow, b: IDiagnosticsRow) => number
+> = {
+  'Virtual Document': (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return a.document.id_path.localeCompare(b.document.id_path);
+  },
+  Message: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return a.data.diagnostic.message.localeCompare(b.data.diagnostic.message);
+  },
+  Source: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return a.data.diagnostic.source.localeCompare(b.data.diagnostic.source);
+  },
+  Code: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return (a.data.diagnostic.code + '').localeCompare(
+      b.data.diagnostic.source + ''
+    );
+  },
+  Severity: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return a.data.diagnostic.severity > b.data.diagnostic.severity ? 1 : -1;
+  },
+  Line: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return a.data.range.start.line > b.data.range.start.line ? 1 : -1;
+  },
+  Ch: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return a.data.range.start.ch > b.data.range.start.ch ? 1 : -1;
+  },
+  Cell: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
+    return a.cell_nr > b.cell_nr ? 1 : -1;
+  }
+};
+
+export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
+  sort_key = 'Severity';
+  sort_direction = 1;
+
+  constructor(model: DiagnosticsListing.Model) {
+    super();
+    this.model = model;
+  }
+
+  sort(key: string) {
+    if (key === this.sort_key) {
+      this.sort_direction = this.sort_direction * -1;
+    } else {
+      this.sort_key = key;
+      this.sort_direction = 1;
+    }
+    this.update();
+  }
+
+  render() {
+    let diagnostics_db = this.model.diagnostics;
+    const editor = this.model.virtual_editor;
+    if (!diagnostics_db || typeof editor === 'undefined') {
+      return <div>No issues detected, great job!</div>;
+    }
+    let documents_count = diagnostics_db.size;
+
+    let by_document = Array.from(diagnostics_db).map(
+      ([virtual_document, diagnostics]) => {
+        return diagnostics.map((diagnostic_data, i) => {
+          let cell_nr: number = null;
+          if (editor.has_cells) {
+            let notebook_editor = editor as VirtualEditorForNotebook;
+            let { cell_id } = notebook_editor.find_cell_by_editor(
+              diagnostic_data.editor
+            );
+            cell_nr = cell_id + 1;
+          }
+          return {
+            data: diagnostic_data,
+            key: virtual_document.uri + ',' + i,
+            document: virtual_document,
+            cell_nr: cell_nr
+          } as IDiagnosticsRow;
+        });
+      }
+    );
+    let flattened: IDiagnosticsRow[] = [].concat.apply([], by_document);
+
+    let sorter = sorters[this.sort_key];
+    let sorted = flattened.sort((a, b) => sorter(a, b) * this.sort_direction);
+
+    let elements = sorted.map(({ data, key, document, cell_nr }) => {
+      let diagnostic = data.diagnostic;
+
+      let cm_editor = data.editor;
+
+      let message = diagnostic.message;
+      let code = '' + diagnostic.code;
+      if (message.startsWith(code)) {
+        message = message.slice(code.length);
+      }
+      let severity = diagnostic.severity || 1;
+
+      return (
+        <tr
+          key={key}
+          onClick={() => {
+            focus_on(cm_editor.getWrapperElement());
+            cm_editor.getDoc().setCursor(data.range.start);
+            cm_editor.focus();
+          }}
+        >
+          {documents_count > 1 ? (
+            <td>
+              <DocumentLocator document={document} editor={editor} />
+            </td>
+          ) : null}
+          <td>{message}</td>
+          <td>{diagnostic.code}</td>
+          <td>{diagnosticSeverityNames[severity]}</td>
+          <td>{diagnostic.source}</td>
+          {editor.has_cells ? <td>{cell_nr}</td> : null}
+          <td>{data.range.start.line}</td>
+          <td>{data.range.start.ch}</td>
+        </tr>
+      );
+    });
+
+    let SortableTH = (props: { name: string }): any => {
+      const is_sort_key = props.name === this.sort_key;
+      return (
+        <th
+          onClick={() => this.sort(props.name)}
+          className={
+            is_sort_key
+              ? 'lsp-sorted ' +
+                (this.sort_direction === 1 ? 'lsp-descending' : '')
+              : ''
+          }
+        >
+          {props.name}
+          {is_sort_key ? <span className={'lsp-caret'} /> : null}
+        </th>
+      );
+    };
+
+    return (
+      <table className={'lsp-diagnostics-listing'}>
+        <thead>
+          <tr>
+            {documents_count > 1 ? (
+              <SortableTH name={'Virtual Document'} />
+            ) : null}
+            <SortableTH name={'Message'} />
+            <SortableTH name={'Code'} />
+            <SortableTH name={'Severity'} />
+            <SortableTH name={'Source'} />
+            {editor.has_cells ? <SortableTH name={'Cell'} /> : null}
+            <SortableTH name={'Line'} />
+            <SortableTH name={'Ch'} />
+          </tr>
+        </thead>
+        <tbody>{elements}</tbody>
+      </table>
+    );
+  }
+}
+
+export namespace DiagnosticsListing {
+  /**
+   * A VDomModel for the LSP of current file editor/notebook.
+   */
+  export class Model extends VDomModel {
+    diagnostics: DiagnosticsDatabase;
+    virtual_editor: VirtualEditor;
+
+    constructor() {
+      super();
+    }
+  }
+}

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/highlights.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/highlights.ts
@@ -83,9 +83,13 @@ export class Highlights extends CodeMirrorLSPFeature {
     if (document !== this.virtual_document) {
       return;
     }
-    let virtual_position = this.virtual_editor.root_position_to_virtual_position(
-      root_position
-    );
-    this.connection.getDocumentHighlights(virtual_position);
+    try {
+      let virtual_position = this.virtual_editor.root_position_to_virtual_position(
+        root_position
+      );
+      this.connection.getDocumentHighlights(virtual_position);
+    } catch (e) {
+      console.warn('Could not get highlights:', e);
+    }
   }
 }

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/rename.ts
@@ -107,7 +107,9 @@ function ux_workaround_for_rope_limitation(
   if (!has_index_error) {
     return null;
   }
-  let dire_python_errors = (diagnostics_feature.diagnostics_db || []).filter(
+  let dire_python_errors = (
+    diagnostics_feature.diagnostics_db.all || []
+  ).filter(
     diagnostic =>
       diagnostic.diagnostic.message.includes('invalid syntax') ||
       diagnostic.diagnostic.message.includes('SyntaxError') ||

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/testutils.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/testutils.ts
@@ -13,11 +13,14 @@ import {
   StatusMessage
 } from '../jupyterlab/jl_adapter';
 import { VirtualEditorForNotebook } from '../../virtual/editors/notebook';
-import { Notebook } from '@jupyterlab/notebook';
+import { Notebook, NotebookModel } from '@jupyterlab/notebook';
 import { NBTestUtils } from '@jupyterlab/testutils';
 import { IOverridesRegistry } from '../../magics/overrides';
 import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
+import { nbformat } from '@jupyterlab/coreutils';
+import { ICellModel } from '@jupyterlab/cells';
 import createNotebook = NBTestUtils.createNotebook;
+import { CodeMirrorAdapter } from './cm_adapter';
 
 interface IFeatureTestEnvironment {
   host: HTMLElement;
@@ -145,6 +148,7 @@ export class FileEditorFeatureTestEnvironment extends FeatureTestEnvironment {
 
 export class NotebookFeatureTestEnvironment extends FeatureTestEnvironment {
   public notebook: Notebook;
+  virtual_editor: VirtualEditorForNotebook;
   public wrapper: HTMLElement;
 
   constructor(
@@ -170,5 +174,82 @@ export class NotebookFeatureTestEnvironment extends FeatureTestEnvironment {
       this.foreign_code_extractors,
       this.path
     );
+  }
+}
+
+export function code_cell(
+  source: string[] | string,
+  metadata: object = { trusted: false }
+) {
+  return {
+    cell_type: 'code',
+    source: source,
+    metadata: metadata,
+    execution_count: null,
+    outputs: []
+  } as nbformat.ICodeCell;
+}
+
+export function set_notebook_content(
+  notebook: Notebook,
+  cells: nbformat.ICodeCell[],
+  metadata = python_notebook_metadata
+) {
+  let test_notebook = {
+    cells: cells,
+    metadata: metadata
+  } as nbformat.INotebookContent;
+
+  notebook.model = new NotebookModel();
+  notebook.model.fromJSON(test_notebook);
+}
+
+export const python_notebook_metadata = {
+  kernelspec: {
+    display_name: 'Python [default]',
+    language: 'python',
+    name: 'python3'
+  },
+  language_info: {
+    codemirror_mode: {
+      name: 'ipython',
+      version: 3
+    },
+    file_extension: '.py',
+    mimetype: 'text/x-python',
+    name: 'python',
+    nbconvert_exporter: 'python',
+    pygments_lexer: 'ipython3',
+    version: '3.5.2'
+  },
+  orig_nbformat: 4.1
+} as nbformat.INotebookMetadata;
+
+export function showAllCells(notebook: Notebook) {
+  notebook.show();
+  // iterate over every cell to activate the editors
+  for (let i = 0; i < notebook.model.cells.length; i++) {
+    notebook.activeCellIndex = i;
+    notebook.activeCell.show();
+  }
+}
+
+export function getCellsJSON(notebook: Notebook) {
+  let cells: Array<ICellModel> = [];
+  for (let i = 0; i < notebook.model.cells.length; i++) {
+    cells.push(notebook.model.cells.get(i));
+  }
+  return cells.map(cell => cell.toJSON());
+}
+
+export async function synchronize_content(
+  environment: FeatureTestEnvironment,
+  adapter: CodeMirrorAdapter
+) {
+  await environment.virtual_editor.update_documents();
+  try {
+    await adapter.updateAfterChange();
+  } catch (e) {
+    console.warn(e);
   }
 }

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/statusbar.tsx
@@ -4,22 +4,22 @@
 
 import React from 'react';
 
-import { VDomRenderer, VDomModel } from '@jupyterlab/apputils';
+import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
 import '../../../../style/statusbar.css';
 
 import * as SCHEMA from '../../../_schema';
 
 import {
+  GroupItem,
   interactiveItem,
   Popup,
   showPopup,
-  TextItem,
-  GroupItem
+  TextItem
 } from '@jupyterlab/statusbar';
 
 import { DefaultIconReact } from '@jupyterlab/ui-components';
 import { JupyterLabWidgetAdapter } from '../jl_adapter';
-import { VirtualDocument } from '../../../virtual/document';
+import { collect_documents, VirtualDocument } from '../../../virtual/document';
 import { LSPConnection } from '../../../connection';
 import { PageConfig } from '@jupyterlab/coreutils';
 
@@ -284,18 +284,6 @@ export interface IStatus {
   open_connections: Array<LSPConnection>;
   detected_documents: Set<VirtualDocument>;
   status: StatusCode;
-}
-
-function collect_documents(
-  virtual_document: VirtualDocument
-): Set<VirtualDocument> {
-  let collected = new Set<VirtualDocument>();
-  collected.add(virtual_document);
-  for (let foreign of virtual_document.foreign_documents.values()) {
-    let foreign_languages = collect_documents(foreign);
-    foreign_languages.forEach(collected.add, collected);
-  }
-  return collected;
 }
 
 function collect_languages(virtual_document: VirtualDocument): Set<string> {

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
@@ -225,7 +225,7 @@ export abstract class JupyterLabWidgetAdapter
     await this.connect(virtual_document).catch(console.warn);
 
     virtual_document.foreign_document_opened.connect((host, context) => {
-      this.connect(context.foreign_document).catch(console.warn);
+      this.connect_document(context.foreign_document).catch(console.warn);
     });
   }
 

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
@@ -399,7 +399,8 @@ export abstract class JupyterLabWidgetAdapter
       virtual_position,
       root_position,
       features: this.get_features(document),
-      editor: this.virtual_editor
+      editor: this.virtual_editor,
+      app: this.app
     };
   }
 

--- a/packages/jupyterlab-lsp/src/command_manager.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.ts
@@ -107,10 +107,16 @@ export abstract class ContextMenuCommandManager extends LSPCommandManager {
   }
 
   is_visible(command: IFeatureCommand): boolean {
-    let context = this.current_adapter.get_context_from_context_menu();
-    return (
-      this.current_adapter && context.connection && command.is_enabled(context)
-    );
+    try {
+      let context = this.current_adapter.get_context_from_context_menu();
+      return (
+        this.current_adapter &&
+        context.connection &&
+        command.is_enabled(context)
+      );
+    } catch (e) {
+      return false;
+    }
   }
 
   protected get_rank(command: IFeatureCommand): number {
@@ -154,6 +160,7 @@ export class FileEditorCommandManager extends ContextMenuCommandManager {
 }
 
 export interface ICommandContext {
+  app: JupyterFrontEnd;
   document: VirtualDocument;
   connection: LSPConnection;
   virtual_position: IVirtualPosition;

--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -86,27 +86,13 @@ export class DocumentConnectionManager {
     this.documents_changed.emit(this.documents);
   }
 
-  protected solve_uris(virtual_document: VirtualDocument, language: string) {
-    const wsBase = PageConfig.getBaseUrl().replace(/^http/, 'ws');
-    const rootUri = PageConfig.getOption('rootUri');
-    const virtualDocumentsUri = PageConfig.getOption('virtualDocumentsUri');
-
-    const baseUri = virtual_document.has_lsp_supported_file
-      ? rootUri
-      : virtualDocumentsUri;
-
-    return {
-      base: baseUri,
-      document: URLExt.join(baseUri, virtual_document.uri),
-      server: URLExt.join('ws://jupyter-lsp', language),
-      socket: URLExt.join(wsBase, 'lsp', language)
-    };
-  }
-
   private connect_socket(options: ISocketConnectionOptions): LSPConnection {
     let { virtual_document, language } = options;
 
-    const uris = this.solve_uris(virtual_document, language);
+    const uris = DocumentConnectionManager.solve_uris(
+      virtual_document,
+      language
+    );
 
     let socket = new WebSocket(uris.socket);
 
@@ -231,5 +217,27 @@ export class DocumentConnectionManager {
       this.closed.emit({ connection, virtual_document });
     }
     this.connections.clear();
+  }
+}
+
+export namespace DocumentConnectionManager {
+  export function solve_uris(
+    virtual_document: VirtualDocument,
+    language: string
+  ) {
+    const wsBase = PageConfig.getBaseUrl().replace(/^http/, 'ws');
+    const rootUri = PageConfig.getOption('rootUri');
+    const virtualDocumentsUri = PageConfig.getOption('virtualDocumentsUri');
+
+    const baseUri = virtual_document.has_lsp_supported_file
+      ? rootUri
+      : virtualDocumentsUri;
+
+    return {
+      base: baseUri,
+      document: URLExt.join(baseUri, virtual_document.uri),
+      server: URLExt.join('ws://jupyter-lsp', language),
+      socket: URLExt.join(wsBase, 'lsp', language)
+    };
   }
 }

--- a/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
@@ -9,7 +9,6 @@ import {
 import * as CodeMirror from 'codemirror';
 import { PageConfig } from '@jupyterlab/coreutils';
 import { DocumentConnectionManager } from '../connection_manager';
-import { VirtualDocument } from './document';
 
 class VirtualEditorImplementation extends VirtualEditor {
   private cm_editor: CodeMirror.Editor;
@@ -75,16 +74,8 @@ describe('VirtualEditor', () => {
       const virtualDocumentsUri = PageConfig.getOption('virtualDocumentsUri');
       expect(rootUri).to.be.not.equal(virtualDocumentsUri);
 
-      class DummyConnectionManager extends DocumentConnectionManager {
-        public get_solved_uris(document: VirtualDocument, language: string) {
-          return this.solve_uris(document, language);
-        }
-      }
-
-      const manager = new DummyConnectionManager();
-
       let document = editor.virtual_document;
-      let uris = manager.get_solved_uris(document, 'python');
+      let uris = DocumentConnectionManager.solve_uris(document, 'python');
       expect(uris.base.startsWith(virtualDocumentsUri)).to.be.equal(true);
 
       let editor_with_plain_file = new VirtualEditorImplementation(
@@ -96,7 +87,7 @@ describe('VirtualEditor', () => {
         true
       );
       document = editor_with_plain_file.virtual_document;
-      uris = manager.get_solved_uris(document, 'python');
+      uris = DocumentConnectionManager.solve_uris(document, 'python');
       expect(uris.base.startsWith(virtualDocumentsUri)).to.be.equal(false);
     });
   });

--- a/packages/jupyterlab-lsp/style/diagnostics_listing.css
+++ b/packages/jupyterlab-lsp/style/diagnostics_listing.css
@@ -1,0 +1,80 @@
+.lsp-diagnostics-panel-content {
+    overflow-y: auto;
+}
+
+.lsp-diagnostics-listing {
+    color: var(--jp-ui-font-color1);
+    background: var(--jp-layout-color1);
+    font-size: var(--jp-ui-font-size1);
+    border-spacing: 0;
+    width: 100%;
+}
+
+.lsp-diagnostics-listing thead {
+    box-shadow: var(--jp-toolbar-box-shadow);
+}
+
+.lsp-diagnostics-listing tbody {
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.lsp-diagnostics-listing th {
+    padding: 4px 12px;
+    font-weight: 500;
+    text-align: left;
+    border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+    background: var(--jp-layout-color1);
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    white-space: nowrap;
+    user-select: none;
+}
+
+.lsp-diagnostics-listing th:not(:first-child) {
+    border-left: var(--jp-border-width) solid var(--jp-border-color2);
+}
+
+.lsp-diagnostics-listing th:hover {
+    background: var(--jp-layout-color2);
+}
+
+.lsp-document-locator span:not(:last-child)::after {
+    content: ' > ';
+}
+
+.lsp-diagnostics-listing td:first-child,.lsp-diagnostics-listing td:last-child {
+    padding: 4px 12px;
+}
+
+.lsp-diagnostics-listing tbody td:not(:first-child):not(:last-child) {
+    padding: 4px 2px;
+}
+
+.lsp-diagnostics-listing tbody tr:hover {
+    background: var(--jp-layout-color2);
+}
+
+.lsp-sort-caret
+{
+    height: 16px;
+    width: 16px;
+    background-size: 18px;
+    background-image: 18px;
+    background-repeat: no-repeat;
+    background-position: center;
+    display: inline-block;
+    position: relative;
+    top: 3px;
+}
+
+.lsp-sorted .lsp-caret {
+    background-image: var(--jp-icon-caretup);
+    margin-top: -4px;
+    left: 3px;
+}
+
+.lsp-sorted.lsp-descending .lsp-caret {
+    background-image: var(--jp-icon-caretdown);
+}

--- a/packages/jupyterlab-lsp/style/diagnostics_listing.css
+++ b/packages/jupyterlab-lsp/style/diagnostics_listing.css
@@ -1,80 +1,80 @@
 .lsp-diagnostics-panel-content {
-    overflow-y: auto;
+  overflow-y: auto;
 }
 
 .lsp-diagnostics-listing {
-    color: var(--jp-ui-font-color1);
-    background: var(--jp-layout-color1);
-    font-size: var(--jp-ui-font-size1);
-    border-spacing: 0;
-    width: 100%;
+  color: var(--jp-ui-font-color1);
+  background: var(--jp-layout-color1);
+  font-size: var(--jp-ui-font-size1);
+  border-spacing: 0;
+  width: 100%;
 }
 
 .lsp-diagnostics-listing thead {
-    box-shadow: var(--jp-toolbar-box-shadow);
+  box-shadow: var(--jp-toolbar-box-shadow);
 }
 
 .lsp-diagnostics-listing tbody {
-    overflow-y: auto;
-    overflow-x: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .lsp-diagnostics-listing th {
-    padding: 4px 12px;
-    font-weight: 500;
-    text-align: left;
-    border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
-    background: var(--jp-layout-color1);
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    white-space: nowrap;
-    user-select: none;
+  padding: 4px 12px;
+  font-weight: 500;
+  text-align: left;
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
+  background: var(--jp-layout-color1);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  white-space: nowrap;
+  user-select: none;
 }
 
 .lsp-diagnostics-listing th:not(:first-child) {
-    border-left: var(--jp-border-width) solid var(--jp-border-color2);
+  border-left: var(--jp-border-width) solid var(--jp-border-color2);
 }
 
 .lsp-diagnostics-listing th:hover {
-    background: var(--jp-layout-color2);
+  background: var(--jp-layout-color2);
 }
 
 .lsp-document-locator span:not(:last-child)::after {
-    content: ' > ';
+  content: ' > ';
 }
 
-.lsp-diagnostics-listing td:first-child,.lsp-diagnostics-listing td:last-child {
-    padding: 4px 12px;
+.lsp-diagnostics-listing td:first-child,
+.lsp-diagnostics-listing td:last-child {
+  padding: 4px 12px;
 }
 
 .lsp-diagnostics-listing tbody td:not(:first-child):not(:last-child) {
-    padding: 4px 2px;
+  padding: 4px 2px;
 }
 
 .lsp-diagnostics-listing tbody tr:hover {
-    background: var(--jp-layout-color2);
+  background: var(--jp-layout-color2);
 }
 
-.lsp-sort-caret
-{
-    height: 16px;
-    width: 16px;
-    background-size: 18px;
-    background-image: 18px;
-    background-repeat: no-repeat;
-    background-position: center;
-    display: inline-block;
-    position: relative;
-    top: 3px;
+.lsp-sort-caret {
+  height: 16px;
+  width: 16px;
+  background-size: 18px;
+  background-image: 18px;
+  background-repeat: no-repeat;
+  background-position: center;
+  display: inline-block;
+  position: relative;
+  top: 3px;
 }
 
 .lsp-sorted .lsp-caret {
-    background-image: var(--jp-icon-caretup);
-    margin-top: -4px;
-    left: 3px;
+  background-image: var(--jp-icon-caretup);
+  margin-top: -4px;
+  left: 3px;
 }
 
 .lsp-sorted.lsp-descending .lsp-caret {
-    background-image: var(--jp-icon-caretdown);
+  background-image: var(--jp-icon-caretdown);
 }


### PR DESCRIPTION
Add diagnostics/inspections panel.

## References

Closes #42 

## Code changes

- adds jest test for inspections in a notebook
- adds a few testutilis, moves utilities to testutilis from feature.spec.ts
- fixes a bug with foreign governments not being updated TODO tests
- fixes diagnostics being displayed in a wrong document
- protects from failures in highlights feature (such is a while other story and requires a lot of testing)

## User-facing changes

Adds a diagnostics panel. The diagnostics table is scrollable, sortable and a click on the diagnostic moves the user to the relevant place in the notebook or editor.

![diagnostics_panel](https://user-images.githubusercontent.com/5832902/71786083-a040f900-2fff-11ea-9fdb-fe53bd99ac3d.gif)


## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
