### PR TITLE
Fix various bugs in the completer feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
     [#159](https://github.com/krassowski/jupyterlab-lsp/pull/159)
     )
 
+- bugfixes
+
+  - fixed various small bugs in the completer (
+    [#162](https://github.com/krassowski/jupyterlab-lsp/pull/162)
+    )
+
 ## `lsp-ws-connection 0.3.1`
 
 - added `sendSaved()` method (textDocument/didSave) (

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -59,6 +59,7 @@ User Can Select Lowercase After Starting Uppercase
     [Tags]    language:python
     Setup Notebook    Python    Completion.ipynb
     # `from time import Tim<tab>` → `from time import time`
+    Wait Until Fully Initialized
     Enter Cell Editor    5    line=1
     Trigger Completer
     Completer Should Suggest    time

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -198,8 +198,13 @@ Gently Reset Workspace
 
 Enter Cell Editor
     [Arguments]    ${cell_nr}    ${line}=1
-    Click Element    css:.jp-CodeCell:nth-child(${cell_nr}) .CodeMirror-line:nth-child(${line})
-    Wait Until Page Contains Element    css:.jp-CodeCell:nth-child(${cell_nr}) .CodeMirror-focused
+    Click Element    css:.jp-Cell:nth-child(${cell_nr}) .CodeMirror-line:nth-child(${line})
+    Wait Until Page Contains Element    css:.jp-Cell:nth-child(${cell_nr}) .CodeMirror-focused
+
+Place Cursor In Cell Editor At
+    [Arguments]    ${cell_nr}    ${line}    ${character}
+    Enter Cell Editor    ${cell_nr}    ${line}
+    Execute JavaScript    return document.querySelector('.jp-Cell:nth-child(${cell_nr}) .CodeMirror').CodeMirror.setCursor({line: ${line} - 1, ch: ${character}})
 
 Wait Until Fully Initialized
     Wait Until Element Contains    ${STATUSBAR}    Fully initialized    timeout=35s

--- a/atest/examples/Completion.ipynb
+++ b/atest/examples/Completion.ipynb
@@ -29,12 +29,100 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`from time import Tim<tab>` → `from time import time`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from time import Tim"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setup (not a test case)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def display_table():\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`disp<tab>data` → `display_table<cursor>data`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dispdata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`disp<tab>lay` → `display_table<cursor>`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`from statistics <tab>` → `from statistics import<cursor>`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from statistics "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`import os.pat<tab>` → select `pathsep` → `import os.pathsep` (tests whether kernel prefixes are removed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os.pat"
    ]
   }
  ],

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/completion.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/components/completion.ts
@@ -111,6 +111,7 @@ export class LSPConnector extends DataConnector<
     const start = editor.getPositionAt(token.offset);
     const end = editor.getPositionAt(token.offset + token.value.length);
 
+    let position_in_token = cursor.column - start.column - 1;
     const typed_character = token.value[cursor.column - start.column - 1];
 
     let start_in_root = this.transform_from_editor_to_root(start);
@@ -150,7 +151,8 @@ export class LSPConnector extends DataConnector<
             virtual_start,
             virtual_end,
             virtual_cursor,
-            document
+            document,
+            position_in_token
           )
         ]).then(([kernel, lsp]) =>
           this.merge_replies(kernel, lsp, this._editor)
@@ -163,7 +165,8 @@ export class LSPConnector extends DataConnector<
         virtual_start,
         virtual_end,
         virtual_cursor,
-        document
+        document,
+        position_in_token
       ).catch(e => {
         console.warn('LSP: hint failed', e);
         return this.fallback_connector.fetch(request);
@@ -180,7 +183,8 @@ export class LSPConnector extends DataConnector<
     start: IVirtualPosition,
     end: IVirtualPosition,
     cursor: IVirtualPosition,
-    document: VirtualDocument
+    document: VirtualDocument,
+    position_in_token: number
   ): Promise<CompletionHandler.IReply> {
     let connection = this._connections.get(document.id_path);
 
@@ -190,7 +194,7 @@ export class LSPConnector extends DataConnector<
     // to the matches...
     // Suggested in https://github.com/jupyterlab/jupyterlab/issues/7044, TODO PR
 
-    console.log(token);
+    console.log('[LSP][Completer] Token:', token);
 
     let completion_items: lsProtocol.CompletionItem[] = [];
     await connection
@@ -208,6 +212,8 @@ export class LSPConnector extends DataConnector<
         completion_items = items || [];
       });
 
+    let prefix = token.value.slice(0, position_in_token + 1);
+
     let matches: Array<string> = [];
     const types: Array<IItemType> = [];
     let all_non_prefixed = true;
@@ -219,10 +225,22 @@ export class LSPConnector extends DataConnector<
       // kind: 3
       // label: "mean(data)"
       // sortText: "amean"
+
+      // TODO: add support for match.textEdit
       let text = match.insertText ? match.insertText : match.label;
 
-      if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
+      if (text.toLowerCase().startsWith(prefix.toLowerCase())) {
         all_non_prefixed = false;
+        if (prefix !== token.value) {
+          if (text.toLowerCase().startsWith(token.value.toLowerCase())) {
+            // given a completion insert text "display_table" and two test cases:
+            // disp<tab>data →  display_table<cursor>data
+            // disp<tab>lay  →  display_table<cursor>
+            // we have to adjust the prefix for the latter (otherwise we would get display_table<cursor>lay),
+            // as we are constrained NOT to replace after the prefix (which would be "disp" otherwise)
+            prefix = token.value;
+          }
+        }
       }
 
       matches.push(text);
@@ -243,7 +261,7 @@ export class LSPConnector extends DataConnector<
       // text = token.value + text;
       // but it did not work for "from statistics <tab>" and lead to "from statisticsimport" (no space)
       start: token.offset + (all_non_prefixed ? 1 : 0),
-      end: token.offset + token.value.length,
+      end: token.offset + prefix.length,
       matches: matches,
       metadata: {
         _jupyter_types_experimental: types
@@ -266,7 +284,7 @@ export class LSPConnector extends DataConnector<
     } else if (lsp.matches.length === 0) {
       return kernel;
     }
-    console.log('merging LSP and kernel completions:', lsp, kernel);
+    console.log('[LSP][Completer] Merging completions:', lsp, kernel);
 
     // Populate the result with a copy of the lsp matches.
     const matches = lsp.matches.slice();
@@ -285,8 +303,10 @@ export class LSPConnector extends DataConnector<
     if (lsp.start > kernel.start) {
       const cursor = editor.getCursorPosition();
       const line = editor.getLine(cursor.line);
-      prefix = line.substring(cursor.column - 1, cursor.column);
-      console.log('will remove prefix from kernel response:', prefix);
+      prefix = line.substring(kernel.start, lsp.start);
+      console.log('[LSP][Completer] Removing kernel prefix: ', prefix);
+    } else if (lsp.start < kernel.start) {
+      console.warn('[LSP][Completer] Kernel start > LSP start');
     }
 
     let remove_prefix = (value: string) => {


### PR DESCRIPTION
## References

Fixes the completer issues as detailed in #30, adding many test cases.

## Code changes

Bugfixes only. New useful robot keywords:
- `Place Cursor In Cell Editor At` (global, in addition to entering a specific cell and line allows to set cursor after a specific character), and
- `Select Completer Suggestion` (Completer)

## User-facing changes

Well, the completer is now (fully?) reliable ;)

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
