### PR TITLE
Diagnostics panel improvements: copy, ignore (filter), jump from context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   - refactored the codebase with a new architecture which allows dynamic feature, document widget adapter, and code editor registration ([#318])
   - the document in the connections list in the statusbar popover are now represented by easy-to-understand DocumentLocator (breadcrumbs) widget rather than an internal id ([bacc006])
   - syntax highlighting mode is adjusted to the language with the majority of the code in an editor ([#319])
+  - copy diagnostics message and filter diagnostics from context menu of Diagnostic Panel ([#330])
 
 - bug fixes
 
@@ -45,6 +46,7 @@
 [#319]: https://github.com/krassowski/jupyterlab-lsp/pull/319
 [#322]: https://github.com/krassowski/jupyterlab-lsp/pull/322
 [#329]: https://github.com/krassowski/jupyterlab-lsp/pull/329
+[#330]: https://github.com/krassowski/jupyterlab-lsp/pull/330
 [00448d0]: https://github.com/krassowski/jupyterlab-lsp/pull/318/commits/00448d0c55e7f9a1e7e0a5322f17610daac47dfe
 [bacc006]: https://github.com/krassowski/jupyterlab-lsp/pull/318/commits/bacc0066da0727ff7397574914bf0401e4d8f7cb
 [4e5b2ad]: https://github.com/krassowski/jupyterlab-lsp/pull/318/commits/4e5b2adf655120458cc8be4b453fe9a78c98e061

--- a/atest/04_Interface/DiagnosticsPanel.robot
+++ b/atest/04_Interface/DiagnosticsPanel.robot
@@ -1,57 +1,95 @@
 *** Settings ***
 Suite Setup       Setup Suite For Screenshots    diagnostics_panel
 Resource          ../Keywords.robot
-Test Setup        Gently Reset Workspace
+Test Setup        Set Up
+Test Teardown     Clean Up
 
 *** Variables ***
 ${EXPECTED_COUNT}    1
 ${DIAGNOSTIC}     W291 trailing whitespace (pycodestyle)
 ${DIAGNOSTIC MESSAGE}    trailing whitespace
-${MENU COLUMNS}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(text(), "columns")]
-${MENU COLUMN MESSAGE}    xpath://div[contains(@class, 'p-Menu-itemLabel')][contains(text(), "Message")]
+${MENU COLUMNS}    xpath://div[contains(@class, 'lm-Menu-itemLabel')][contains(text(), "columns")]
+${LAB MENU}       css:.lm-Menu
 
 *** Test Cases ***
 Diagnostics Panel Opens
-    Open Notebook And Panel    Panel.ipynb
     Capture Page Screenshot    03-panel-opens.png
-    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count
-    [Teardown]    Clean Up After Working With File    Panel.ipynb
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    ${EXPECTED_COUNT}
 
 Diagnostics Panel Works After Rename
     [Documentation]    Test for #141 bug (diagnostics were not cleared after rename)
-    Open Notebook And Panel    Panel.ipynb
     Rename Jupyter File    Panel.ipynb    PanelRenamed.ipynb
     Close Diagnostics Panel
     Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${DIAGNOSTIC}"]    timeout=20s
     Capture Page Screenshot    00-panel-rename.png
     Open Diagnostics Panel
     Capture Page Screenshot    01-panel-rename.png
-    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    ${EXPECTED_COUNT}
     Clean Up After Working With File    PanelRenamed.ipynb
-    [Teardown]    Clean Up After Working With File    Panel.ipynb
 
 Diagnostics Panel Can Be Restored
-    Open Notebook And Panel    Panel.ipynb
     Close Diagnostics Panel
     Open Diagnostics Panel
-    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count
-    [Teardown]    Clean Up After Working With File    Panel.ipynb
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    ${EXPECTED_COUNT}
 
 Columns Can Be Hidden
-    Open Notebook And Panel    Panel.ipynb
     Wait Until Keyword Succeeds    10 x    1s    Element Should Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE}
     Open Context Menu Over    css:.lsp-diagnostics-listing th
     Capture Page Screenshot    01-menu-visible.png
-    Mouse Over    ${MENU COLUMNS}
-    Wait Until Page Contains Element    ${MENU COLUMN MESSAGE}    timeout=10s
-    Mouse Over    ${MENU COLUMN MESSAGE}
-    Capture Page Screenshot    02-message-column-visible.png
-    Click Element    ${MENU COLUMN MESSAGE}
+    Expand Menu Entry    columns
+    Select Menu Entry    Message
     Capture Page Screenshot    03-message-column-toggled.png
     Wait Until Keyword Succeeds    10 x    1s    Element Should Not Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE}
-    [Teardown]    Clean Up After Working With File    Panel.ipynb
+
+Diagnostics Can Be Ignored By Code
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    1
+    Open Context Menu Over    css:.lsp-diagnostics-listing tbody tr
+    Expand Menu Entry    Ignore diagnostics
+    Select Menu Entry    code
+    Open in Advanced Settings    ${DIAGNOSTICS PLUGIN ID}
+    Capture Page Screenshot    02-code-pressed.png
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    0
+
+Diagnostics Can Be Ignored By Message
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    1
+    Open Context Menu Over    css:.lsp-diagnostics-listing tbody tr
+    Expand Menu Entry    Ignore diagnostics
+    Capture Page Screenshot    02-menu-visible.png
+    Select Menu Entry    Ignore diagnostics with "W291 trailing whitespace" message
+    Open in Advanced Settings    ${DIAGNOSTICS PLUGIN ID}
+    Capture Page Screenshot    02-message-pressed.png
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    0
+
+Diagnostic Message Can Be Copied
+    Wait Until Keyword Succeeds    10 x    1s    Element Should Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE}
+    Open Context Menu Over    css:.lsp-diagnostics-listing tbody tr
+    Select Menu Entry    Copy diagnostic
+    Close Diagnostics Panel
+    Wait Until Element Contains    css:.lsp-statusbar-item    Successfully copied    timeout=10s
 
 *** Keywords ***
+Expand Menu Entry
+    [Arguments]    ${label}
+    ${entry} =    Set Variable    xpath://div[contains(@class, 'lm-Menu-itemLabel')][contains(text(), "${label}")]
+    Wait Until Page Contains Element    ${entry}    timeout=10s
+    ${menus before} =    Get Element Count    ${LAB MENU}
+    Mouse Over    ${entry}
+    ${expected menus} =    Evaluate    ${menus before} + 1
+    Wait Until Keyword Succeeds    10 x    1s    Menus Count Equal    ${expected menus}
+
+Menus Count Equal
+    [Arguments]    ${count}
+    ${menus count} =    Get Element Count    ${LAB MENU}
+    Should Be Equal    ${menus count}    ${count}
+
+Select Menu Entry
+    [Arguments]    ${label}
+    ${entry}    Set Variable    xpath://div[contains(@class, 'lm-Menu-itemLabel')][contains(text(), '${label}')]
+    Wait Until Page Contains Element    ${entry}    timeout=10s
+    Mouse Over    ${entry}
+    Click Element    ${entry}
+    Wait Until Page Does Not Contain Element    ${entry}    timeout=10s
+
 Open Notebook And Panel
     [Arguments]    ${notebook}
     Setup Notebook    Python    ${notebook}
@@ -61,5 +99,15 @@ Open Notebook And Panel
     Capture Page Screenshot    00-notebook-and-panel-opened.png
 
 Should Have Expected Rows Count
+    [Arguments]    ${expected_count}
     ${count} =    Count Diagnostics In Panel
-    Should Be True    ${count} == ${EXPECTED_COUNT}
+    Should Be True    ${count} == ${expected_count}
+
+Set Up
+    Gently Reset Workspace
+    Open Notebook And Panel    Panel.ipynb
+
+Clean Up
+    Clean Up After Working With File    Panel.ipynb
+    Reset Plugin Settings    plugin=diagnostics
+    Reset Application State

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -199,7 +199,7 @@ Select Completer Suggestion
 
 Completer Should Suggest
     [Arguments]    ${text}
-    Wait Until Page Contains Element    ${COMPLETER_BOX} .jp-Completer-item[data-value="${text}"]
+    Wait Until Page Contains Element    ${COMPLETER_BOX} .jp-Completer-item[data-value="${text}"]    timeout=10s
     Capture Page Screenshot    ${text.replace(' ', '_')}.png
 
 Completer Should Include Icon

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -58,6 +58,8 @@ Initialize User Settings
     Create File    ${SETTINGS DIR}${/}@jupyterlab${/}codemirror-extension${/}commands.jupyterlab-settings    {"styleActiveLine": true}
 
 Reset Plugin Settings
+    [Arguments]    ${package}=jupyterlab-lsp    ${plugin}=plugin
+    ${LSP PLUGIN SETTINGS FILE} =    Set Variable    @krassowski${/}${package}${/}${plugin}.jupyterlab-settings
     Create File    ${SETTINGS DIR}${/}${LSP PLUGIN SETTINGS FILE}    {}
 
 Tear Down Everything
@@ -278,7 +280,6 @@ Wait Until Fully Initialized
 Open Context Menu Over
     [Arguments]    ${sel}
     Wait Until Keyword Succeeds    10 x    0.1 s    Mouse Over    ${sel}
-    Wait Until Keyword Succeeds    10 x    0.1 s    Click Element    ${sel}
     Wait Until Keyword Succeeds    10 x    0.1 s    Open Context Menu    ${sel}
 
 Prepare File for Editing

--- a/atest/Variables.robot
+++ b/atest/Variables.robot
@@ -34,7 +34,7 @@ ${CM CURSORS}     css:.CodeMirror-cursors:not([style='visibility: hidden'])
 # settings
 ${LSP PLUGIN ID}    @krassowski/jupyterlab-lsp:plugin
 ${COMPLETION PLUGIN ID}    @krassowski/jupyterlab-lsp:completion
-${LSP PLUGIN SETTINGS FILE}    @krassowski${/}jupyterlab-lsp${/}plugin.jupyterlab-settings
+${DIAGNOSTICS PLUGIN ID}    @krassowski/jupyterlab-lsp:diagnostics
 ${CSS USER SETTINGS}    .jp-SettingsRawEditor-user
 ${JLAB XP CLOSE SETTINGS}    ${JLAB XP DOCK TAB}\[contains(., 'Settings')]/*[contains(@class, 'm-TabBar-tabCloseIcon')]
 # diagnostics

--- a/atest/examples/Diagnostic.ipynb
+++ b/atest/examples/Diagnostic.ipynb
@@ -66,7 +66,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/atest/examples/Panel.ipynb
+++ b/atest/examples/Panel.ipynb
@@ -35,7 +35,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -190,7 +190,7 @@ export class VirtualDocument {
   foreign_extractors: IForeignCodeExtractor[];
   overrides_registry: ICodeOverridesRegistry;
   protected foreign_extractors_registry: IForeignCodeExtractorsRegistry;
-  protected lines: Array<string>;
+  protected line_blocks: Array<string>;
 
   // TODO: merge into unused documents {standalone: Map, continuous: Map} ?
   protected unused_documents: Set<VirtualDocument>;
@@ -288,7 +288,7 @@ export class VirtualDocument {
     this.foreign_extractors = null;
     this.foreign_extractors_registry = null;
     this.line_magics_overrides = null;
-    this.lines = null;
+    this.line_blocks = null;
     this.overrides_registry = null;
   }
 
@@ -331,7 +331,7 @@ export class VirtualDocument {
     this.source_lines.clear();
     this.last_virtual_line = 0;
     this.last_source_line = 0;
-    this.lines = [];
+    this.line_blocks = [];
   }
 
   private forward_closed_signal(
@@ -650,7 +650,7 @@ export class VirtualDocument {
 
     // one empty line is necessary to separate code blocks, next 'n' lines are to silence linters;
     // the final cell does not get the additional lines (thanks to the use of join, see below)
-    this.lines.push(lines.join('\n') + '\n');
+    this.line_blocks.push(lines.join('\n') + '\n');
 
     // adding the virtual lines for the blank lines
     for (let i = 0; i < this.blank_lines_between_cells; i++) {
@@ -667,11 +667,14 @@ export class VirtualDocument {
 
   get value() {
     let lines_padding = '\n'.repeat(this.blank_lines_between_cells);
-    return this.lines.join(lines_padding);
+    return this.line_blocks.join(lines_padding);
   }
 
   get last_line() {
-    return this.lines[this.lines.length];
+    const lines_in_last_block = this.line_blocks[
+      this.line_blocks.length - 1
+    ].split('\n');
+    return lines_in_last_block[lines_in_last_block.length - 1];
   }
 
   close_expired_documents() {


### PR DESCRIPTION
## References

Together with prematurely pushed to master 75a90e84567bb177a8a5a641235811ddf831aa5f, closes #154 and probably helps #160.

## User-facing changes

![newcontextmenu](https://user-images.githubusercontent.com/5832902/91775267-939e9000-ebe2-11ea-9c8f-f4bbdcd0c64b.png)

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
