### PR TITLE
More Robot Test Robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Advanced static-analysis autocompletion without a running kernel
 Either:
 
 - JupyterLab >=1.1.4,<1.2
-- JupyterLab >=1.2.3,<1.3.0a0
+- JupyterLab >=1.2.4,<1.3.0a0
 - Python 3.5+
 - nodejs 8+
 

--- a/atest/00_Smoke.robot
+++ b/atest/00_Smoke.robot
@@ -5,10 +5,6 @@ Resource          Keywords.robot
 *** Test Cases ***
 Lab Version
     Capture Page Screenshot    00-smoke.png
-    ${script} =    Get Element Attribute    id:jupyter-config-data    innerHTML
-    ${config} =    Evaluate    __import__("json").loads("""${script}""")
-    Set Global Variable    ${PAGE CONFIG}    ${config}
-    Set Global Variable    ${LAB VERSION}    ${config["appVersion"]}
 
 Root URI
     [Documentation]    the rootUri should be set in the page config

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -28,6 +28,10 @@ Setup Server and Browser
     ...    stderr=STDOUT
     Set Global Variable    ${SERVER}    ${server}
     Open JupyterLab
+    ${script} =    Get Element Attribute    id:jupyter-config-data    innerHTML
+    ${config} =    Evaluate    __import__("json").loads("""${script}""")
+    Set Global Variable    ${PAGE CONFIG}    ${config}
+    Set Global Variable    ${LAB VERSION}    ${config["appVersion"]}
 
 Setup Suite For Screenshots
     [Arguments]    ${folder}

--- a/ci/job.combine.yml
+++ b/ci/job.combine.yml
@@ -6,6 +6,7 @@ parameters:
   pythons:
     - ThreeSix
     - ThreeSeven
+    - ThreeEight
   install_robot: conda install -yc conda-forge robotframework
 
 jobs:

--- a/ci/job.test.yml
+++ b/ci/job.test.yml
@@ -17,7 +17,7 @@ parameters:
       spec: '>=3.7,<3.8.0a0'
       lab: '>=1.2.4,<1.3.0a0'
     - name: ThreeEight
-      spec: '>=3.8,<3.7.0a0'
+      spec: '>=3.8,<3.9.0a0'
       lab: '>=1.2.4,<1.3.0a0'
   env_update: conda env update -n jupyterlab-lsp --file env-test.yml --quiet
   lab_ext: jupyter labextension install --no-build $(THIRD_PARTY_LABEXTENSIONS) $(FIRST_PARTY_LABEXTENSIONS)

--- a/ci/job.test.yml
+++ b/ci/job.test.yml
@@ -15,7 +15,10 @@ parameters:
       lab: '>=1.1,<1.2.0a0'
     - name: ThreeSeven
       spec: '>=3.7,<3.8.0a0'
-      lab: '>=1.2.3,<1.3.0a0'
+      lab: '>=1.2.4,<1.3.0a0'
+    - name: ThreeEight
+      spec: '>=3.8,<3.7.0a0'
+      lab: '>=1.2.4,<1.3.0a0'
   env_update: conda env update -n jupyterlab-lsp --file env-test.yml --quiet
   lab_ext: jupyter labextension install --no-build $(THIRD_PARTY_LABEXTENSIONS) $(FIRST_PARTY_LABEXTENSIONS)
 
@@ -38,13 +41,6 @@ jobs:
 
               - script: conda info && conda list -n jupyterlab-lsp
                 displayName: list conda packages and info
-
-              # TODO: determine how can bring this back to get more robust installs (see #115)
-              # - task: CacheBeta@0
-              #   inputs:
-              #     key: yarn | $(Agent.OS) | yarn.lock
-              #     path: $(YARN_CACHE_FOLDER)
-              #   displayName: restore cached yarn packages
 
               - script: ${{ platform.activate }} jupyterlab-lsp && jlpm || jlpm || jlpm
                 displayName: install npm dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   # runtime dependencies
   - python >=3.7,<3.8.0a0
-  - jupyterlab >=1.2.3,<1.3.0a0
+  - jupyterlab >=1.2.4,<1.3.0a0
   - notebook >=4.3.1
   # build dependencies
   - nodejs

--- a/requirements-lab.txt
+++ b/requirements-lab.txt
@@ -1,3 +1,3 @@
 # the version of jupyterlab
 -r requirements.txt
