### PR TITLE
Fix syntax highlighting not being deactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 2.0.8` (unreleased)
+
+- bug fixes
+
+  - custom cell syntax highlighting is now properly removed when no longer needed ([#387])
+
+[#387]: https://github.com/krassowski/jupyterlab-lsp/issues/387
+
 ### `@krassowski/jupyterlab-lsp 2.0.7` (2020-09-18)
 
 - bug fixes

--- a/atest/05_Features/Syntax_highlighting.robot
+++ b/atest/05_Features/Syntax_highlighting.robot
@@ -24,13 +24,29 @@ Highlighing Mode Works For Multiple Documents
     ${mode} =    Get Mode Of A Cell    6
     should be equal    ${mode['name']}    javascript
 
+Highlighting Mode Changes Back And Forth After Edits
+    ${mode} =    Get Mode Of A Cell    2
+    should be equal    ${mode['name']}    markdown
+    Enter Cell Editor    2    line=1
+    Press Keys    None    BACKSPACE
+    Capture Page Screenshot    backapse.png
+    wait until keyword succeeds    5x    2s    Mode Of A Cell Should Equal    2    ipython
+    Enter Cell Editor    2    line=1
+    Press Keys    None    n
+    wait until keyword succeeds    5x    2s    Mode Of A Cell Should Equal    2    markdown
+
 *** Keywords ***
 Get Mode Of A Cell
-    [Arguments]    ${cell_nr}
-    Click Element    css:.jp-Cell:nth-child(${cell_nr})
-    Wait Until Page Contains Element    css:.jp-Cell:nth-child(${cell_nr}) .CodeMirror-focused
-    ${mode} =    Execute JavaScript    return document.querySelector('.jp-Cell:nth-child(${cell_nr}) .CodeMirror').CodeMirror.getMode()
+    [Arguments]    ${cell_number}
+    Click Element    css:.jp-Cell:nth-child(${cell_number})
+    Wait Until Page Contains Element    css:.jp-Cell:nth-child(${cell_number}) .CodeMirror-focused
+    ${mode} =    Execute JavaScript    return document.querySelector('.jp-Cell:nth-child(${cell_number}) .CodeMirror').CodeMirror.getMode()
     [Return]    ${mode}
 
 Setup Highlighting Test
     Setup Notebook    Python    Syntax highlighting.ipynb
+
+Mode Of A Cell Should Equal
+    [Arguments]    ${cell_number}    ${expected_mode}
+    ${mode} =    Get Mode Of A Cell    ${cell_number}
+    should be equal    ${mode['name']}    ${expected_mode}

--- a/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
+++ b/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
@@ -77,11 +77,10 @@ export class CMSyntaxHighlighting extends CodeMirrorIntegration {
           continue;
         }
 
-        let old_mode = editor.getOption('mode');
-
         // change the mode if the majority of the code is the foreign code
         if (coverage > this.settings.composite.foreignCodeThreshold) {
           editors_with_current_highlight.add(ce_editor);
+          let old_mode = editor.getOption('mode');
           if (old_mode != mode.mime) {
             editor.setOption('mode', mode.mime);
           }

--- a/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
+++ b/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
@@ -29,10 +29,12 @@ const FEATURE_ID = PLUGIN_ID + ':syntax_highlighting';
 export class CMSyntaxHighlighting extends CodeMirrorIntegration {
   lab_integration: SyntaxLabIntegration;
   settings: IFeatureSettings<LSPSyntaxHighlightingSettings>;
+  editors_with_active_highlight: Set<CodeMirrorEditor>;
 
   constructor(options: IEditorIntegrationOptions) {
     super(options);
     this.virtual_document.changed.connect(this.update_mode.bind(this), this);
+    this.editors_with_active_highlight = new Set();
   }
 
   private get_mode(language: string) {
@@ -52,10 +54,12 @@ export class CMSyntaxHighlighting extends CodeMirrorIntegration {
 
   update_mode() {
     let root = this.virtual_document;
+    let editors_with_current_highlight = new Set<CodeMirrorEditor>();
+
     for (let map of root.foreign_document_maps) {
       for (let [range, block] of map.entries()) {
-        let ce_editor = block.editor;
-        let editor = (ce_editor as CodeMirrorEditor).editor;
+        let ce_editor = block.editor as CodeMirrorEditor;
+        let editor = ce_editor.editor;
         let lines = editor.getValue('\n');
         let total_area = lines.concat('').length;
 
@@ -73,15 +77,27 @@ export class CMSyntaxHighlighting extends CodeMirrorIntegration {
           continue;
         }
 
+        let old_mode = editor.getOption('mode');
+
         // change the mode if the majority of the code is the foreign code
         if (coverage > this.settings.composite.foreignCodeThreshold) {
-          let old_mode = editor.getOption('mode');
+          editors_with_current_highlight.add(ce_editor);
           if (old_mode != mode.mime) {
             editor.setOption('mode', mode.mime);
           }
         }
       }
     }
+
+    if (editors_with_current_highlight != this.editors_with_active_highlight) {
+      for (let ce_editor of this.editors_with_active_highlight) {
+        if (!editors_with_current_highlight.has(ce_editor)) {
+          ce_editor.editor.setOption('mode', ce_editor.model.mimeType);
+        }
+      }
+    }
+
+    this.editors_with_active_highlight = editors_with_current_highlight;
   }
 }
 


### PR DESCRIPTION
## References

Fixes #379.

## Code changes

Keep track of editors where custom syntax mode is applied and revert to the default when no longer deemed appropriate to apply the custom mode.

## User-facing changes

![works_now](https://user-images.githubusercontent.com/5832902/97106566-6f2ed380-16ba-11eb-955f-eead1385223f.gif)

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
