### PR TITLE
virtual_documents customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## CHANGELOG
 
-### `@krassowski/jupyterlab-lsp 2.0.9` (???)
+### `jupyter-lsp 0.9.3` (???)
 
 - features
 
-  - The virtual document folder can be configure with `JP_LSP_VIRTUAL_DIR` or  
+  - The virtual document folder can be configure with `JP_LSP_VIRTUAL_DIR` or
     `LanguageServerManager.virtual_documents_dir`. Its default value is kept
     unchanged: *contents.root_dir* / `.virtual_documents` ([#416])
+
+[#416]: https://github.com/krassowski/jupyterlab-lsp/issues/416
+
+### `@krassowski/jupyterlab-lsp 2.0.9` (???)
 
 - bug fixes
 
@@ -14,7 +18,6 @@
     robustly in files and folder names ([#403])
 
 [#403]: https://github.com/krassowski/jupyterlab-lsp/issues/403
-[#416]: https://github.com/krassowski/jupyterlab-lsp/issues/416
 
 ### `@krassowski/jupyterlab_go_to_definition 2.0.0` (???)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ### `@krassowski/jupyterlab-lsp 2.0.9` (???)
 
+- features
+
+  - The virtual document folder can be configure with `JP_LSP_VIRTUAL_DIR` or  
+    `LanguageServerManager.virtual_documents_dir`. Its default value is kept
+    unchanged: *contents.root_dir* / `.virtual_documents` ([#416])
+
 - bug fixes
 
   - handles characters that need escaping (spaces, non-ASCII characters) more
     robustly in files and folder names ([#403])
 
 [#403]: https://github.com/krassowski/jupyterlab-lsp/issues/403
+[#416]: https://github.com/krassowski/jupyterlab-lsp/issues/416
 
 ### `@krassowski/jupyterlab_go_to_definition 2.0.0` (???)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
   - The virtual document folder can be configure with `JP_LSP_VIRTUAL_DIR` or
     `LanguageServerManager.virtual_documents_dir`. Its default value is kept
-    unchanged: *contents.root_dir* / `.virtual_documents` ([#416])
+    unchanged: _contents.root_dir_ / `.virtual_documents` ([#416])
 
 [#416]: https://github.com/krassowski/jupyterlab-lsp/issues/416
 

--- a/docs/Configuring.ipynb
+++ b/docs/Configuring.ipynb
@@ -175,6 +175,19 @@
    ]
   },
   {
+   "source": [
+    "#### virtual_documents_dir\n",
+    "\n",
+    "> default: os.getenv(\"JP_LSP_VIRTUAL_DIR\", \".virtual_documents\")\n",
+    "\n",
+    "Path to virtual documents relative to the content manager root directory.\n",
+    "\n",
+    "Its default value can be set with `JP_LSP_VIRTUAL_DIR` environment variable and fallback to `.virtual_documents`."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/py_src/jupyter_lsp/manager.py
+++ b/py_src/jupyter_lsp/manager.py
@@ -1,11 +1,12 @@
 """ A configurable frontend for stdio-based Language Servers
 """
+import os
 import traceback
 from typing import Dict, Text, Tuple
 
 import entrypoints
 from notebook.transutils import _
-from traitlets import Bool, Dict as Dict_, Instance, List as List_, default
+from traitlets import Bool, Dict as Dict_, Instance, List as List_, Unicode, default
 
 from .constants import (
     EP_LISTENER_ALL_V1,
@@ -46,6 +47,15 @@ class LanguageServerManager(LanguageServerManagerAPI):
         help="sessions keyed by language server name",
     )  # type: Dict[Tuple[Text], LanguageServerSession]
 
+    virtual_documents_dir = Unicode(
+        help="""Path to virtual documents relative to the content manager root
+        directory.
+
+        Its default value can be set with JP_LSP_VIRTUAL_DIR and fallback to
+        '.virtual_documents'.
+        """
+    ).tag(config=True)
+
     all_listeners = List_(trait=LoadableCallable).tag(config=True)
     server_listeners = List_(trait=LoadableCallable).tag(config=True)
     client_listeners = List_(trait=LoadableCallable).tag(config=True)
@@ -53,6 +63,10 @@ class LanguageServerManager(LanguageServerManagerAPI):
     @default("language_servers")
     def _default_language_servers(self):
         return {}
+
+    @default("virtual_documents_dir")
+    def _default_virtual_documents_dir(self):
+        return os.getenv("JP_LSP_VIRTUAL_DIR", ".virtual_documents")
 
     def __init__(self, **kwargs):
         """Before starting, perform all necessary configuration"""

--- a/py_src/jupyter_lsp/manager.py
+++ b/py_src/jupyter_lsp/manager.py
@@ -1,5 +1,6 @@
 """ A configurable frontend for stdio-based Language Servers
 """
+import os
 import traceback
 from typing import Dict, Text, Tuple
 

--- a/py_src/jupyter_lsp/manager.py
+++ b/py_src/jupyter_lsp/manager.py
@@ -1,6 +1,5 @@
 """ A configurable frontend for stdio-based Language Servers
 """
-import os
 import traceback
 from typing import Dict, Text, Tuple
 

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -2,6 +2,7 @@
 """
 import json
 import os
+from pathlib import Path
 
 import traitlets
 
@@ -26,7 +27,7 @@ def load_jupyter_server_extension(nbapp):
         page_config["rootUri"] = root_uri
         nbapp.log.debug("[lsp] rootUri will be %s", root_uri)
 
-        virtual_documents_uri = os.path.join(root_uri, manager.virtual_documents_dir)
+        virtual_documents_uri = normalized_uri(Path(contents.root_dir) / manager.virtual_documents_dir)
         page_config["virtualDocumentsUri"] = virtual_documents_uri
         nbapp.log.debug("[lsp] virtualDocumentsUri will be %s", virtual_documents_uri)
     else:  # pragma: no cover

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -27,7 +27,9 @@ def load_jupyter_server_extension(nbapp):
         page_config["rootUri"] = root_uri
         nbapp.log.debug("[lsp] rootUri will be %s", root_uri)
 
-        virtual_documents_uri = normalized_uri(Path(contents.root_dir) / manager.virtual_documents_dir)
+        virtual_documents_uri = normalized_uri(
+            Path(contents.root_dir) / manager.virtual_documents_dir
+        )
         page_config["virtualDocumentsUri"] = virtual_documents_uri
         nbapp.log.debug("[lsp] virtualDocumentsUri will be %s", virtual_documents_uri)
     else:  # pragma: no cover

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -1,7 +1,6 @@
 """ add language server support to the running jupyter notebook application
 """
 import json
-import os
 from pathlib import Path
 
 import traitlets

--- a/py_src/jupyter_lsp/serverextension.py
+++ b/py_src/jupyter_lsp/serverextension.py
@@ -1,6 +1,7 @@
 """ add language server support to the running jupyter notebook application
 """
 import json
+import os
 
 import traitlets
 
@@ -25,7 +26,7 @@ def load_jupyter_server_extension(nbapp):
         page_config["rootUri"] = root_uri
         nbapp.log.debug("[lsp] rootUri will be %s", root_uri)
 
-        virtual_documents_uri = root_uri + "/.virtual_documents"
+        virtual_documents_uri = os.path.join(root_uri, manager.virtual_documents_dir)
         page_config["virtualDocumentsUri"] = virtual_documents_uri
         nbapp.log.debug("[lsp] virtualDocumentsUri will be %s", virtual_documents_uri)
     else:  # pragma: no cover

--- a/py_src/jupyter_lsp/tests/test_extension.py
+++ b/py_src/jupyter_lsp/tests/test_extension.py
@@ -1,3 +1,6 @@
+import os
+
+
 def test_serverextension_path(app):
     import jupyter_lsp
 
@@ -18,3 +21,29 @@ def test_serverextension(app):
                 found_lsp = True
 
     assert found_lsp, "apparently didn't install the /lsp/ route"
+
+
+def test_default_virtual_documents_dir(app):
+    app.initialize(
+        ["--NotebookApp.nbserver_extensions={'jupyter_lsp.serverextension': True}"]
+    )
+    assert app.language_server_manager.virtual_documents_dir == ".virtual_documents"
+
+
+def test_virtual_documents_dir_config(app):
+    custom_dir = ".custom_virtual_dir"
+    app.initialize(
+        [
+            "--NotebookApp.nbserver_extensions={'jupyter_lsp.serverextension': True}",
+            "--NotebookApp.LanguageServerManager.virtual_documents_dir=" + custom_dir,
+        ]
+    )
+    assert app.language_server_manager.virtual_documents_dir == custom_dir
+
+
+def test_virtual_documents_dir_env(app):
+    os.environ["JP_LSP_VIRTUAL_DIR"] = custom_dir = ".custom_virtual_dir"
+    app.initialize(
+        ["--NotebookApp.nbserver_extensions={'jupyter_lsp.serverextension': True}"]
+    )
+    assert app.language_server_manager.virtual_documents_dir == custom_dir


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->
Fixes #353
<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
Move the ".virtual_documents" definition to a configuration in `LanguageServerManager`. Its default value is kept
but that default value can be overwritten by the environment variable `JP_LSP_VIRTUAL_DIR`

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->
None - except if they must know about the virtual document folder.
<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->
None

## Chores

- [x] linted
- [x] tested
- [x] documented
- [x] changelog entry
