### PR TITLE
Start the diagnostics panel docked at the bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
     return MarkupContent (
     [#164](https://github.com/krassowski/jupyterlab-lsp/pull/164)
     )
+  - Start the diagnostics panel docked at the bottom and improve
+    the re-spawning of the (closed) diagnostics panel (
+    [#166](https://github.com/krassowski/jupyterlab-lsp/pull/166)
+    )
 
 ## `lsp-ws-connection 0.3.1`
 

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
@@ -21,24 +21,29 @@ import { VirtualEditor } from '../../../virtual/editor';
 const default_severity = 2;
 
 class DiagnosticsPanel {
-  content: DiagnosticsListing;
-  widget: MainAreaWidget<DiagnosticsListing>;
+  private _content: DiagnosticsListing = null;
+  private _widget: MainAreaWidget<DiagnosticsListing> = null;
   is_registered = false;
 
-  constructor() {
-    this.widget = this.init_widget();
-    this.widget.content.disposed.connect(() => {
-      // immortal widget (or mild memory leak) TODO: rewrite this
-      this.widget.dispose();
-      this.widget = this.init_widget();
-    });
+  get widget() {
+    if (this._widget == null || this._widget.content.model === null) {
+      if (this._widget && !this._widget.isDisposed) {
+        this._widget.dispose();
+      }
+      this._widget = this.init_widget();
+    }
+    return this._widget;
   }
 
-  init_widget() {
-    this.content = new DiagnosticsListing(new DiagnosticsListing.Model());
-    this.content.model.diagnostics = new DiagnosticsDatabase();
-    this.content.addClass('lsp-diagnostics-panel-content');
-    const widget = new MainAreaWidget({ content: this.content });
+  get content() {
+    return this.widget.content;
+  }
+
+  protected init_widget() {
+    this._content = new DiagnosticsListing(new DiagnosticsListing.Model());
+    this._content.model.diagnostics = new DiagnosticsDatabase();
+    this._content.addClass('lsp-diagnostics-panel-content');
+    const widget = new MainAreaWidget({ content: this._content });
     widget.id = 'lsp-diagnostics-panel';
     widget.title.label = 'Diagnostics Panel';
     widget.title.closable = true;

--- a/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/adapters/codemirror/features/diagnostics.ts
@@ -68,7 +68,7 @@ export class Diagnostics extends CodeMirrorLSPFeature {
   static commands: Array<IFeatureCommand> = [
     {
       id: 'show-diagnostics-panel',
-      execute: ({ app, features }) => {
+      execute: ({ app, features, adapter }) => {
         let diagnostics_feature = features.get('Diagnostics') as Diagnostics;
         diagnostics_feature.switchDiagnosticsPanelSource();
 
@@ -113,7 +113,11 @@ export class Diagnostics extends CodeMirrorLSPFeature {
         }
 
         if (!panel_widget.isAttached) {
-          app.shell.add(panel_widget, 'main');
+          console.warn(adapter.widget_id);
+          app.shell.add(panel_widget, 'main', {
+            ref: adapter.widget_id,
+            mode: 'split-bottom'
+          });
         }
         app.shell.activateById(panel_widget.id);
       },

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
@@ -150,6 +150,10 @@ export abstract class JupyterLabWidgetAdapter
   abstract get mime_type(): string;
   protected abstract connect_completion(): void;
 
+  get widget_id(): string {
+    return this.widget.id;
+  }
+
   get language(): string {
     // the values should follow https://microsoft.github.io/language-server-protocol/specification guidelines
     if (mime_type_language_map.hasOwnProperty(this.mime_type)) {
@@ -425,7 +429,8 @@ export abstract class JupyterLabWidgetAdapter
       root_position,
       features: this.get_features(document),
       editor: this.virtual_editor,
-      app: this.app
+      app: this.app,
+      adapter: this
     };
   }
 

--- a/packages/jupyterlab-lsp/src/command_manager.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.ts
@@ -257,4 +257,5 @@ export interface ICommandContext {
   root_position: IRootPosition;
   features: Map<string, ILSPFeature>;
   editor: VirtualEditor;
+  adapter: JupyterLabWidgetAdapter;
 }


### PR DESCRIPTION
## References

Fixes #157 

## Code changes

Added `adapter` to the command context, but kept the widget private to keep the code from getting more inter-dependent.

## User-facing changes

Diagnostics panel open at the bottom, by splitting the active widget in half. 

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
