### PR TITLE
Pin isort to restore the lint step in CI

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,7 +14,9 @@ dependencies:
   # for python language server (and development)
   - black
   - flake8 >=3.5
-  - isort
+  # isort 5.0 has breaking API changes which affect (among others) pylint;
+  # the pin should be removed once https://github.com/PyCQA/pylint/pull/3725 is merged
+  - isort <5
   - mypy
   - pip
   - pylint

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,8 +14,9 @@ dependencies:
   # for python language server (and development)
   - black
   - flake8 >=3.5
-  # isort 5.0 has breaking API changes which affect (among others) pylint;
+  # isort 5.0 has breaking API changes which affect (among others) pylint and nblint;
   # the pin should be removed once https://github.com/PyCQA/pylint/pull/3725 is merged
+  # see https://github.com/krassowski/jupyterlab-lsp/pull/291
   - isort <5
   - mypy
   - pip

--- a/requirements/lint.yml
+++ b/requirements/lint.yml
@@ -6,7 +6,10 @@ channels:
 
 dependencies:
   - black
-  - isort
+  # isort 5.0 has breaking API changes which affect (among others) pylint and nblint;
+  # the pin should be removed once https://github.com/PyCQA/pylint/pull/3725 is merged
+  # see https://github.com/krassowski/jupyterlab-lsp/pull/291
+  - isort <5
   - mypy
   - robotframework-lint >=1.1
   - robotframework >=3.2


### PR DESCRIPTION
## References

#290 shows a failure in the lint step (all the actual tests pass ok). The root cause seems to be a recent release of isort (5.0) which affects nblint and pylint. Until both have migrated to isort 5.0 the proposed solution is to pin isort <5.

Upstream/root issues:
 - [ ] https://github.com/PyCQA/pylint/pull/3725
- [ ] #292 for our nblint.py script

```python
 robot --name Linux37 --outputdir /home/vsts/work/1/s/atest/output/dry_run_linux_37_1 --output /home/vsts/work/1/s/atest/output/dry_run_linux_37_1.robot.xml --log /home/vsts/work/1/s/atest/output/dry_run_linux_37_1.log.html --report /home/vsts/work/1/s/atest/output/dry_run_linux_37_1.report.html --xunitskipnoncritical --xunit /home/vsts/work/1/s/atest/output/dry_run_linux_37_1.xunit.xml --variable OS:Linux --variable PY:37 --randomize all --dryrun --console quiet --noncritical language:yamlANDfeature:config --noncritical language:pythonANDpy:36ANDos:windows /home/vsts/work/1/s/atest
0 errors in 2 seconds
..Traceback (most recent call last):
  File "scripts/nblint.py", line 87, in <module>
    sys.exit(nblint())
  File "scripts/nblint.py", line 64, in nblint
    new = isort.SortImports(file_contents=source).output
AttributeError: module 'isort' has no attribute 'SortImports'
```

## Code changes

Pin isort in:
 - binder/environment.yml
 - requirements/lint.yml

## User-facing changes

None

## Backwards-incompatible changes

None

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
