### PR TITLE
Alleviate too aggressive line magics substitution #281

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     (and vice versa) ([#195][])
   - restores sorting order-indicating caret icons in diagnostics panel table ([#261][])
   - handles document open and change operation ordering more predictably ([#284][])
+  - fixes some pyflakes issues caused by line magics substitution
 
 [#195]: https://github.com/krassowski/jupyterlab-lsp/issues/195
 [#261]: https://github.com/krassowski/jupyterlab-lsp/issues/261

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## CHANGELOG
 
-### `@krassowski/jupyterlab-lsp 1.0.1` (unreleased)
+### `@krassowski/jupyterlab-lsp 1.1.0` (unreleased)
+
+- features
+
+  - language servers can now be configured from the Advanced Settings Editor ([#245][])
 
 - bug fixes
 
@@ -8,10 +12,33 @@
     (and vice versa) ([#195][])
   - restores sorting order-indicating caret icons in diagnostics panel table ([#261][])
   - handles document open and change operation ordering more predictably ([#284][])
-  - fixes some pyflakes issues caused by line magics substitution
+  - fixes some pyflakes issues caused by line magics substitution ([#293][])
 
 [#195]: https://github.com/krassowski/jupyterlab-lsp/issues/195
 [#261]: https://github.com/krassowski/jupyterlab-lsp/issues/261
+[#293]: https://github.com/krassowski/jupyterlab-lsp/pull/293
+
+### `@krassowski/jupyterlab-lsp 0.9.0` (unreleased)
+
+- features
+
+  - language servers can now be configured from the Advanced Settings Editor ([#245][])
+
+- bug fixes
+
+  - handles document open and change operation ordering more predictably ([#284][])
+
+### `lsp-ws-connection 0.5.0` (unreleased)
+
+- features
+
+  - language servers can now be configured from the Advanced Settings Editor ([#245][])
+
+- bug fixes
+
+  - handles document open and change operation ordering more predictably ([#284][])
+
+[#245]: https://github.com/krassowski/jupyterlab-lsp/pull/245
 [#284]: https://github.com/krassowski/jupyterlab-lsp/pull/284
 
 ### `@krassowski/jupyterlab-lsp 1.0.0` (2020-03-14)

--- a/packages/jupyterlab-lsp/src/magics/defaults.spec.ts
+++ b/packages/jupyterlab-lsp/src/magics/defaults.spec.ts
@@ -104,6 +104,20 @@ describe('Default IPython overrides', () => {
       expect(reverse).to.equal(LINE_MAGIC_WITH_SPACE);
     });
 
+    it('overrides x =%ls', () => {
+      // this is a corner-case as described in
+      // https://github.com/krassowski/jupyterlab-lsp/issues/281#issuecomment-645286076
+      let override = line_magics_map.override_for('x =%ls');
+      expect(override).to.equal(
+        'x =get_ipython().run_line_magic("ls", "")'
+      );
+    });
+
+    it('does not override line-magic-like constructs', () => {
+      let override = line_magics_map.override_for('list("%")');
+      expect(override).to.equal(null);
+    });
+
     it('escapes arguments', () => {
       const line_magic_with_args = '%MAGIC "arg"';
       let override = line_magics_map.override_for(line_magic_with_args);
@@ -121,6 +135,11 @@ describe('Default IPython overrides', () => {
 
       let reverse = line_magics_map.reverse.override_for(override);
       expect(reverse).to.equal('!ls -o');
+    });
+
+    it('does not override shell-like constructs', () => {
+      let override = line_magics_map.override_for('"!ls"');
+      expect(override).to.equal(null);
     });
   });
 });

--- a/packages/jupyterlab-lsp/src/magics/defaults.spec.ts
+++ b/packages/jupyterlab-lsp/src/magics/defaults.spec.ts
@@ -108,9 +108,7 @@ describe('Default IPython overrides', () => {
       // this is a corner-case as described in
       // https://github.com/krassowski/jupyterlab-lsp/issues/281#issuecomment-645286076
       let override = line_magics_map.override_for('x =%ls');
-      expect(override).to.equal(
-        'x =get_ipython().run_line_magic("ls", "")'
-      );
+      expect(override).to.equal('x =get_ipython().run_line_magic("ls", "")');
     });
 
     it('does not override line-magic-like constructs', () => {

--- a/packages/jupyterlab-lsp/src/magics/defaults.ts
+++ b/packages/jupyterlab-lsp/src/magics/defaults.ts
@@ -39,11 +39,11 @@ export const language_specific_overrides: IOverridesRegistry = {
 
       // note magics do not have to start with the new line, for example x = !ls or x = %ls are both valid.
       // x =%ls is also valid. However, percent may also appear in strings, e.g. ls('%').
-      // Hence: (^|\s|=) for shell commands (!) and line magics (%); see issue #281.
+      // Hence: (^|\\s|=) for shell commands (!) and line magics (%); see issue #281.
       // This does not solve all issues, for example `list(" %ls")` still leads to:
       // `list(" get_ipython().run_line_magic("ls")", "")`.
       {
-        pattern: '(^|\s|=)!(\\S+)(.*)(\n)?',
+        pattern: '(^|\\s|=)!(\\S+)(.*)(\n)?',
         replacement: '$1get_ipython().getoutput("$2$3")$4',
         reverse: {
           pattern: 'get_ipython\\(\\).getoutput\\("(.*?)"\\)(\n)?',


### PR DESCRIPTION
## References

Partially fixes too aggressive line magic (%) and shell (!) substitution which was pyflakes causing issues.

Fixes #281.

## Code changes

Regular expressions got improved, tests added.

## User-facing changes

Pyflakes should more often work than not. Not always as some things cannot be achieved with regular expressions.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
