### PR TITLE
Pin robotframework to <3.2

### DIFF
--- a/ci/env-test.yml.in
+++ b/ci/env-test.yml.in
@@ -30,3 +30,4 @@ dependencies:
   - firefox
   - geckodriver
   - robotframework-seleniumlibrary
+  - robotframework <3.2

--- a/ci/job.lint.yml
+++ b/ci/job.lint.yml
@@ -34,11 +34,11 @@ jobs:
               - script: ${{ platform.activate }} jupyterlab-lsp && python scripts/integrity.py
                 displayName: check integrity of package versions
 
-              - script: ${{ platform.activate }} jupyterlab-lsp && python scripts/lint.py
-                displayName: lint backend
-
               - script: ${{ platform.activate }} jupyterlab-lsp && jlpm || jlpm || jlpm
                 displayName: install npm dependencies
+
+              - script: ${{ platform.activate }} jupyterlab-lsp && python scripts/lint.py
+                displayName: lint backend
 
               - script: ${{ platform.activate }} jupyterlab-lsp && jlpm build:schema
                 displayName: build schema so linting can complete

--- a/requirements/atest.txt
+++ b/requirements/atest.txt
@@ -1,3 +1,4 @@
 # acceptance test dependencies for jupyter_lsp
 -r ./lab.txt
 robotframework-seleniumlibrary
+robotframework <3.2

--- a/requirements/atest.yml
+++ b/requirements/atest.yml
@@ -6,5 +6,6 @@ channels:
 
 dependencies:
   - robotframework-seleniumlibrary
+  - robotframework <3.2
   - firefox
   - geckodriver

--- a/requirements/lint.yml
+++ b/requirements/lint.yml
@@ -9,3 +9,4 @@ dependencies:
   - isort
   - mypy
   - robotframework-lint
+  - robotframework <3.2


### PR DESCRIPTION
## References

- fixes #262 

## Code changes

robotframework 3.2 changed a number of interfaces: we'll likely want to use it, but for now, let's pin.

## User-facing changes

n/a

## Backwards-incompatible changes

n/a

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
