### PR TITLE
Correctly extract last character on paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - bug fixes
 
   - custom cell syntax highlighting is now properly removed when no longer needed ([#387])
+  - the completer in continuous hinting now works well with the pasted text ([#389])
 
 [#387]: https://github.com/krassowski/jupyterlab-lsp/issues/387
+[#389]: https://github.com/krassowski/jupyterlab-lsp/issues/389
 
 ### `@krassowski/jupyterlab-lsp 2.0.7` (2020-09-18)
 

--- a/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
@@ -230,7 +230,8 @@ export abstract class CodeMirrorIntegration
 
   protected extract_last_character(change: CodeMirror.EditorChange): string {
     if (change.origin === 'paste') {
-      return change.text[0][change.text.length - 1];
+      let last_line = change.text[change.text.length - 1];
+      return last_line[last_line.length - 1];
     } else {
       return change.text[0][0];
     }


### PR DESCRIPTION
## References

Fixes #380

## Code changes

Fixes some premature optimization done poorly, minimal change set and no tests as attempts at testing clipboard with Robot wasted me some precious ours the other week.

## User-facing changes

![now_works](https://user-images.githubusercontent.com/5832902/97107594-3f82ca00-16c0-11eb-8d26-2bb0f25b86fb.gif)


## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
