### PR TITLE
Add commands to palette, add diagnostics panel tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     in code (on click); accessible from the context menu (
     [#127](https://github.com/krassowski/jupyterlab-lsp/pull/127)
     )
+  - all commands are now accessible from the command palette
 - bugfixes
   - diagnostics in foreign documents are now correctly updated (
     [133fd3d](https://github.com/krassowski/jupyterlab-lsp/pull/129/commits/133fd3d71401c7e5affc0a8637ee157de65bef62)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@
     in code (on click); accessible from the context menu (
     [#127](https://github.com/krassowski/jupyterlab-lsp/pull/127)
     )
-  - all commands are now accessible from the command palette
+  - all commands are now accessible from the command palette (
+    [#142](https://github.com/krassowski/jupyterlab-lsp/pull/142)
+    )
 - bugfixes
   - diagnostics in foreign documents are now correctly updated (
     [133fd3d](https://github.com/krassowski/jupyterlab-lsp/pull/129/commits/133fd3d71401c7e5affc0a8637ee157de65bef62)

--- a/atest/01_Editor.robot
+++ b/atest/01_Editor.robot
@@ -12,6 +12,8 @@ ${CM CURSOR}      css:.CodeMirror-cursor
 ${CM CURSORS}     css:.CodeMirror-cursors:not([style='visibility: hidden'])
 ${DIALOG WINDOW}    css:.jp-Dialog
 ${DIALOG INPUT}    css:.jp-Input-Dialog input
+${DIAGNOSTICS PANEL}    css:#lsp-diagnostics-panel
+${DIAGNOSTIC PANEL CLOSE}    css:.p-DockPanel-tabBar .p-TabBar-tab[data-id="lsp-diagnostics-panel"] .p-TabBar-tabCloseIcon
 
 *** Test Cases ***
 Bash
@@ -106,6 +108,13 @@ Editor Should Show Diagnostics
     Set Tags    feature:diagnostics
     Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${diagnostic}"]    timeout=20s
     Capture Page Screenshot    01-diagnostics.png
+    Lab Command    Show Diagnostics Panel
+    Wait Until Page Contains Element    ${DIAGNOSTICS PANEL}    timeout=20s
+    Capture Page Screenshot    02-diagnostics.png
+    ${count} =    Get Element Count    css:.lsp-diagnostics-listing tr
+    SHOULD BE TRUE    ${count} >= 1
+    Mouse Over    ${DIAGNOSTIC PANEL CLOSE}
+    Click Element    ${DIAGNOSTIC PANEL CLOSE}
 
 Editor Should Jump To Definition
     [Arguments]    ${symbol}

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
@@ -363,6 +363,9 @@ export abstract class JupyterLabWidgetAdapter
   }
 
   get_position_from_context_menu(): IRootPosition {
+    // Note: could also try using this.app.contextMenu.menu.contentNode position.
+    // Note: could add a guard on this.app.contextMenu.menu.isAttached
+
     // get the first node as it gives the most accurate approximation
     let leaf_node = this.app.contextMenuHitTest(() => true);
 
@@ -378,6 +381,7 @@ export abstract class JupyterLabWidgetAdapter
       top = event.clientY;
       event.stopPropagation();
     }
+
     return this.virtual_editor.coordsChar(
       {
         left: left,
@@ -387,8 +391,7 @@ export abstract class JupyterLabWidgetAdapter
     ) as IRootPosition;
   }
 
-  get_context_from_context_menu(): ICommandContext {
-    let root_position = this.get_position_from_context_menu();
+  get_context(root_position: IRootPosition): ICommandContext {
     let document = this.virtual_editor.document_at_root_position(root_position);
     let virtual_position = this.virtual_editor.root_position_to_virtual_position(
       root_position
@@ -402,6 +405,11 @@ export abstract class JupyterLabWidgetAdapter
       editor: this.virtual_editor,
       app: this.app
     };
+  }
+
+  get_context_from_context_menu(): ICommandContext {
+    let root_position = this.get_position_from_context_menu();
+    return this.get_context(root_position);
   }
 
   public create_tooltip(

--- a/packages/jupyterlab-lsp/src/command_manager.spec.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ContextMenuCommandManager } from './command_manager';
+import { ContextCommandManager, ICommandContext } from './command_manager';
 import {
   CommandEntryPoint,
   IFeatureCommand
@@ -7,7 +7,7 @@ import {
 import { JupyterLabWidgetAdapter } from './adapters/jupyterlab/jl_adapter';
 
 describe('ContextMenuCommandManager', () => {
-  class ManagerImplementation extends ContextMenuCommandManager {
+  class ManagerImplementation extends ContextCommandManager {
     public get_rank(command: IFeatureCommand): number {
       return super.get_rank(command);
     }
@@ -16,6 +16,10 @@ describe('ContextMenuCommandManager', () => {
     selector: string;
 
     get current_adapter(): JupyterLabWidgetAdapter {
+      return undefined;
+    }
+
+    context_from_active_document(): ICommandContext {
       return undefined;
     }
   }
@@ -34,14 +38,14 @@ describe('ContextMenuCommandManager', () => {
 
   describe('#get_rank()', () => {
     it('uses in-group (relative) positioning by default', () => {
-      manager = new ManagerImplementation(null, null, null, 0, 5);
+      manager = new ManagerImplementation(null, null, null, null, 0, 5);
       let rank = manager.get_rank(base_command);
       expect(rank).to.equal(0);
 
       rank = manager.get_rank({ ...base_command, rank: 1 });
       expect(rank).to.equal(1 / 5);
 
-      manager = new ManagerImplementation(null, null, null, 1, 5);
+      manager = new ManagerImplementation(null, null, null, null, 1, 5);
 
       rank = manager.get_rank({ ...base_command, rank: 1 });
       expect(rank).to.equal(1 + 1 / 5);
@@ -49,7 +53,7 @@ describe('ContextMenuCommandManager', () => {
   });
 
   it('respects is_rank_relative value', () => {
-    manager = new ManagerImplementation(null, null, null, 0, 5);
+    manager = new ManagerImplementation(null, null, null, null, 0, 5);
 
     let rank = manager.get_rank({
       ...base_command,

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -109,7 +109,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
       let adapter = null;
       if (notebookTracker.has(current)) {
         let id = (current as NotebookPanel).id;
-        console.warn(id);
         adapter = notebook_adapters.get(id);
       } else if (fileEditorTracker.has(current)) {
         let id = (current as IDocumentWidget<FileEditor>).content.id;
@@ -162,6 +161,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     let command_manager = new FileEditorCommandManager(
       app,
+      palette,
       fileEditorTracker,
       'file_editor'
     );
@@ -189,6 +189,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     // TODO: PR bumping rank of clear all outputs instead?
     let notebook_command_manager = new NotebookCommandManager(
       app,
+      palette,
       notebookTracker,
       'notebook',
       // adding a very small number (epsilon) places the group just after 10th entry

--- a/packages/jupyterlab-lsp/src/virtual/editors/notebook.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editors/notebook.ts
@@ -41,7 +41,9 @@ class DocDispatcher implements CodeMirror.Doc {
   getCursor(start?: string): CodeMirror.Position {
     let cell = this.virtual_editor.notebook.activeCell;
     let active_editor = cell.editor as CodeMirrorEditor;
-    let cursor = active_editor.editor.getDoc().getCursor(start);
+    let cursor = active_editor.editor
+      .getDoc()
+      .getCursor(start) as IEditorPosition;
     return this.virtual_editor.transform_from_notebook_to_root(cell, cursor);
   }
 }
@@ -94,7 +96,7 @@ export class VirtualEditorForNotebook extends VirtualEditor {
 
   transform_from_notebook_to_root(
     cell: Cell,
-    position: CodeMirror.Position
+    position: IEditorPosition
   ): IRootPosition {
     // TODO: if cell is not known, refresh
     let shift = this.cell_to_corresponding_source_line.get(cell);
@@ -102,7 +104,7 @@ export class VirtualEditorForNotebook extends VirtualEditor {
       throw Error('Cell not found in cell_line_map');
     }
     return {
-      ...position,
+      ...(position as CodeMirror.Position),
       line: position.line + shift
     } as IRootPosition;
   }
@@ -197,7 +199,7 @@ export class VirtualEditorForNotebook extends VirtualEditor {
         continue;
       }
 
-      return this.transform_from_notebook_to_root(cell, pos);
+      return this.transform_from_notebook_to_root(cell, pos as IEditorPosition);
     }
   }
 


### PR DESCRIPTION
Commands are now also accessible from the command palette, while diagnostics panel is tested during diagnostics tests.

## References

A prerequisite for a test and fix for #141.

## Code changes

`ContextMenuCommandManager` became `ContextCommandManager` and takes care of attachment, visibility and execution of commands invoked from both the context menu and commands palette. 

## User-facing changes

One can discover options of the extension via the command palette.

## Backwards-incompatible changes

`ContextCommandManager` and its constructor.

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
