### PR TITLE
Fix performance issues caused by lazy syntax highlight implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 2.0.6` (unreleased)
+
+- bug fixes
+
+  - fix syntax highlighting of %%language cells slowing down editing in notebooks ([#361])
+
+[#361]: https://github.com/krassowski/jupyterlab-lsp/issues/361
+
 ### `@krassowski/jupyterlab-lsp 2.0.5` (2020-09-11)
 
 - bug fixes

--- a/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
+++ b/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
@@ -75,7 +75,10 @@ export class CMSyntaxHighlighting extends CodeMirrorIntegration {
 
         // change the mode if the majority of the code is the foreign code
         if (coverage > this.settings.composite.foreignCodeThreshold) {
-          editor.setOption('mode', mode.mime);
+          let old_mode = editor.getOption('mode');
+          if (old_mode != mode.mime) {
+            editor.setOption('mode', mode.mime);
+          }
         }
       }
     }


### PR DESCRIPTION
## References

Fixes #360

## Code changes

Added an if to chek current mode.

## User-facing changes

Great performance increase if working with `%%language` magics.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
