### PR TITLE
Fix statusbar message pooling data from all editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,14 @@
   - pressing "Cancel" rename during rename now correctly aborts the rename operation ([#318])
   - when a language server for a foreign document is not available an explanation is displayed (rather than the "Connecting..." status as before) ([4e5b2ad])
   - when jump target is not found a message is now shown instead of raising an exception ([00448d0])
-  - fixed status message expiration and replacement ([8798f2d])
+  - fixed status message expiration and replacement ([8798f2d]), ([#329])
   - fixed some context command rank issues introduced after an attempt of migration to nulls ([#318])
 
 [#301]: https://github.com/krassowski/jupyterlab-lsp/pull/301
 [#315]: https://github.com/krassowski/jupyterlab-lsp/pull/315
 [#318]: https://github.com/krassowski/jupyterlab-lsp/pull/318
 [#322]: https://github.com/krassowski/jupyterlab-lsp/pull/322
+[#329]: https://github.com/krassowski/jupyterlab-lsp/pull/329
 [00448d0]: https://github.com/krassowski/jupyterlab-lsp/pull/318/commits/00448d0c55e7f9a1e7e0a5322f17610daac47dfe
 [bacc006]: https://github.com/krassowski/jupyterlab-lsp/pull/318/commits/bacc0066da0727ff7397574914bf0401e4d8f7cb
 [4e5b2ad]: https://github.com/krassowski/jupyterlab-lsp/pull/318/commits/4e5b2adf655120458cc8be4b453fe9a78c98e061

--- a/atest/04_Interface/Statusbar.robot
+++ b/atest/04_Interface/Statusbar.robot
@@ -18,3 +18,20 @@ Statusbar Popup Opens
     Element Should Contain    ${POPOVER}    python
     Element Should Contain    ${POPOVER}    initialized
     [Teardown]    Clean Up After Working With File    Python.ipynb
+
+Status Changes Correctly Between Editors
+    Prepare File for Editing    Python    status    example.py
+    Wait Until Fully Initialized
+    Open File    example.plain
+    Wait Until Element Contains    ${STATUSBAR}    Initialized (additional servers needed)    timeout=60s
+    Capture Page Screenshot    01-both-open.png
+    Switch To Tab    example.py
+    Wait Until Fully Initialized
+    Switch To Tab    example.plain
+    Wait Until Element Contains    ${STATUSBAR}    Initialized (additional servers needed)    timeout=60s
+    [Teardown]    Clean Up After Working With File    example.plain
+
+*** Keywords ***
+Switch To Tab
+    [Arguments]    ${file}
+    Click Element    ${JLAB XP DOCK TAB}\[contains(., '${file}')]

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -285,8 +285,12 @@ Prepare File for Editing
     [Arguments]    ${Language}    ${Screenshots}    ${file}
     Set Tags    language:${Language.lower()}
     Set Screenshot Directory    ${OUTPUT DIR}${/}screenshots${/}${Screenshots}${/}${Language.lower()}
-    Copy File    examples${/}${file}    ${OUTPUT DIR}${/}home${/}${file}
     Try to Close All Tabs
+    Open File    ${file}
+
+Open File
+    [Arguments]    ${file}
+    Copy File    examples${/}${file}    ${OUTPUT DIR}${/}home${/}${file}
     Open ${file} in ${MENU EDITOR}
     Capture Page Screenshot    00-opened.png
 

--- a/atest/examples/example.plain
+++ b/atest/examples/example.plain
@@ -1,0 +1,2 @@
+There is nothing interesting in here.
+It is here just to test how the extension works with files for which there is no associated language support.

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -322,8 +322,7 @@ const classByStatus: StatusIconClass = {
 const shortMessageByStatus: StatusMap = {
   waiting: 'Waiting...',
   initialized: 'Fully initialized',
-  initialized_but_some_missing:
-    'Initialized (additional servers can be installed)',
+  initialized_but_some_missing: 'Initialized (additional servers needed)',
   initializing: 'Partially initialized',
   connecting: 'Connecting...'
 };
@@ -436,7 +435,22 @@ export namespace LSPStatus {
     }
 
     get status(): IStatus {
-      const detected_documents = this._connection_manager.documents;
+      let detected_documents: Map<string, VirtualDocument>;
+
+      if (!this.adapter?.virtual_editor) {
+        detected_documents = new Map();
+      } else {
+        let main_document = this.adapter.virtual_editor.virtual_document;
+        const all_documents = this._connection_manager.documents;
+        // detected documents that are open in the current virtual editor
+        const detected_documents_set = collect_documents(main_document);
+        detected_documents = new Map(
+          [...all_documents].filter(([id, doc]) =>
+            detected_documents_set.has(doc)
+          )
+        );
+      }
+
       let connected_documents = new Set<VirtualDocument>();
       let initialized_documents = new Set<VirtualDocument>();
       let absent_documents = new Set<VirtualDocument>();


### PR DESCRIPTION
It turns out that the `detected_documents` were basically all documents (documents across all open editors) rather than documents detected in given editor (as expected) probably introduced during refactor towards connection manager, but will be fine now as I added a test for it (with two editors being open).

## References

This is a further fix to #310 (after https://github.com/krassowski/jupyterlab-lsp/pull/318/commits/4e5b2adf655120458cc8be4b453fe9a78c98e061 which made a progress towards it before).

## User-facing changes

I reduced the verbosity of the status message from previously committed "Initialized (additional servers can be installed)" to "Initialized (additional servers needed)".

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [ ] changelog entry
