### PR TITLE
Allow jlab version lesser than 3.0.0a0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Open it searching for "Show diagnostics panel" in JupyterLab commands palette or
 
 Either:
 
-- JupyterLab >=2,<2.1
+- JupyterLab >=2,<3.0.0a0
 
 And:
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   # runtime dependencies
   - python >=3.7,<3.8.0a0
-  - jupyterlab >=2,<2.1.0a0
+  - jupyterlab >=2,<3.0.0a0
   - notebook >=4.3.1
   # build dependencies
   - nodejs

--- a/ci/job.docs.yml
+++ b/ci/job.docs.yml
@@ -6,7 +6,7 @@ parameters:
   pythons:
     - name: ThreeSeven
       spec: '>=3.7,<3.8.0a0'
-      lab: '>=2,<2.1.0a0'
+      lab: '>=2,<3.0.0a0'
       nodejs: '>=12,<13.0.0a0'
   env_update: conda env update -n jupyterlab-lsp --file env-test.yml --quiet
   env_docs: conda env update -n jupyterlab-lsp --file requirements/docs.yml --quiet

--- a/ci/job.lint.yml
+++ b/ci/job.lint.yml
@@ -6,7 +6,7 @@ parameters:
   pythons:
     - name: ThreeSeven
       spec: '>=3.7,<3.8.0a0'
-      lab: '>=2,<2.1.0a0'
+      lab: '>=2,<3.0.0a0'
       nodejs: '>=12,<13.0.0a0'
   env_update: conda env update -n jupyterlab-lsp --file env-test.yml --quiet
   env_lint: conda env update -n jupyterlab-lsp --file requirements/lint.yml --quiet

--- a/ci/job.test.yml
+++ b/ci/job.test.yml
@@ -12,15 +12,15 @@ parameters:
   pythons:
     - name: ThreeSix
       spec: '>=3.6,<3.7.0a0'
-      lab: '>=2,<2.1.0a0'
+      lab: '>=2,<3.0.0a0'
       nodejs: '>=10,<11.0.0.a0'
     - name: ThreeSeven
       spec: '>=3.7,<3.8.0a0'
-      lab: '>=2,<2.1.0a0'
+      lab: '>=2,<3.0.0a0'
       nodejs: '>=12,<13.0.0a0'
     - name: ThreeEight
       spec: '>=3.8,<3.9.0a0'
-      lab: '>=2,<2.1.0a0'
+      lab: '>=2,<3.0.0a0'
       nodejs: '>=13,<14.0.0a0'
   js_cov_packages:
     - jupyterlab-go-to-definition

--- a/requirements/lab.txt
+++ b/requirements/lab.txt
@@ -1,3 +1,3 @@
 # the version of jupyterlab
 -r ./prod.txt
-jupyterlab >=2,<2.1.0a0
+jupyterlab >=2,<3.0.0a0


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

Change JLab constrain to >=2.0, <3.0.0a0 in test scripts.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

Consequence of #242 as discussed in https://github.com/conda-forge/staged-recipes/pull/11280#discussion_r407234128

## Code changes

<!-- Describe the code changes and how they address the issue. -->
N/A

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
N/A
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->
N/A

## Chores

- [x] tested
