### PR TITLE
Refactor how the notebook changes are picked up, events bound and unbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@
 
   - handles characters that need escaping (spaces, non-ASCII characters) more
     robustly in files and folder names ([#403])
+  - moving cells now triggers the document update immediately leading to immediate diagnostics update ([#421])
+  - changing cell type to `raw` or `markdown` and then back to `code` properly unbinds/binds event handlers and updates document ([#421])
+  - pasted cells are added to the LSP document immediately, without the need for the user to enter them ([#421])
 
 [#403]: https://github.com/krassowski/jupyterlab-lsp/issues/403
+[#421]: https://github.com/krassowski/jupyterlab-lsp/issues/421
 
 ### `@krassowski/jupyterlab_go_to_definition 2.0.0` (???)
 

--- a/atest/03_Notebook.robot
+++ b/atest/03_Notebook.robot
@@ -11,6 +11,39 @@ Python
     Capture Page Screenshot    01-python.png
     [Teardown]    Clean Up After Working With File    Python.ipynb
 
+Conversion Of Cell Types
+    [Setup]    Setup Notebook    Python    Python.ipynb
+    ${lsp_entry} =    Set Variable    Show diagnostics panel
+    # initial (code) cell
+    Open Context Menu Over Cell Editor    1
+    Capture Page Screenshot    01-initial-code-cell.png
+    Context Menu Should Contain    ${lsp_entry}
+    Close Context Menu
+    # raw cell
+    Lab Command    Change to Raw Cell Type
+    Open Context Menu Over Cell Editor    1
+    Capture Page Screenshot    02-as-raw-cell.png
+    Context Menu Should Not Contain    ${lsp_entry}
+    Close Context Menu
+    # code cell again
+    Lab Command    Change to Code Cell Type
+    Open Context Menu Over Cell Editor    1
+    Capture Page Screenshot    03-as-code-cell-again.png
+    Context Menu Should Contain    ${lsp_entry}
+    Close Context Menu
+    [Teardown]    Clean Up After Working With File    Python.ipynb
+
+Moving Cells Around
+    [Setup]    Setup Notebook    Python    Python.ipynb
+    ${diagnostic} =    Set Variable    undefined name 'test' (pyflakes)
+    Enter Cell Editor    1
+    Lab Command    Move Cells Down
+    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title="${diagnostic}"]    timeout=35s
+    Enter Cell Editor    1
+    Lab Command    Move Cells Down
+    Wait Until Page Does Not Contain Element    css:.cm-lsp-diagnostic[title="${diagnostic}"]    timeout=35s
+    [Teardown]    Clean Up After Working With File    Python.ipynb
+
 Foreign Extractors
     ${file} =    Set Variable    Foreign extractors.ipynb
     Configure JupyterLab Plugin

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -279,6 +279,11 @@ Enter Cell Editor
     Click Element    css:.jp-Cell:nth-child(${cell_nr}) .CodeMirror-line:nth-child(${line})
     Wait Until Page Contains Element    css:.jp-Cell:nth-child(${cell_nr}) .CodeMirror-focused
 
+Open Context Menu Over Cell Editor
+    [Arguments]    ${cell_nr}    ${line}=1
+    Enter Cell Editor    ${cell_nr}    line=${line}
+    Open Context Menu Over    css:.jp-Cell:nth-child(${cell_nr}) .CodeMirror-line:nth-child(${line})
+
 Place Cursor In Cell Editor At
     [Arguments]    ${cell_nr}    ${line}    ${character}
     Enter Cell Editor    ${cell_nr}    ${line}
@@ -300,6 +305,19 @@ Open Context Menu Over
     [Arguments]    ${sel}
     Wait Until Keyword Succeeds    10 x    0.1 s    Mouse Over    ${sel}
     Wait Until Keyword Succeeds    10 x    0.1 s    Open Context Menu    ${sel}
+
+Context Menu Should Contain
+    [Arguments]    ${label}    ${timeout}=10s
+    ${entry}    Set Variable    xpath://div[contains(@class, 'lm-Menu-itemLabel')][contains(text(), '${label}')]
+    Wait Until Page Contains Element    ${entry}    timeout=${timeout}
+
+Context Menu Should Not Contain
+    [Arguments]    ${label}    ${timeout}=10s
+    ${entry}    Set Variable    xpath://div[contains(@class, 'lm-Menu-itemLabel')][contains(text(), '${label}')]
+    Wait Until Page Does Not Contain Element    ${entry}    timeout=${timeout}
+
+Close Context Menu
+    Press Keys    None    ESCAPE
 
 Prepare File for Editing
     [Arguments]    ${Language}    ${Screenshots}    ${file}

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -96,6 +96,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
   protected app: JupyterFrontEnd;
 
   public activeEditorChanged: Signal<WidgetAdapter<T>, IEditorChangedData>;
+  public editorAdded: Signal<WidgetAdapter<T>, IEditorChangedData>;
   public editorRemoved: Signal<WidgetAdapter<T>, IEditorChangedData>;
   public update_finished: Promise<void>;
 
@@ -119,6 +120,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     this.adapterConnected = new Signal(this);
     this.activeEditorChanged = new Signal(this);
     this.editorRemoved = new Signal(this);
+    this.editorAdded = new Signal(this);
     this.adapters = new Map();
     this.status_message = new StatusMessage();
     this.isConnected = false;

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -96,6 +96,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
   protected app: JupyterFrontEnd;
 
   public activeEditorChanged: Signal<WidgetAdapter<T>, IEditorChangedData>;
+  public editorRemoved: Signal<WidgetAdapter<T>, IEditorChangedData>;
   public update_finished: Promise<void>;
 
   /**
@@ -117,6 +118,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     this.connection_manager = extension.connection_manager;
     this.adapterConnected = new Signal(this);
     this.activeEditorChanged = new Signal(this);
+    this.editorRemoved = new Signal(this);
     this.adapters = new Map();
     this.status_message = new StatusMessage();
     this.isConnected = false;

--- a/packages/jupyterlab-lsp/src/adapters/notebook/notebook.ts
+++ b/packages/jupyterlab-lsp/src/adapters/notebook/notebook.ts
@@ -148,36 +148,40 @@ export class NotebookAdapter extends WidgetAdapter<NotebookPanel> {
         let convertedToMarkdownOrRaw = [];
         let convertedToCode = [];
 
-        if (change.newValues.length !== change.oldValues.length) {
+        if (change.newValues.length === change.oldValues.length) {
           // during conversion the cells should not get deleted nor added
-          return;
-        }
-
-        for (let i = 0; i < change.newValues.length; i++) {
-          if (
-            change.oldValues[i].type === 'code' &&
-            change.newValues[i].type !== 'code'
-          ) {
-            convertedToMarkdownOrRaw.push(change.newValues[i]);
-          } else if (
-            change.oldValues[i].type !== 'code' &&
-            change.newValues[i].type === 'code'
-          ) {
-            convertedToCode.push(change.newValues[i]);
+          for (let i = 0; i < change.newValues.length; i++) {
+            if (
+              change.oldValues[i].type === 'code' &&
+              change.newValues[i].type !== 'code'
+            ) {
+              convertedToMarkdownOrRaw.push(change.newValues[i]);
+            } else if (
+              change.oldValues[i].type !== 'code' &&
+              change.newValues[i].type === 'code'
+            ) {
+              convertedToCode.push(change.newValues[i]);
+            }
           }
+          cellsAdded = convertedToCode;
+          cellsRemoved = convertedToMarkdownOrRaw;
         }
-        cellsAdded = convertedToCode;
-        cellsRemoved = convertedToMarkdownOrRaw;
-
       } else if (change.type == 'add') {
-        cellsAdded = change.newValues.filter((cellModel) => cellModel.type === 'code')
+        cellsAdded = change.newValues.filter(
+          cellModel => cellModel.type === 'code'
+        );
       }
       // note: editorRemoved is not emitted for removal of cells by change of type 'remove' (but only during cell type conversion)
       // because there is no easy way to get the widget associated with the removed cell(s) - because it is no
       // longer in the notebook widget list! It would need to be tracked on our side, but it is not necessary
       // as (except for a tiny memory leak) it should not impact the functionality in any way
 
-      if (cellsRemoved.length || cellsAdded.length || change.type === 'move' || change.type === 'remove') {
+      if (
+        cellsRemoved.length ||
+        cellsAdded.length ||
+        change.type === 'move' ||
+        change.type === 'remove'
+      ) {
         // in contrast to the file editor document which can be only changed by the modification of the editor content,
         // the notebook document cna also get modified by a change in the number or arrangement of editors themselves;
         // for this reason each change has to trigger documents update (so that LSP mirror is in sync).
@@ -188,7 +192,7 @@ export class NotebookAdapter extends WidgetAdapter<NotebookPanel> {
         let cellWidget = this.widget.content.widgets.find(
           cell => cell.model.id === cellModel.id
         );
-        this.known_editors_ids.delete(cellWidget.editor.uuid)
+        this.known_editors_ids.delete(cellWidget.editor.uuid);
 
         // for practical purposes this editor got removed from our consideration;
         // it might seem that we should instead look for the editor indicated by
@@ -203,13 +207,12 @@ export class NotebookAdapter extends WidgetAdapter<NotebookPanel> {
         let cellWidget = this.widget.content.widgets.find(
           cell => cell.model.id === cellModel.id
         );
-        this.known_editors_ids.add(cellWidget.editor.uuid)
+        this.known_editors_ids.add(cellWidget.editor.uuid);
 
         this.editorAdded.emit({
           editor: cellWidget.editor
         });
       }
-
     });
   }
 

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -178,8 +178,7 @@ export namespace IFeatureTestEnvironment {
 type TestEnvironmentConstructor = new (...args: any[]) => ITestEnvironment;
 
 function FeatureSupport<TBase extends TestEnvironmentConstructor>(Base: TBase) {
-  return class FeatureTestEnvironment
-    extends Base
+  return class FeatureTestEnvironment extends Base
     implements IFeatureTestEnvironment {
     _connections: Map<CodeMirrorIntegration, LSPConnection>;
 

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -178,7 +178,8 @@ export namespace IFeatureTestEnvironment {
 type TestEnvironmentConstructor = new (...args: any[]) => ITestEnvironment;
 
 function FeatureSupport<TBase extends TestEnvironmentConstructor>(Base: TBase) {
-  return class FeatureTestEnvironment extends Base
+  return class FeatureTestEnvironment
+    extends Base
     implements IFeatureTestEnvironment {
     _connections: Map<CodeMirrorIntegration, LSPConnection>;
 

--- a/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
@@ -519,8 +519,10 @@ export class CodeMirrorVirtualEditor
       callback(cm_editor);
     }
     if (monitor_for_new_blocks) {
-
-      let activation_callback = (adapter: WidgetAdapter<IDocumentWidget>, data: IEditorChangedData) => {
+      let activation_callback = (
+        adapter: WidgetAdapter<IDocumentWidget>,
+        data: IEditorChangedData
+      ) => {
         let { editor } = data;
         if (editor == null) {
           return;
@@ -529,9 +531,9 @@ export class CodeMirrorVirtualEditor
         if (!editors_with_handlers.has(cm_editor)) {
           callback(cm_editor);
         }
-      }
+      };
 
-      this.adapter.editorAdded.connect(activation_callback)
+      this.adapter.editorAdded.connect(activation_callback);
       this.adapter.editorRemoved.connect(
         (adapter, data: IEditorChangedData) => {
           let { editor } = data;

--- a/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
@@ -519,21 +519,18 @@ export class CodeMirrorVirtualEditor
       callback(cm_editor);
     }
     if (monitor_for_new_blocks) {
-      let activation_callback = (
-        adapter: WidgetAdapter<IDocumentWidget>,
-        data: IEditorChangedData
-      ) => {
-        let { editor } = data;
-        if (editor == null) {
-          return;
+      this.adapter.editorAdded.connect(
+        (adapter: WidgetAdapter<IDocumentWidget>, data: IEditorChangedData) => {
+          let { editor } = data;
+          if (editor == null) {
+            return;
+          }
+          let cm_editor = (editor as CodeMirrorEditor).editor;
+          if (!editors_with_handlers.has(cm_editor)) {
+            callback(cm_editor);
+          }
         }
-        let cm_editor = (editor as CodeMirrorEditor).editor;
-        if (!editors_with_handlers.has(cm_editor)) {
-          callback(cm_editor);
-        }
-      };
-
-      this.adapter.editorAdded.connect(activation_callback);
+      );
       this.adapter.editorRemoved.connect(
         (adapter, data: IEditorChangedData) => {
           let { editor } = data;

--- a/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
@@ -519,18 +519,19 @@ export class CodeMirrorVirtualEditor
       callback(cm_editor);
     }
     if (monitor_for_new_blocks) {
-      this.adapter.activeEditorChanged.connect(
-        (adapter, data: IEditorChangedData) => {
-          let { editor } = data;
-          if (editor == null) {
-            return;
-          }
-          let cm_editor = (editor as CodeMirrorEditor).editor;
-          if (!editors_with_handlers.has(cm_editor)) {
-            callback(cm_editor);
-          }
+
+      let activation_callback = (adapter: WidgetAdapter<IDocumentWidget>, data: IEditorChangedData) => {
+        let { editor } = data;
+        if (editor == null) {
+          return;
         }
-      );
+        let cm_editor = (editor as CodeMirrorEditor).editor;
+        if (!editors_with_handlers.has(cm_editor)) {
+          callback(cm_editor);
+        }
+      }
+
+      this.adapter.editorAdded.connect(activation_callback)
       this.adapter.editorRemoved.connect(
         (adapter, data: IEditorChangedData) => {
           let { editor } = data;

--- a/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
@@ -280,9 +280,15 @@ export class CodeMirrorVirtualEditor
     };
     this._event_wrappers.set([eventName, handler], wrapped_handler);
 
-    this.forEveryBlockEditor(cm_editor => {
-      cm_editor.on(eventName, wrapped_handler);
-    });
+    this.forEveryBlockEditor(
+      cm_editor => {
+        cm_editor.on(eventName, wrapped_handler);
+      },
+      true,
+      cm_editor => {
+        cm_editor.off(eventName, wrapped_handler);
+      }
+    );
   }
 
   off(eventName: string, handler: CodeMirrorHandler, ...args: any[]): void {
@@ -496,20 +502,17 @@ export class CodeMirrorVirtualEditor
     return 0;
   }
 
-  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
-    this.forEveryBlockEditor(cm_editor => {
-      cm_editor.getWrapperElement().addEventListener(type, listener);
-    });
-  }
-
   forEveryBlockEditor(
     callback: (cm_editor: CodeMirror.Editor) => any,
-    monitor_for_new_blocks = true
+    monitor_for_new_blocks = true,
+    on_editor_removed_callback: (cm_editor: CodeMirror.Editor) => any = null
   ) {
     const editors_with_handlers = new Set<CodeMirror.Editor>();
 
-    // TODO... the need of iterating over all editors is universal. How does the virtual
-    //  editor gets knowledge of the editor instances? From the adapter obviously.
+    // TODO... the need of iterating over all editors is universal - so this could be
+    //  generalised to the VirtualEditor rather than live in CodeMirrorVirtualEditor;
+    //  How would the VirtualEditor get knowledge of the editor instances?
+    //  From the adapter (obviously).
     for (let editor of this.adapter.editors) {
       let cm_editor = (editor as CodeMirrorEditor).editor;
       editors_with_handlers.add(cm_editor);
@@ -526,6 +529,16 @@ export class CodeMirrorVirtualEditor
           if (!editors_with_handlers.has(cm_editor)) {
             callback(cm_editor);
           }
+        }
+      );
+      this.adapter.editorRemoved.connect(
+        (adapter, data: IEditorChangedData) => {
+          let { editor } = data;
+          if (editor == null) {
+            return;
+          }
+          let cm_editor = (editor as CodeMirrorEditor).editor;
+          on_editor_removed_callback(cm_editor);
         }
       );
     }


### PR DESCRIPTION
Previously the binding of events was only performed upon the user entering a code cell. Moreover, updates to the virtual document were only triggered on code edition, and not on cell edition (rearrangement, cell pasting etc). This was kind-of ok for the initial demo, but a number of scenarios require a better management of the events binding  [E] and document updates [D]:

- code cell being converted to markdown or raw cell:
  - [E] we do not want to trigger LSP there
  - [D] we want to refresh virtual document to exclude the converted fragment
- code cells being pasted or converted from markdown/raw cells:
  - [E] user should be able to get context menu on those without the need to enter them first
  - [D] the diagnostics should be shown in these just after paste
- cells being moved around:
  - [D] document should get updated to reflect the changes (and query diagnostics) associated with the change

Overall this small refactoring has a hug potential to squash numerous bugs and stability issues that arouse only after a longer work with a notebook (i.e. involving the use of feature such as moving cells, pasting, conversion of types) and were difficult to pinpoint so far.

## References

Fixes #393.

## Code changes

- Added `editorAdded` and `editorRemoved` events to `WidgetAdapter`.
- Added callback for removal of events from editors and made use of it.
- Started tracking `Notebook.model.cells` and trigger document updates, or editor events from there, as needed.

## User-facing changes

| before | after |
|--------|-------|
| ![before-markdown](https://user-images.githubusercontent.com/5832902/101963214-1681ae80-3c06-11eb-9c6b-4f0837e96004.gif)    |   ![after-markdown](https://user-images.githubusercontent.com/5832902/101963224-1b466280-3c06-11eb-8f83-d3acf4b2d60d.gif) |
| ![before-move](https://user-images.githubusercontent.com/5832902/101963233-24373400-3c06-11eb-8f1c-764ba89a4855.gif) | ![after-move](https://user-images.githubusercontent.com/5832902/101963236-27cabb00-3c06-11eb-9358-dfdbe216af1a.gif)   |

Plus pasting of cells works better with LSP, but a third set of GIFs would be redundant.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
