### PR TITLE
completion case sensitive will  keep a no need token value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
   - completion now work properly when the kernel is shut down (
     [#146](https://github.com/krassowski/jupyterlab-lsp/pull/146)
     )
+  - a lowercase completion option selected from an uppercase token
+    will now correctly substitute the incomplete token (
+    [#143](https://github.com/krassowski/jupyterlab-lsp/pull/143)
+    )
 
 ## `lsp-ws-connection 0.3.0`
 

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -50,6 +50,15 @@ Autocompletes If Only One Option
     Wait Until Keyword Succeeds    20x    0.5s    Cell Editor Should Equal    3    list.clear
     [Teardown]    Clean Up After Working With File    Completion.ipynb
 
+User Can Select Lowercase After Starting Uppercase
+    Setup Notebook    Python    Completion.ipynb
+    Enter Cell Editor    4    line=1
+    Trigger Completer
+    Completer Should Suggest  time
+    Press Keys    None    ENTER
+    Wait Until Keyword Succeeds    20x    0.5s    Cell Editor Should Equal    4    from time import time
+    [Teardown]    Clean Up After Working With File    Completion.ipynb
+
 *** Keywords ***
 Enter Cell Editor
     [Arguments]    ${cell_nr}    ${line}=1

--- a/atest/examples/Completion.ipynb
+++ b/atest/examples/Completion.ipynb
@@ -27,6 +27,15 @@
    "source": [
     "list."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import Tim"
+   ]
   }
  ],
  "metadata": {

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/completion.ts
@@ -212,7 +212,7 @@ export class LSPConnector extends DataConnector<
       // sortText: "amean"
       let text = match.insertText ? match.insertText : match.label;
 
-      if (text.startsWith(token.value)) {
+      if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
         all_non_prefixed = false;
       }
 
@@ -276,7 +276,7 @@ export class LSPConnector extends DataConnector<
     if (lsp.start > kernel.start) {
       const cursor = editor.getCursorPosition();
       const line = editor.getLine(cursor.line);
-      prefix = line.substring(kernel.start, kernel.end);
+      prefix = line.substring(cursor.column - 1, cursor.column);
       console.log('will remove prefix from kernel response:', prefix);
     }
 


### PR DESCRIPTION
## Code changes

There has two changes.

All in `completion.ts`.

1.  change `merge_replies` function.
when `lsp.start > kernel.start`, correct the right prefix. 
`kernel.start` is the wrong index, because this index is merge all content in cell, and calculate the index, not the current line index.

2.  change `hint` function.

if check text startsWith token case sensitive,
It will keep a no need token value.

Input `from time import T`
before after completion, there will be `from time import Ttime`
now, there will be `from time import time`

## Chores

- [x] linted
- [x] tested
- [x] changelog entry
