### PR TITLE
Fix unwanted path auto-completion, allow user-invoked completion in strings/comments

### DIFF
--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -195,17 +195,20 @@ Open ${file} in ${editor}
     Click Element    ${editor}
 
 Clean Up After Working With File
-    [Arguments]    ${file}
-    Remove File    ${OUTPUT DIR}${/}home${/}${file}
+    [Arguments]    ${file}    ${subdirectory}=.
+    Remove File    ${OUTPUT DIR}${/}home${/}${subdirectory}${/}${file}
+    Run Keyword If    "${subdirectory}" != "."    Remove Directory    ${OUTPUT DIR}${/}home${/}${subdirectory}${/}.ipynb_checkpoints    Recursive
+    Run Keyword If    "${subdirectory}" != "."    Remove Directory    ${OUTPUT DIR}${/}home${/}${subdirectory}    recursive=False
     Reset Application State
 
 Setup Notebook
-    [Arguments]    ${Language}    ${file}    ${isolated}=${True}
+    [Arguments]    ${Language}    ${file}    ${isolated}=${True}    ${subdirectory}=.
     Set Tags    language:${Language.lower()}
     Run Keyword If    ${isolated}    Set Screenshot Directory    ${OUTPUT DIR}${/}screenshots${/}notebook${/}${TEST NAME.replace(' ', '_')}
-    Copy File    examples${/}${file}    ${OUTPUT DIR}${/}home${/}${file}
+    Copy File    examples${/}${file}    ${OUTPUT DIR}${/}home${/}${subdirectory}${/}${file}
     Run Keyword If    ${isolated}    Try to Close All Tabs
-    Open ${file} in ${MENU NOTEBOOK}
+    Lab Command    Open from Path
+    Input Into Dialog    ${subdirectory}${/}${file}
     Capture Page Screenshot    00-notebook-opened.png
     Wait Until Fully Initialized
     Capture Page Screenshot    01-notebook-initialized.png

--- a/atest/examples/Completion.ipynb
+++ b/atest/examples/Completion.ipynb
@@ -124,6 +124,54 @@
    "source": [
     "import os.pat"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`[.]` should **not** auto-expand to `.ipynb_checkpoints/`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`'list.'` should **not** invoke completer (no auto-invocation in comments and strings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'list'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`list.<tab>` (a deliberate user action) should invoke the auto-completer in comments and strings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'list.'"
+   ]
   }
  ],
  "metadata": {
@@ -142,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/jupyterlab/jl_adapter.ts
@@ -264,9 +264,10 @@ export abstract class JupyterLabWidgetAdapter
   abstract find_ce_editor(cm_editor: CodeMirror.Editor): CodeEditor.IEditor;
 
   invoke_completer(kind: CompletionTriggerKind) {
-    this.current_completion_connector.with_trigger_kind(kind, () => {
-      return this.app.commands.execute(this.invoke_command);
-    });
+    this.current_completion_connector.set_trigger_kind_for_next_invocation(
+      kind
+    );
+    this.app.commands.execute(this.invoke_command).catch(console.warn);
   }
 
   protected async on_connected(data: IDocumentConnectionData) {


### PR DESCRIPTION
## References

Fixes #241 

## Code changes

`with_trigger_kind` replaced with `set_trigger_kind_for_next_invocation` as the with the idea did not play well here (it seems that even after converting the callback to await it was only waiting for the invocation, but not for completion due to how commands work); either way it is to be removed as setting `trigger_kind` on an instance is silly and error-prone and should not be done in the first place (but I did not want to re-implement `completer:invoke-notebook` and `completer:invoke-file`); now it seems that a thin wrapper/re-implementation/PR upstream which would allow passing the `trigger_kind` when executing the command is the best way out (also described with a TODO comment), but this may be out of the scope of this PR.

Maybe, just maybe, a custom implementation of a command, let's name it `completer:trigger` would allow getting rid of the current workaround (but then the value from this PR is in adding a test-case).

## TODO

- [ ] play around to check if we can implement `completer:trigger` easily, and in the process get rid of two workarounds:
    - `trigger_kind` on an instance,
   - adding the dummy completer item described below
- [ ] or - if the above cannot be accomplished within two weeks - open an issue for that.

## User-facing changes

- Auto-completion is not performed if LSP does not return results and Kernel returns only one result (which is usually `.ipynb-checkpoints` for Python); to workaround how `completer:invoke-notebook/file` work (auto-completing if there is one suggestion), I add a second dummy (but harmless) suggestion. This is not the final solution, just a workaround.
- Completion in strings and comments can now be manually invoked

## Backwards-incompatible changes

None, but will likely need manual merge with #239

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [ ] changelog entry
