### PR TITLE
Fix continuous hinting showing up when it has nothing to offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
   - custom cell syntax highlighting is now properly removed when no longer needed ([#387])
   - the completer in continuous hinting now works well with the pasted text ([#389])
+  - continuous hinting suggestions will no longer show up if the only hint is the same as the current token ([#391])
 
 [#387]: https://github.com/krassowski/jupyterlab-lsp/issues/387
 [#389]: https://github.com/krassowski/jupyterlab-lsp/issues/389
+[#391]: https://github.com/krassowski/jupyterlab-lsp/issues/391
 
 ### `@krassowski/jupyterlab-lsp 2.0.7` (2020-09-18)
 

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -47,6 +47,14 @@ Works In File Editor
     Completer Should Suggest    add
     [Teardown]    Clean Up After Working With File    completion.py
 
+Continious Hinting Works
+    Configure JupyterLab Plugin    {"continuousHinting": true}    plugin id=${COMPLETION PLUGIN ID}
+    Prepare File for Editing    Python    completion    completion.py
+    Place Cursor In File Editor At    9    2
+    Capture Page Screenshot    01-editor-ready.png
+    Press Keys    None    d
+    Completer Should Suggest    addition
+
 Autocompletes If Only One Option
     Enter Cell Editor    3    line=1
     Press Keys    None    cle

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -205,7 +205,7 @@ export class LSPConnector
     }
 
     return promise.then(reply => {
-      reply = this.suppress_if_needed(reply);
+      reply = this.suppress_if_needed(reply, token);
       this.trigger_kind = CompletionTriggerKind.Invoked;
       return reply;
     });
@@ -413,9 +413,17 @@ export class LSPConnector
     return Promise.resolve(undefined);
   }
 
-  private suppress_if_needed(reply: CompletionHandler.ICompletionItemsReply) {
+  private suppress_if_needed(
+    reply: CompletionHandler.ICompletionItemsReply,
+    token: CodeEditor.IToken
+  ) {
     if (this.trigger_kind == AdditionalCompletionTriggerKinds.AutoInvoked) {
-      if (reply.start == reply.end) {
+      if (
+        // do not auto-invoke if no match found
+        reply.start == reply.end ||
+        // do not auto-invoke if only one match found and this match is exactly the same as the current token
+        (reply.items.length === 1 && reply.items[0].insertText === token.value)
+      ) {
         return {
           start: reply.start,
           end: reply.end,


### PR DESCRIPTION
## References

Fixes #388

## Code changes

Added a test for continuous hinting, but does not test the bug itself (need some better way to test that an action does NOT happen).

## User-facing changes

![now_works_hinting](https://user-images.githubusercontent.com/5832902/97109416-fedc7e00-16ca-11eb-897d-85603d8856cb.gif)

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [.] tested
- [ ] documented
- [x] changelog entry
