### PR TITLE
Delete LANGUAGESERVERS.md

### DIFF
--- a/LANGUAGESERVERS.md
+++ b/LANGUAGESERVERS.md
@@ -1,1 +1,0 @@
-This file has moved to the documentation: [Language Servers](https://jupyterlab-lsp.readthedocs.io/en/latest/Language%20Servers.html) and [Configuring](https://jupyterlab-lsp.readthedocs.io/en/latest/Configuring.html) sections.


### PR DESCRIPTION
This file has been there to redirect users hitting it from an old version of the JupyterLab extension (from the link from a statusbar), which is no longer supported and the file has been there for over 5 months. It's time to remove it.

Also, this is a test of Azure Pipelines (will the webhook trigger a new build?).