### PR TITLE
Allow to hide chosen columns in diagnostics panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## `@krassowski/jupyterlab-lsp 0.7.1` (unreleased)
+
+- features
+
+  - users can now choose which columns to display/hide
+    in the diagnostic panel, using a context menu action (
+    [#159](https://github.com/krassowski/jupyterlab-lsp/pull/159)
+    )
+
 ## `lsp-ws-connection 0.3.1`
 
 - added `sendSaved()` method (textDocument/didSave) (

--- a/atest/01_Editor.robot
+++ b/atest/01_Editor.robot
@@ -112,12 +112,6 @@ Measure Cursor Position
     ${position} =    Wait Until Keyword Succeeds    20 x    0.05s    Get Vertical Position    ${CM CURSOR}
     [Return]    ${position}
 
-Open Context Menu Over
-    [Arguments]    ${sel}
-    Wait Until Keyword Succeeds    10 x    0.1 s    Mouse Over    ${sel}
-    Wait Until Keyword Succeeds    10 x    0.1 s    Click Element    ${sel}
-    Wait Until Keyword Succeeds    10 x    0.1 s    Open Context Menu    ${sel}
-
 Get Editor Content
     ${content}    Execute JavaScript    return document.querySelector('.CodeMirror').CodeMirror.getValue()
     [Return]    ${content}

--- a/atest/04_Interface/DiagnosticsPanel.robot
+++ b/atest/04_Interface/DiagnosticsPanel.robot
@@ -5,6 +5,9 @@ Resource          ../Keywords.robot
 *** Variables ***
 ${EXPECTED_COUNT}    1
 ${DIAGNOSTIC}     W291 trailing whitespace (pycodestyle)
+${DIAGNOSTIC MESSAGE}    trailing whitespace
+${MENU COLUMNS}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(text(), "columns")]
+${MENU COLUMN MESSAGE}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(text(), "Message")]
 
 *** Test Cases ***
 Diagnostics Panel Opens
@@ -34,6 +37,21 @@ Diagnostics Panel Can Be Restored
     Close Diagnostics Panel
     Open Diagnostics Panel
     Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count
+    [Teardown]    Clean Up After Working With File    Panel.ipynb
+
+Columns Can Be Hidden
+    [Setup]    Gently Reset Workspace
+    Open Notebook And Panel    Panel.ipynb
+    Wait Until Keyword Succeeds    10 x    1s    Element Should Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE}
+    Open Context Menu Over    css:.lsp-diagnostics-listing th
+    Capture Page Screenshot    01-menu-visible.png
+    Mouse Over    ${MENU COLUMNS}
+    Wait Until Page Contains Element    ${MENU COLUMN MESSAGE}    timeout=10s
+    Mouse Over    ${MENU COLUMN MESSAGE}
+    Capture Page Screenshot    02-message-column-visible.png
+    Click Element    ${MENU COLUMN MESSAGE}
+    Capture Page Screenshot    03-message-column-toggled.png
+    Wait Until Keyword Succeeds    10 x    1s    Element Should Not Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE}
     [Teardown]    Clean Up After Working With File    Panel.ipynb
 
 *** Keywords ***

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -203,3 +203,9 @@ Enter Cell Editor
 
 Wait Until Fully Initialized
     Wait Until Element Contains    ${STATUSBAR}    Fully initialized    timeout=35s
+
+Open Context Menu Over
+    [Arguments]    ${sel}
+    Wait Until Keyword Succeeds    10 x    0.1 s    Mouse Over    ${sel}
+    Wait Until Keyword Succeeds    10 x    0.1 s    Click Element    ${sel}
+    Wait Until Keyword Succeeds    10 x    0.1 s    Open Context Menu    ${sel}

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -60,6 +60,7 @@
     "@jupyterlab/testutils": "^1.2.2",
     "@jupyterlab/tooltip": "^1.1",
     "@phosphor/algorithm": "*",
