### PR TITLE
Add jupyter serverextension enable --py jupyter_lsp to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Use of a python `virtualenv` or a conda env is also recommended.
 
    ```bash
    pip install jupyter-lsp
+   jupyter serverextension enable --py jupyter_lsp
    ```
 
 1. install `nodejs`


### PR DESCRIPTION
## References

See final comments in #250. I think that we talked about it earlier, but it turns out to be needed for quite a few users, so let's have it here. Not sure if this should be commented by default and marked as optional, or just kept uncommented - I do not see any harm in running this command again if extension is already enabled.