### PR TITLE
Improve error message when there is no language server installed for the current language

### DIFF
--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -326,6 +326,10 @@ export namespace DocumentConnectionManager {
       language
     });
 
+    if (language_server_id === null) {
+      throw `No language server installed for language ${language}`;
+    }
+
     return {
       base: baseUri,
       document: URLExt.join(baseUri, virtual_document.uri),


### PR DESCRIPTION
When there is no language server installed, it fails with
```
TypeError: Path must be a string. Received null
```

Which is not very easy to understand without looking into the code. This PR makes it fail with a nicer error message that tells what is wrong.