### PR TITLE
Fix R foreign extractor, add bash alias, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@
   - all commands are now accessible from the command palette (
     [#142](https://github.com/krassowski/jupyterlab-lsp/pull/142)
     )
-  - bash LSP now covers also `%%bash` magic cell in addition to `%%sh`
+  - bash LSP now also covers `%%bash` magic cell in addition to `%%sh` (
+    [#144](https://github.com/krassowski/jupyterlab-lsp/pull/144)
+    )
 - bugfixes
   - diagnostics in foreign documents are now correctly updated (
     [133fd3d](https://github.com/krassowski/jupyterlab-lsp/pull/129/commits/133fd3d71401c7e5affc0a8637ee157de65bef62)
@@ -32,7 +34,9 @@
   - the workaround for relative root path is now also applied on Mac (
     [#139](https://github.com/krassowski/jupyterlab-lsp/pull/139)
     )
-  - fixed LSP of R in Python (`%%R` magic cell from rpy2)
+  - fixed LSP of R in Python (`%%R` magic cell from rpy2) (
+    [#144](https://github.com/krassowski/jupyterlab-lsp/pull/144)
+    )
 
 ## `lsp-ws-connection 0.3.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   - all commands are now accessible from the command palette (
     [#142](https://github.com/krassowski/jupyterlab-lsp/pull/142)
     )
+  - bash LSP now covers also `%%bash` magic cell in addition to `%%sh`
 - bugfixes
   - diagnostics in foreign documents are now correctly updated (
     [133fd3d](https://github.com/krassowski/jupyterlab-lsp/pull/129/commits/133fd3d71401c7e5affc0a8637ee157de65bef62)
@@ -31,6 +32,7 @@
   - the workaround for relative root path is now also applied on Mac (
     [#139](https://github.com/krassowski/jupyterlab-lsp/pull/139)
     )
+  - fixed LSP of R in Python (`%%R` magic cell from rpy2)
 
 ## `lsp-ws-connection 0.3.0`
 

--- a/atest/03_Notebook.robot
+++ b/atest/03_Notebook.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Suite Setup       Setup Suite For Screenshots    notebook
+Resource          Keywords.robot
+
+*** Test Cases ***
+Python
+    [Setup]    Reset Application State
+    Setup Notebook    Python    Python.ipynb
+    Capture Page Screenshot    01-python.png
+    ${diagnostic} =    Set Variable    W291 trailing whitespace (pycodestyle)
+    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title="${diagnostic}"]    timeout=20s
+    Capture Page Screenshot    02-python.png
+    Clean Up After Working With File    Python.ipynb
+
+Foregin Extractors
+    [Setup]    Reset Application State
+    Setup Notebook    Python    Foreign extractors.ipynb
+    @{diagnostics} =    Create List    Failed to parse expression    Name 'valid' is not defined (mypy)    Trailing whitespace is superfluous. (lintr)
+    FOR    ${diagnostic}    IN    @{diagnostics}
+        Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title="${diagnostic}"]    timeout=30s
+        Capture Page Screenshot    0x-${diagnostic}.png
+    END
+    Clean Up After Working With File    Foreign Extractors.ipynb

--- a/atest/03_Notebook.robot
+++ b/atest/03_Notebook.robot
@@ -15,7 +15,7 @@ Python
 Foregin Extractors
     [Setup]    Reset Application State
     Setup Notebook    Python    Foreign extractors.ipynb
-    @{diagnostics} =    Create List    Failed to parse expression    Name 'valid' is not defined (mypy)    Trailing whitespace is superfluous. (lintr)
+    @{diagnostics} =    Create List    Failed to parse expression    undefined name 'valid' (pyflakes)    Trailing whitespace is superfluous. (lintr)
     FOR    ${diagnostic}    IN    @{diagnostics}
         Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title="${diagnostic}"]    timeout=30s
         Capture Page Screenshot    0x-${diagnostic}.png

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -126,3 +126,53 @@ Open With JupyterLab Menu
     FOR    ${submenu}    IN    @{submenus}
         Click JupyterLab Menu Item    ${submenu}
     END
+
+Ensure File Browser is Open
+    ${sel} =    Set Variable    css:.p-TabBar-tab[data-id="filebrowser"]:not(.p-mod-current)
+    ${els} =    Get WebElements    ${sel}
+    Run Keyword If    ${els.__len__()}    Click Element    ${sel}
+
+Input Into Dialog
+    [Arguments]    ${text}
+    Wait For Dialog
+    Click Element    ${DIALOG INPUT}
+    Input Text    ${DIALOG INPUT}    ${text}
+    Click Element    ${DIALOG ACCEPT}
+
+Open ${file} in ${editor}
+    Ensure File Browser is Open
+    Click Element    css:button[title="Refresh File List"]
+    Open Context Menu    css:.jp-DirListing-item[title="${file}"]
+    Mouse Over    ${MENU OPEN WITH}
+    Wait Until Page Contains Element    ${editor}
+    Mouse Over    ${editor}
+    Click Element    ${editor}
+
+Clean Up After Working With File
+    [Arguments]    ${file}
+    Remove File    ${OUTPUT DIR}${/}home${/}${file}
+    Reset Application State
+
+Setup Notebook
+    [Arguments]    ${Language}    ${file}
+    Set Tags    language:${Language.lower()}
+    Set Screenshot Directory    ${OUTPUT DIR}${/}screenshots${/}notebook${/}${file.lower()}
+    Copy File    examples${/}${file}    ${OUTPUT DIR}${/}home${/}${file}
+    Lab Command    Close All Tabs
+    Open ${file} in ${MENU NOTEBOOK}
+    Capture Page Screenshot    00-opened.png
+
+Open Diagnostics Panel
+    Lab Command    Show Diagnostics Panel
+    Wait Until Page Contains Element    ${DIAGNOSTICS PANEL}    timeout=20s
+
+Count Diagnostics In Panel
+    ${count} =    Get Element Count    css:.lsp-diagnostics-listing tbody tr
+    [Return]    ${count}
+
+Close Diagnostics Panel
+    Mouse Over    ${DIAGNOSTIC PANEL CLOSE}
+    Click Element    ${DIAGNOSTIC PANEL CLOSE}
+
+Wait For Dialog
+    Wait Until Page Contains Element    ${DIALOG WINDOW}    timeout=180s

--- a/atest/Variables.robot
+++ b/atest/Variables.robot
@@ -4,10 +4,20 @@ ${SPLASH}         id:jupyterlab-splash
 ${BASE}           /@est/
 # override with `python scripts/atest.py --variable HEADLESS:0`
 ${HEADLESS}       1
-${CMD PALETTE INPUT}    css:.p-CommandPalette-input
-${CMD PALETTE ITEM ACTIVE}    css:.p-CommandPalette-item.p-mod-active
+${CMD PALETTE INPUT}    css:#command-palette .p-CommandPalette-input
+${CMD PALETTE ITEM ACTIVE}    css:#command-palette .p-CommandPalette-item.p-mod-active
 ${JLAB XP TOP}    //div[@id='jp-top-panel']
 ${JLAB XP MENU ITEM LABEL}    //div[@class='p-Menu-itemLabel']
 ${JLAB XP MENU LABEL}    //div[@class='p-MenuBar-itemLabel']
 ${JLAB CSS VERSION}    css:.jp-About-version
 ${CSS DIALOG OK}    css:.jp-Dialog .jp-mod-accept
+${MENU OPEN WITH}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(text(), "Open With")]
+# R is missing on purpose (may need to use .)
+${MENU RENAME}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(., "ename")]
+# N is missing on purpose
+${MENU NOTEBOOK}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(., "otebook")]
+${DIAGNOSTICS PANEL}    id:lsp-diagnostics-panel
+${DIAGNOSTIC PANEL CLOSE}    css:.p-DockPanel-tabBar .p-TabBar-tab[data-id="lsp-diagnostics-panel"] .p-TabBar-tabCloseIcon
+${DIALOG WINDOW}    css:.jp-Dialog
+${DIALOG INPUT}    css:.jp-Input-Dialog input
+${DIALOG ACCEPT}    css:button.jp-Dialog-button.jp-mod-accept

--- a/atest/examples/Foreign extractors.ipynb
+++ b/atest/examples/Foreign extractors.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Smoke"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valid = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%python\n",
+    "valid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### R"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%R\n",
+    "test   \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### bash"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "echo $"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/atest/examples/Python.ipynb
+++ b/atest/examples/Python.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = 1   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/packages/jupyterlab-lsp/src/extractors/defaults.ts
+++ b/packages/jupyterlab-lsp/src/extractors/defaults.ts
@@ -9,14 +9,14 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     // R magics (non-standalone: the R code will always be in the same, single R-namespace)
     //
     new RegExpForeignCodeExtractor({
-      language: 'R',
+      language: 'r',
       pattern: '^%%R( .*?)?\n([^]*)',
       extract_to_foreign: '$2',
       is_standalone: false,
       file_extension: 'R'
     }),
     new RegExpForeignCodeExtractor({
-      language: 'R',
+      language: 'r',
       pattern: '(^|\n)%R (.*)\n?',
       extract_to_foreign: '$2',
       is_standalone: false,
@@ -49,7 +49,7 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     }),
     new RegExpForeignCodeExtractor({
       language: 'sh',
-      pattern: '^%%(sh)( .*?)?\n([^]*)',
+      pattern: '^%%(sh|bash)( .*?)?\n([^]*)',
       extract_to_foreign: '$3',
       is_standalone: true,
       file_extension: 'sh'


### PR DESCRIPTION
Fix R foreign extractor, add bash alias, add notebook and extractors acceptance tests.

## Code changes

Added `03_Notebook.robot`, generalized some keywords relevant to both file editor and notebook and moved them to `Keywords.robot`.

## User-facing changes

Foreign code extractors for `%%bash` and `%%R` cells work now and again (respectively) :tada: 

## Chores

- [x] linted
- [X] tested
- [ ] documented
- [x] changelog entry
