### PR TITLE
Bump Azure CI to run on macOS-10.14 (was .13)

### DIFF
--- a/ci/job.test.yml
+++ b/ci/job.test.yml
@@ -4,7 +4,7 @@ parameters:
       vmImage: ubuntu-16.04
       activate: source activate
     - name: MacOSX
-      vmImage: macos-10.13
+      vmImage: macos-10.14
       activate: source activate
     - name: Windows
       vmImage: vs2017-win2016


### PR DESCRIPTION
## References

#178 

## Code changes

None

## User-facing changes

None

## Backwards-incompatible changes

None

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry