### PR TITLE
Release v1.0.0 (compatible with JupyterLab 2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## CHANGELOG
 
-### `@krassowski/jupyterlab-lsp 1.0.0` (unreleased)
+### `@krassowski/jupyterlab-lsp 1.0.0` (2020-03-14)
 
 - features
 
   - supports JupyterLab 2.0
 
-### `@krassowski/jupyterlab_go_to_definition 1.0.0` (unreleased)
+### `@krassowski/jupyterlab_go_to_definition 1.0.0` (2020-03-14)
 
 - features
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ Use of a python `virtualenv` or a conda env is also recommended.
 1. install the frontend extension:
 
    ```bash
-   jupyter labextension install @krassowski/jupyterlab-lsp
+   jupyter labextension install @krassowski/jupyterlab-lsp           # for JupyterLab 2.x
+   # jupyter labextension install @krassowski/jupyterlab-lsp@0.8.0   # for JupyterLab 1.x
    ```
 
 1. install LSP servers for languages of your choice; for example, for Python


### PR DESCRIPTION
Release v1.0.0

## Chores

- [x] linted
- [ ] tested
- [x] documented
- [x] changelog entry