-jupyterlab >=1.2.3,<1.3.0a0
+jupyterlab >=1.2.4,<1.3.0a0

--- a/scripts/atest.py
+++ b/scripts/atest.py
@@ -19,7 +19,7 @@ PY = "".join(map(str, sys.version_info[:2]))
 
 OS_PY_ARGS = {
     # notebook and ipykernel releases do not yet support python 3.8 on windows
-    ("Windows", "38"): ["--exclude", "*"]
+    ("Windows", "38"): ["--include", "not-supported", "--runemptysuite"]
 }
 
 

--- a/scripts/atest.py
+++ b/scripts/atest.py
@@ -62,6 +62,8 @@ def atest(attempt, extra_args):
         f"OS:{OS}",
         "--variable",
         f"PY:{PY}",
+        "--randomize",
+        "all",
         *(extra_args or []),
         ATEST,
     ]

--- a/scripts/atest.py
+++ b/scripts/atest.py
@@ -5,6 +5,7 @@ import os
 import platform
 import shutil
 import sys
+import time
 from pathlib import Path
 
 import robot
@@ -95,7 +96,9 @@ def attempt_atest_with_retries(*extra_args):
     while error_count != 0 and attempt <= retries:
         attempt += 1
         print("attempt {} of {}...".format(attempt, retries + 1))
+        start_time = time.time()
         error_count = atest(attempt=attempt, extra_args=list(extra_args))
+        print(error_count, "errors in", int(time.time() - start_time), "seconds")
 
     return error_count
 

--- a/scripts/combine.py
+++ b/scripts/combine.py
@@ -24,7 +24,8 @@ def combine_robot_reports():
         *OUT.glob("*.robot.xml"),
     ]
 
-    rebot_cli(args, exit=False)
+    return_code = rebot_cli(args, exit=False)
+    print("rebot returned", return_code)
 
     return 0
 

--- a/scripts/combine.py
+++ b/scripts/combine.py
@@ -24,7 +24,9 @@ def combine_robot_reports():
         *OUT.glob("*.robot.xml"),
     ]
 
-    return rebot_cli(args, exit=False)
+    rebot_cli(args, exit=False)
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/utest.py
+++ b/scripts/utest.py
@@ -13,6 +13,8 @@ OS_PY_ARGS = {
     ("Windows", "38"): ["-k", "not serverextension"]
 }
 
+DEFAULT_ARGS = ["--cov-fail-under=100"]
+
 
 def run_tests():
     """ actually run the tests
@@ -27,9 +29,8 @@ def run_tests():
         "-p",
         "no:warnings",
         "--flake8",
-        "--cov-fail-under=100",
         "-vv",
-        *OS_PY_ARGS.get((OS, PY), []),
+        *OS_PY_ARGS.get((OS, PY), DEFAULT_ARGS),
     ] + list(sys.argv[1:])
 
     return pytest.main(args)

--- a/scripts/utest.py
+++ b/scripts/utest.py
@@ -1,8 +1,17 @@
 """ run python unit tests with pytest
 """
+import platform
 import sys
 
 import pytest
+
+OS = platform.system()
+PY = "".join(map(str, sys.version_info[:2]))
+
+OS_PY_ARGS = {
+    # notebook and ipykernel releases do not yet support python 3.8 on windows
+    ("Windows", "38"): ["-k", "not serverextension"]
+}
 
 
 def run_tests():
@@ -20,6 +29,7 @@ def run_tests():
         "--flake8",
         "--cov-fail-under=100",
         "-vv",
+        *OS_PY_ARGS.get((OS, PY), []),
     ] + list(sys.argv[1:])
 
     return pytest.main(args)


### PR DESCRIPTION
## References

- https://github.com/krassowski/jupyterlab-lsp/pull/146#issuecomment-573379944
  - adds 3.8 excursions
- https://github.com/krassowski/jupyterlab-lsp/pull/145#issuecomment-572315068
  - only retries failed tests

## Code changes

- [x] Moves the lab version detection up to the suite startup, which _should_ leave all the tests independent of each other. 
- [x] turns on test/suite order randomization, which should help shake out interdependencies between tests.
- [ ] marks `WHAT VERSIONS DO WE WANT` to be `--noncritical`, so that we don't get hard fails from stuff we know is flaky, but don't know how to unflake... yet

## User-facing changes

None

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
