### PR TITLE
Fix the (hopefully) last corner case of %R line magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@
   - rpy2 magics received enhanced support for argument parsing
     in both parent Python document (re-written overrides) and
     exctracted R documents (improved foreign code extractor) (
-    [#148](https://github.com/krassowski/jupyterlab-lsp/pull/148)
+    [#148](https://github.com/krassowski/jupyterlab-lsp/pull/148),
+    [#153](https://github.com/krassowski/jupyterlab-lsp/pull/153)
     )
   - console logs can now easily be redirected to a floating console
     windows for debugging of the browser tests (see CONTRIBUTING.md)

--- a/packages/jupyterlab-lsp/src/extractors/defaults.spec.ts
+++ b/packages/jupyterlab-lsp/src/extractors/defaults.spec.ts
@@ -63,23 +63,29 @@ describe('Default extractors', () => {
 
       let r_document = get_the_only_virtual(foreign_document_map);
       expect(r_document.language).to.equal('r');
-      expect(r_document.value).to.equal('df <- data.frame()\nggplot(df)\n');
+      expect(r_document.value).to.equal('df <- data.frame(); ggplot(df)\n');
+    });
+
+    it('parses input when no code is given', () => {
+      let code = '%R -i df';
+      let { foreign_document_map } = extract(code);
+
+      let r_document = get_the_only_virtual(foreign_document_map);
+      expect(r_document.value).to.equal('df <- data.frame();\n');
     });
 
     it('parses multiple inputs (into dummy data frames)', () => {
       let code = wrap_in_python_lines('%R -i df -i x ggplot(df)');
       let r_document = get_the_only_virtual(extract(code).foreign_document_map);
       expect(r_document.value).to.equal(
-        'df <- data.frame()\n' + 'x <- data.frame()\n' + 'ggplot(df)\n'
+        'df <- data.frame(); x <- data.frame(); ggplot(df)\n'
       );
     });
 
     it('parses inputs ignoring other arguments', () => {
       let code = wrap_in_python_lines('%R -i df --width 300 -o x ggplot(df)');
       let r_document = get_the_only_virtual(extract(code).foreign_document_map);
-      expect(r_document.value).to.equal(
-        'df <- data.frame()\n' + 'ggplot(df)\n'
-      );
+      expect(r_document.value).to.equal('df <- data.frame(); ggplot(df)\n');
     });
   });
 
@@ -101,6 +107,6 @@ describe('Default extractors', () => {
 
     let r_document = get_the_only_virtual(foreign_document_map);
     expect(r_document.language).to.equal('r');
-    expect(r_document.value).to.equal('df <- data.frame()\nggplot(df)\n');
+    expect(r_document.value).to.equal('df <- data.frame(); ggplot(df)\n');
   });
 });

--- a/packages/jupyterlab-lsp/src/extractors/defaults.ts
+++ b/packages/jupyterlab-lsp/src/extractors/defaults.ts
@@ -9,11 +9,17 @@ import {
 function rpy2_replacer(match: string, ...args: string[]) {
   let r = extract_r_args(args, -3);
   // define dummy input variables using empty data frames
-  let inputs = r.inputs.map(i => i + ' <- data.frame()').join('\n');
-  if (inputs !== '') {
-    inputs += '\n';
+  let inputs = r.inputs.map(i => i + ' <- data.frame();').join(' ');
+  let code: string;
+  if (typeof r.rest === 'undefined') {
+    code = '';
+  } else {
+    code = r.rest.startsWith(' ') ? r.rest.slice(1) : r.rest;
   }
-  return `${inputs}${r.rest}`;
+  if (inputs !== '' && code) {
+    inputs += ' ';
+  }
+  return `${inputs}${code}`;
 }
 
 // TODO: make the regex code extractors configurable
@@ -32,7 +38,7 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     }),
     new RegExpForeignCodeExtractor({
       language: 'r',
-      pattern: '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + ' (.*)\n?',
+      pattern: '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '( .*)?\n?',
       extract_to_foreign: rpy2_replacer,
       is_standalone: false,
       file_extension: 'R'

--- a/packages/jupyterlab-lsp/src/magics/rpy2.ts
+++ b/packages/jupyterlab-lsp/src/magics/rpy2.ts
@@ -20,7 +20,7 @@ export function extract_r_args(args: string[], content_position: number) {
   return {
     inputs: inputs,
     outputs: outputs,
-    rest: args.slice(content_position, content_position + 1),
+    rest: args[args.length + content_position],
     others: others
   };
 }


### PR DESCRIPTION
## References

Follows #144 with a fix for a case when `%R` line magic is used to import / export stuff but does not introduce any code to the R document, e.g. `%R -i data`.

## Code changes

In addition, the dummy assignments to introduce the imported varaibles are now all in one line with the line code; this might improve diagnostics until a better solution is in place.

## User-facing changes

None

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [ ] changelog entry