+    "@phosphor/widgets": "*",
     "@types/chai": "^4.1.7",
     "@types/codemirror": "^0.0.74",
     "@types/events": "^3.0.0",
@@ -93,6 +94,7 @@
     "@jupyterlab/testutils": "^1.2.2",
     "@jupyterlab/tooltip": "^1.1",
     "@phosphor/algorithm": "*",
+    "@phosphor/widgets": "*",
     "codemirror": "*",
     "react": "*"
   },

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
@@ -110,7 +110,6 @@ export class Diagnostics extends CodeMirrorLSPFeature {
             type: 'submenu'
           });
           app.shell.add(panel_widget, 'main');
-          //app.commands.addCommand('lsp-panel-columns', {})
         }
         app.shell.activateById(panel_widget.id);
       },

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
@@ -23,6 +23,7 @@ const default_severity = 2;
 class DiagnosticsPanel {
   content: DiagnosticsListing;
   widget: MainAreaWidget<DiagnosticsListing>;
+  is_registered = false;
 
   constructor() {
     this.widget = this.init_widget();
@@ -82,7 +83,7 @@ export class Diagnostics extends CodeMirrorLSPFeature {
           }
         };
 
-        if (!panel_widget.isAttached) {
+        if (!diagnostics_panel.is_registered) {
           let columns_menu = new Menu({ commands: app.commands });
           app.commands.addCommand(CMD_COLUMN_VISIBILITY, {
             execute: args => {
@@ -108,6 +109,10 @@ export class Diagnostics extends CodeMirrorLSPFeature {
             submenu: columns_menu,
             type: 'submenu'
           });
+          diagnostics_panel.is_registered = true;
+        }
+
+        if (!panel_widget.isAttached) {
           app.shell.add(panel_widget, 'main');
         }
         app.shell.activateById(panel_widget.id);

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
@@ -103,7 +103,6 @@ export class Diagnostics extends CodeMirrorLSPFeature {
               args: { name: column.name }
             });
           }
-          console.log(columns_menu);
           app.contextMenu.addItem({
             selector: '.' + DIAGNOSTICS_LISTING_CLASS + ' th',
             submenu: columns_menu,

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
@@ -110,7 +110,10 @@ interface IDiagnosticsRow {
   data: IEditorDiagnostic;
   key: string;
   document: VirtualDocument;
-  cell_nr?: number;
+  /**
+   * Cell number is the ordinal, 1-based cell identifier displayed to the user.
+   */
+  cell_number?: number;
 }
 
 interface IListingContext {
@@ -223,8 +226,8 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     }),
     new Column({
       name: 'Cell',
-      render_cell: row => <td>{row.cell_nr}</td>,
-      sort: (a, b) => (a.cell_nr > b.cell_nr ? 1 : -1),
+      render_cell: row => <td>{row.cell_number}</td>,
+      sort: (a, b) => (a.cell_number > b.cell_number ? 1 : -1),
       is_available: context => context.editor.has_cells
     }),
     new Column({
@@ -265,19 +268,19 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     let by_document = Array.from(diagnostics_db).map(
       ([virtual_document, diagnostics]) => {
         return diagnostics.map((diagnostic_data, i) => {
-          let cell_nr: number = null;
+          let cell_number: number = null;
           if (editor.has_cells) {
             let notebook_editor = editor as VirtualEditorForNotebook;
             let { cell_id } = notebook_editor.find_cell_by_editor(
               diagnostic_data.editor
             );
-            cell_nr = cell_id + 1;
+            cell_number = cell_id + 1;
           }
           return {
             data: diagnostic_data,
             key: virtual_document.uri + ',' + i,
             document: virtual_document,
-            cell_nr: cell_nr,
+            cell_number: cell_number,
             editor: editor
           } as IDiagnosticsRow;
         });

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
@@ -288,7 +288,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     let sorted_column = this.columns.filter(
       column => column.name === this.sort_key
     )[0];
-    let sorter = sorted_column.sort;
+    let sorter = sorted_column.sort.bind(sorted_column);
     let sorted = flattened.sort((a, b) => sorter(a, b) * this.sort_direction);
 
     let context: IListingContext = {

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics_listing.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
 import * as lsProtocol from 'vscode-languageserver-protocol';
 import * as CodeMirror from 'codemirror';
@@ -24,6 +24,8 @@ export interface IEditorDiagnostic {
     end: IEditorPosition;
   };
 }
+
+export const DIAGNOSTICS_LISTING_CLASS = 'lsp-diagnostics-listing';
 
 export class DiagnosticsDatabase extends Map<
   VirtualDocument,
@@ -111,41 +113,132 @@ interface IDiagnosticsRow {
   cell_nr?: number;
 }
 
-const sorters: Record<
-  string,
-  (a: IDiagnosticsRow, b: IDiagnosticsRow) => number
-> = {
-  'Virtual Document': (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return a.document.id_path.localeCompare(b.document.id_path);
-  },
-  Message: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return a.data.diagnostic.message.localeCompare(b.data.diagnostic.message);
-  },
-  Source: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return a.data.diagnostic.source.localeCompare(b.data.diagnostic.source);
-  },
-  Code: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return (a.data.diagnostic.code + '').localeCompare(
-      b.data.diagnostic.source + ''
-    );
-  },
-  Severity: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return a.data.diagnostic.severity > b.data.diagnostic.severity ? 1 : -1;
-  },
-  Line: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return a.data.range.start.line > b.data.range.start.line ? 1 : -1;
-  },
-  Ch: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return a.data.range.start.ch > b.data.range.start.ch ? 1 : -1;
-  },
-  Cell: (a: IDiagnosticsRow, b: IDiagnosticsRow) => {
-    return a.cell_nr > b.cell_nr ? 1 : -1;
+interface IListingContext {
+  db: DiagnosticsDatabase;
+  editor: VirtualEditor;
+}
+
+interface IColumnOptions {
+  name: string;
+  render_cell(data: IDiagnosticsRow, context?: IListingContext): ReactElement;
+  sort(a: IDiagnosticsRow, b: IDiagnosticsRow): number;
+  is_available?(context: IListingContext): boolean;
+}
+
+class Column {
+  public is_visible: boolean;
+
+  constructor(private options: IColumnOptions) {
+    this.is_visible = true;
   }
-};
+
+  render_cell(data: IDiagnosticsRow, context: IListingContext) {
+    return this.options.render_cell(data, context);
+  }
+
+  sort(a: IDiagnosticsRow, b: IDiagnosticsRow) {
+    return this.options.sort(a, b);
+  }
+
+  get name(): string {
+    return this.options.name;
+  }
+
+  is_available(context: IListingContext) {
+    if (typeof this.options.is_available !== 'undefined') {
+      return this.options.is_available(context);
+    }
+    return true;
+  }
+
+  render_header(listing: DiagnosticsListing): ReactElement {
+    return <SortableTH name={this.name} listing={listing} />;
+  }
+}
+
+function SortableTH(props: { name: string; listing: DiagnosticsListing }): any {
+  const is_sort_key = props.name === props.listing.sort_key;
+  return (
+    <th
+      onClick={() => props.listing.sort(props.name)}
+      className={
+        is_sort_key
+          ? 'lsp-sorted ' +
+            (props.listing.sort_direction === 1 ? 'lsp-descending' : '')
+          : ''
+      }
+    >
+      {props.name}
+      {is_sort_key ? <span className={'lsp-caret'} /> : null}
+    </th>
+  );
+}
 
 export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
   sort_key = 'Severity';
   sort_direction = 1;
+
+  columns = [
+    new Column({
+      name: 'Virtual Document',
+      render_cell: (row, context) => (
+        <td>
+          <DocumentLocator document={row.document} editor={context.editor} />
+        </td>
+      ),
+      sort: (a, b) => a.document.id_path.localeCompare(b.document.id_path),
+      is_available: context => context.db.size > 1
+    }),
+    new Column({
+      name: 'Message',
+      render_cell: row => {
+        let message = message_without_code(row.data.diagnostic);
+        return <td>{message}</td>;
+      },
+      sort: (a, b) =>
+        a.data.diagnostic.message.localeCompare(b.data.diagnostic.message)
+    }),
+    new Column({
+      name: 'Code',
+      render_cell: row => <td>{row.data.diagnostic.code}</td>,
+      sort: (a, b) =>
+        (a.data.diagnostic.code + '').localeCompare(
+          b.data.diagnostic.source + ''
+        )
+    }),
+    new Column({
+      name: 'Severity',
+      // TODO: use default diagnostic severity
+      render_cell: row => (
+        <td>{diagnosticSeverityNames[row.data.diagnostic.severity || 1]}</td>
+      ),
+      sort: (a, b) =>
+        a.data.diagnostic.severity > b.data.diagnostic.severity ? 1 : -1
+    }),
+    new Column({
+      name: 'Source',
+      render_cell: row => <td>{row.data.diagnostic.source}</td>,
+      sort: (a, b) =>
+        a.data.diagnostic.source.localeCompare(b.data.diagnostic.source)
+    }),
+    new Column({
+      name: 'Cell',
+      render_cell: row => <td>{row.cell_nr}</td>,
+      sort: (a, b) => (a.cell_nr > b.cell_nr ? 1 : -1),
+      is_available: context => context.editor.has_cells
+    }),
+    new Column({
+      name: 'Line',
+      render_cell: row => <td>{row.data.range.start.line}</td>,
+      sort: (a, b) =>
+        a.data.range.start.line > b.data.range.start.line ? 1 : -1
+    }),
+    new Column({
+      name: 'Ch',
+      render_cell: row => <td>{row.data.range.start.line}</td>,
+      sort: (a, b) => (a.data.range.start.ch > b.data.range.start.ch ? 1 : -1)
+    })
+  ];
 
   constructor(model: DiagnosticsListing.Model) {
     super();
@@ -168,7 +261,6 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     if (!diagnostics_db || typeof editor === 'undefined') {
       return <div>No issues detected, great job!</div>;
     }
-    let documents_count = diagnostics_db.size;
 
     let by_document = Array.from(diagnostics_db).map(
       ([virtual_document, diagnostics]) => {
@@ -185,82 +277,58 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
             data: diagnostic_data,
             key: virtual_document.uri + ',' + i,
             document: virtual_document,
-            cell_nr: cell_nr
+            cell_nr: cell_nr,
+            editor: editor
           } as IDiagnosticsRow;
         });
       }
     );
     let flattened: IDiagnosticsRow[] = [].concat.apply([], by_document);
 
