### PR TITLE
Don't use hardcoded color for fuzzy highlight, show outline when in active line

### DIFF
--- a/packages/jupyterlab-lsp/style/index.css
+++ b/packages/jupyterlab-lsp/style/index.css
@@ -39,8 +39,6 @@
   background-color: var(--jp-layout-color2);
 }
 
-/* fuzzy matches (not exact symbol matches) */
-.cm-lsp-highlight-Text {
-  background-color: #ddeeee;
-  box-shadow: 0 0 3px 3px #ddeeee;
+.CodeMirror-activeline .cm-lsp-highlight {
+  outline: 1px dotted var(--jp-layout-color3);
 }


### PR DESCRIPTION
## References

Fixes #195. I gave up on having a different style for fuzzy matches - it does not seem to be something that others editors do, and there is no reasonable support from the servers for the distinction between fuzzy and exact highlight.

As this still uses the same colour as is used for line highlights, I added a small dotted outline when in the active line.

## User-facing changes

When using the dark theme, the fuzzy highlights (as returned by R language server) are now readable and indistinguishable from normal highlights:
![Screenshot from 2020-03-22 10-33-52](https://user-images.githubusercontent.com/5832902/77247440-2fd26d00-6c29-11ea-8771-fccc869f4e10.png)
![Screenshot from 2020-03-22 10-33-42](https://user-images.githubusercontent.com/5832902/77247441-306b0380-6c29-11ea-8277-5aec36d9d3f9.png)

There is a very subtle outline added for active line:
![Screenshot from 2020-03-22 10-33-21](https://user-images.githubusercontent.com/5832902/77247442-306b0380-6c29-11ea-848d-58dbfdad699d.png)
![Screenshot from 2020-03-22 10-33-01](https://user-images.githubusercontent.com/5832902/77247444-31039a00-6c29-11ea-84fa-7e50cb54f68f.png)

Same with the light theme:
![Screenshot from 2020-03-22 10-32-41](https://user-images.githubusercontent.com/5832902/77247445-319c3080-6c29-11ea-92e9-782f194f9682.png)
![Screenshot from 2020-03-22 10-32-19](https://user-images.githubusercontent.com/5832902/77247446-319c3080-6c29-11ea-9a1c-21a2a268db52.png)
![Screenshot from 2020-03-22 10-32-08](https://user-images.githubusercontent.com/5832902/77247447-3234c700-6c29-11ea-996a-889bfed9073a.png)
![Screenshot from 2020-03-22 10-32-01](https://user-images.githubusercontent.com/5832902/77247448-32cd5d80-6c29-11ea-85d3-983ce0475cd6.png)

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
