### PR TITLE
Remove --pre from pip install instructons

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Use of a python `virtualenv` or a conda env is also recommended.
 1. install the server extension:
 
    ```bash
-   pip install --pre jupyter-lsp
+   pip install jupyter-lsp
    ```
 
 1. install `nodejs`


### PR DESCRIPTION
Its no longer needed, and severely annoying when combining with pipenv (as this enables pre mode for the whole project , which can and will break other things.)

I brutally scrapped the whole template for how to contribute a patch and I think I'll let the diff speak for itself 😂. Loving the project and I'm eagerly watching the changes happening, great job so far 👍.