### PR TITLE
Implement didSave, fixes #95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## `lsp-ws-connection 0.3.1`
+
+- added sendSaved() method (textDocument/didSave) (
+  [#147](https://github.com/krassowski/jupyterlab-lsp/pull/147)
+  )
+
 ## `@krassowski/jupyterlab-lsp 0.7.0-beta.1`
 
 - features
@@ -39,6 +45,11 @@
     )
   - completion now work properly when the kernel is shut down (
     [#146](https://github.com/krassowski/jupyterlab-lsp/pull/146)
+    )
+  - `didSave()` is emitted on file save, enabling the workaround
+    used by R language server to lazily load `library(tidyverse)` (
+    [#95](https://github.com/krassowski/jupyterlab-lsp/pull/95),
+    [#147](https://github.com/krassowski/jupyterlab-lsp/pull/147),
     )
 
 ## `lsp-ws-connection 0.3.0`

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/completion.ts
@@ -68,7 +68,10 @@ export class LSPConnector extends DataConnector<
   }
 
   protected get _has_kernel(): boolean {
-    return this.options.session && this.options.session.kernel !== null;
+    return (
+      typeof this.options.session !== 'undefined' &&
+      this.options.session.kernel !== null
+    );
   }
 
   protected get _kernel_language(): string {

--- a/packages/lsp-ws-connection/src/ws-connection.ts
+++ b/packages/lsp-ws-connection/src/ws-connection.ts
@@ -139,7 +139,7 @@ export class LspWsConnection extends events.EventEmitter
           synchronization: {
             dynamicRegistration: true,
             willSave: false,
-            didSave: false,
+            didSave: true,
             willSaveWaitUntil: false
           },
           completion: {
@@ -228,6 +228,23 @@ export class LspWsConnection extends events.EventEmitter
       textDocumentChange
     );
     this.documentVersion++;
+  }
+
+  public sendSaved() {
+    if (!this.isConnected || !this.isInitialized) {
+      return;
+    }
+    const textDocumentChange: protocol.DidSaveTextDocumentParams = {
+      textDocument: {
+        uri: this.documentInfo.documentUri,
+        version: this.documentVersion
+      } as protocol.VersionedTextDocumentIdentifier,
+      text: this.documentInfo.documentText()
+    };
+    this.connection.sendNotification(
+      'textDocument/didSave',
+      textDocumentChange
+    );
   }
 
   public getHoverTooltip(location: IPosition) {


### PR DESCRIPTION
## References

Implements didSave which solves #95 (as far as our responsibility goes, making it work without saving is on the LSP server).

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
