### PR TITLE
Add manual packages installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ You can contribute to the project through:
 - proposing parts of the architecture that can be [extended](./EXTENDING.md)
 - improving [documentation](#Documentation)
 - tackling Big Issues from the [future roadmap](./ROADMAP.md)
-- improving [testing](#Testing)
+- improving testing
 - reviewing pull requests
 
 [jupyterlab-lsp]: https://github.com/krassowski/jupyterlab-lsp.git
@@ -74,6 +74,15 @@ jlpm build
 jlpm lab:link
 ```
 
+If `npm` dependencies did not get installed, you can trigger installation script for each package separately:
+
+```bash
+cd packages/jupyterlab-lsp
+jlpm install
+cd ../lsp-ws-connection
+npm install
+```
+
 ## Frontend Development
 
 To rebuild the schemas, packages, and the JupyterLab app:
@@ -129,7 +138,7 @@ Language Server features with [Robot Framework][] and [SeleniumLibrary][].
 First, ensure you've prepared JupyterLab for `jupyterlab-lsp`
 [frontend](#frontend-development) and [server](#server-development) development.
 
-Prepare the enviroment:
+Prepare the environment:
 
 ```bash
 conda env update -n jupyterlab-lsp --file environment-atest.yml
@@ -188,6 +197,8 @@ atest/
 - To display logs on the screenshots, write logs with `virtual_editor.console.log` method,
   and change `create_console('browser')` to `create_console('floating')` in `VirtualEditor`
   constructor (please feel free to add a config option for this).
+
+-
 
 ### Formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,8 +198,6 @@ atest/
   and change `create_console('browser')` to `create_console('floating')` in `VirtualEditor`
   constructor (please feel free to add a config option for this).
 
--
-
 ### Formatting
 
 Minimal code style is enforced with `pytest-flake8` during unit testing. If installed,


### PR DESCRIPTION
Yesterday I ran into a problem with packages and had to `rm -rf node_modules` (all of them). The frontend installation instruction did not work for me as it did not install deep dev dependencies.

I am a newbie to metapackages, lerna and other such things so I would just start by adding explicit instructions for manual install (but I guess that this might be solved by an improvement to the global-level `package.json`; there is also a small chance I am getting something wrong).

## Other changes

- Removed incorrect link to testing section (no such section, we have three of them - let's not confuse new contributors with a broken link)
- Fixed a typo

## Chores

- [x] linted
- [ ] tested
- [x] documented
- [ ] changelog entry
