### PR TITLE
Export tokens

### DIFF
--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -49,6 +49,8 @@ import { plugin as THEME_VSCODE } from '@krassowski/theme-vscode';
 import { plugin as THEME_MATERIAL } from '@krassowski/theme-material';
 import { CODE_OVERRIDES_MANAGER } from './overrides';
 
+export * from './tokens';
+
 export const codeCheckIcon = new LabIcon({
   name: 'lsp:codeCheck',
   svgstr: codeCheckSvg


### PR DESCRIPTION
Export tokens for other extensions to depend on them.

If tokens are not exported, one can retrieve them doing *e.g.*:
```Typescript
import { ILSPAdapterManager } from '@krassowski/jupyterlab-lsp/lib/tokens';
```

But this code will be compiled by webpack into
```javascript
/* harmony import */ var _krassowski_jupyterlab_lsp_lib_tokens__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @krassowski/jupyterlab-lsp/lib/tokens */ "./node_modules/@krassowski/jupyterlab-lsp/lib/tokens.js");
```

Meaning that the third-party extension now ships its own copy of `@krassowski/jupyterlab-lsp`, with its own definition of the Tokens.

If we export the tokens, third-party extensions are able to do:
```Typescript
import { ILSPAdapterManager } from '@krassowski/jupyterlab-lsp';
```

Which compiles to:
```JavaScript
/* harmony import */ var _krassowski_jupyterlab_lsp__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! @krassowski/jupyterlab-lsp */ "webpack/sharing/consume/default/@krassowski/jupyterlab-lsp");
```

Meaning that all extensions which depend on those tokens will use the **same** tokens.


This is very important in JupyterLab 3 and the new federated modules, during the plugin activation, because JupyterLab relies on the `Token` instances themselves, not the name of the token.
 
Third-party extensions will be able to define `jupyterlab-lsp` as a shared packages (a package that is shared with other extensions) so it's not duplicated and bundled in all third-party extensions.

They can enable this by adding the following in their `package.json`:
```
"jupyterlab": {
    "extension": true,
    "outputDir": "my_extension/labextension",
    "sharedPackages": {
      "@krassowski/jupyterlab-lsp": {
        "bundled": false,
        "singleton": true
      }
    }
  }
```


https://github.com/jupyterlab/jupyterlab/blob/b29bfeb81e707dcb963d7d8e39a5d2ca1a036546/builder/metadata_schema.json#L28-L62