### PR TITLE
Fix too aggressive overrides of IPython's pinfo (`?`) and pinfo2 (`??`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 2.0.5` (2020-09-11)
+
+- bug fixes
+
+  - fix too aggressive overrides of IPython's pinfo (`?`) and pinfo2 (`??`) ([#352])
+
+[#352]: https://github.com/krassowski/jupyterlab-lsp/issues/352
+
 ### `@krassowski/jupyterlab-lsp 2.0.4` (2020-09-11)
 
 - bug fixes

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
@@ -206,5 +206,19 @@ describe('Default IPython overrides', () => {
       reverse = line_magics_map.reverse.override_for(override);
       expect(reverse).to.equal('int??');
     });
+
+    it('does not override standalone question marks', () => {
+      let override = line_magics_map.override_for("'q?'");
+      expect(override).to.equal(null);
+
+      override = line_magics_map.override_for('#?');
+      expect(override).to.equal(null);
+
+      override = line_magics_map.override_for("?q'");
+      expect(override).to.equal(null);
+
+      override = line_magics_map.override_for("?#'");
+      expect(override).to.equal(null);
+    });
   });
 });

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
@@ -42,6 +42,8 @@ function empty_or_escaped(x: string) {
  */
 export const LINE_MAGIC_PREFIX = '^(\\s*|\\s*\\S+\\s*=\\s*)';
 
+export const PYTHON_IDENTIFIER = '([^?s\'"\\(\\)-\\+\\/#]+)';
+
 export let overrides: IScopedCodeOverride[] = [
   /**
    * Line magics
@@ -60,7 +62,10 @@ export let overrides: IScopedCodeOverride[] = [
   },
   {
     // note: assignments of pinfo/pinfo2 are not supported by IPython
-    pattern: '^(\\s*)' + '(\\?{1,2})(\\S+)(\n)?',
+    // and only "simple" identifiers are supported, i.e.
+    //    ?x['a']
+    // would not be solved, leading to "Object `x['a']` not found."
+    pattern: '^(\\s*)' + '(\\?{1,2})' + PYTHON_IDENTIFIER + '(\n)?$',
     replacement: (match, prefix, marks, name, line_break) => {
       const cmd = marks == '?' ? 'pinfo' : 'pinfo2';
       line_break = line_break || '';
@@ -79,7 +84,7 @@ export let overrides: IScopedCodeOverride[] = [
     }
   },
   {
-    pattern: '^(\\s*)' + '([^\\?\\s]+)(\\?{1,2})(\n)?',
+    pattern: '^(\\s*)' + PYTHON_IDENTIFIER + '(\\?{1,2})(\n)?',
     replacement: (match, prefix, name, marks, line_break) => {
       const cmd = marks == '?' ? 'pinfo' : 'pinfo2';
       line_break = line_break || '';


### PR DESCRIPTION
See the test cases added for details. Final fix for this week, hopefully nothing else will break LSP in my notebooks :)

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
