### PR TITLE
Correctly display documentation of signature returned as MarkupContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   - fixed various small bugs in the completer (
     [#162](https://github.com/krassowski/jupyterlab-lsp/pull/162)
     )
+  - fix documentation display in signature for LSP servers which
+    return MarkupContent (
+    [#164](https://github.com/krassowski/jupyterlab-lsp/pull/164)
+    )
 
 ## `lsp-ws-connection 0.3.1`
 

--- a/atest/05_Features/Signature.robot
+++ b/atest/05_Features/Signature.robot
@@ -1,5 +1,6 @@
 *** Settings ***
-Suite Setup       Setup Suite For Screenshots    completion
+Suite Setup       Setup Suite For Screenshots    signature
+Force Tags        feature:signature
 Resource          ../Keywords.robot
 
 *** Variables ***


### PR DESCRIPTION
## References

Fixes #161

## Code changes

Sadly no browser test for this yet. My faild attempt was:

```robot
Signature Displays Markdown Documentation
    Setup Notebook    Python        Signature.ipynb
    Enter Cell Editor    3    line=2
    Wait Until Fully Initialized
    Press Keys    None    (
    Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
    # `list(`
    # should show: "Functions to construct, coerce and check for both kinds of <strong>R</strong> lists."
    Element Should Contain    ${SIGNATURE_BOX}    Functions to construct, coerce and check for both kinds of R lists.
    Element Should Contain    ${SIGNATURE_BOX} strong    R
    [Teardown]    Clean Up After Working With File    Signature.ipynb
```

Where cell 3rd was:
```
%%R
line
```

but I got stuck on `Wait Until Fully Initialized`  - some problems with the R languageserver (strangely, only during tests...)

## User-facing changes

![Screenshot from 2020-01-19 17-59-44](https://user-images.githubusercontent.com/5832902/72685809-8dd9bb80-3ae5-11ea-8b2e-f6531f571e51.png)

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
