### PR TITLE
[do not merge] blacklist bad zipp version

### DIFF
--- a/ci/env-test.yml.in
+++ b/ci/env-test.yml.in
@@ -25,6 +25,7 @@ dependencies:
   - pytest-flake8
   - pytest-runner
   - ruamel_yaml
+  - zipp !=2.0.0
   # browser testing
   - firefox
   - geckodriver

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pylint
   - python-language-server
   - ruamel_yaml
+  - zipp !=2.0.0
   - pip: # not-yet-appearing-in-conda-forge
       - pyls-black
       - pyls-isort


### PR DESCRIPTION
## References

- fixes #173

## Code changes

- pins `zipp !=2.0.0`

## User-facing changes

None

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