-    let sorter = sorters[this.sort_key];
+    let sorted_column = this.columns.filter(
+      column => column.name === this.sort_key
+    )[0];
+    let sorter = sorted_column.sort;
     let sorted = flattened.sort((a, b) => sorter(a, b) * this.sort_direction);
 
-    let elements = sorted.map(({ data, key, document, cell_nr }) => {
-      let diagnostic = data.diagnostic;
+    let context: IListingContext = {
+      db: diagnostics_db,
+      editor: editor
+    };
 
-      let cm_editor = data.editor;
+    let columns_to_display = this.columns.filter(
+      column => column.is_available(context) && column.is_visible
+    );
 
-      let message = message_without_code(diagnostic);
-      let severity = diagnostic.severity || 1;
+    let elements = sorted.map(row => {
+      let cm_editor = row.data.editor;
+
+      let cells = columns_to_display.map(column =>
+        column.render_cell(row, context)
+      );
 
       return (
         <tr
-          key={key}
+          key={row.key}
           onClick={() => {
             focus_on(cm_editor.getWrapperElement());
-            cm_editor.getDoc().setCursor(data.range.start);
+            cm_editor.getDoc().setCursor(row.data.range.start);
             cm_editor.focus();
           }}
         >
-          {documents_count > 1 ? (
-            <td>
-              <DocumentLocator document={document} editor={editor} />
-            </td>
-          ) : null}
-          <td>{message}</td>
-          <td>{diagnostic.code}</td>
-          <td>{diagnosticSeverityNames[severity]}</td>
-          <td>{diagnostic.source}</td>
-          {editor.has_cells ? <td>{cell_nr}</td> : null}
-          <td>{data.range.start.line}</td>
-          <td>{data.range.start.ch}</td>
+          {cells}
         </tr>
       );
     });
 
-    let SortableTH = (props: { name: string }): any => {
-      const is_sort_key = props.name === this.sort_key;
-      return (
-        <th
-          onClick={() => this.sort(props.name)}
-          className={
-            is_sort_key
-              ? 'lsp-sorted ' +
-                (this.sort_direction === 1 ? 'lsp-descending' : '')
-              : ''
-          }
-        >
-          {props.name}
-          {is_sort_key ? <span className={'lsp-caret'} /> : null}
-        </th>
-      );
-    };
+    let columns_headers = columns_to_display.map(column =>
+      column.render_header(this)
+    );
 
     return (
-      <table className={'lsp-diagnostics-listing'}>
+      <table className={DIAGNOSTICS_LISTING_CLASS}>
         <thead>
-          <tr>
-            {documents_count > 1 ? (
-              <SortableTH name={'Virtual Document'} />
-            ) : null}
-            <SortableTH name={'Message'} />
-            <SortableTH name={'Code'} />
-            <SortableTH name={'Severity'} />
-            <SortableTH name={'Source'} />
-            {editor.has_cells ? <SortableTH name={'Cell'} /> : null}
-            <SortableTH name={'Line'} />
-            <SortableTH name={'Ch'} />
-          </tr>
+          <tr>{columns_headers}</tr>
         </thead>
         <tbody>{elements}</tbody>
       </table>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1313,10 +1313,10 @@
     typestyle "^2.0.1"
 
 "@krassowski/jupyterlab-lsp@file:packages/jupyterlab-lsp":
-  version "0.6.1"
+  version "0.7.0"
   dependencies:
     "@krassowski/jupyterlab_go_to_definition" "^0.7.1"
-    lsp-ws-connection "*"
+    lsp-ws-connection "0.3.1"
 
 "@krassowski/jupyterlab_go_to_definition@^0.7.1":
   version "0.7.1"
@@ -2168,7 +2168,7 @@
   dependencies:
     "@phosphor/algorithm" "^1.2.0"
 
-"@phosphor/widgets@^1.9.0", "@phosphor/widgets@^1.9.3":
+"@phosphor/widgets@*", "@phosphor/widgets@^1.9.0", "@phosphor/widgets@^1.9.3":
   version "1.9.3"
   resolved "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.9.3.tgz#b8b7ad69fd7cc7af8e8c312ebead0e0965a4cefd"
   integrity sha512-61jsxloDrW/+WWQs8wOgsS5waQ/MSsXBuhONt0o6mtdeL93HVz7CYO5krOoot5owammfF6oX1z0sDaUYIYgcPA==
@@ -7346,7 +7346,7 @@ lru-queue@0.1:
     es5-ext "~0.10.2"
 
 "lsp-ws-connection@file:packages/lsp-ws-connection":
-  version "0.2.0"
+  version "0.3.1"
   dependencies:
     vscode-jsonrpc "^4.1.0-next"
     vscode-languageclient "^5.2.1"


### PR DESCRIPTION
Allows choosing which columns to display/hide in the diagnostic panel, using a context menu action.

## References

Closes #149 

## Code changes

Greatly simplifies the `DiagnosticListing.render()` function body by moving the column-specific code to a newly created `Column` class (not exported).  A new interface `IListingContext` facilitates this transition.

## User-facing changes

![Screenshot from 2020-01-18 11-59-47](https://user-images.githubusercontent.com/5832902/72663375-17a45e80-39ea-11ea-8420-e8430ab2f178.png)

## Backwards-incompatible changes

None.

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
