### PR TITLE
Hotfix crash "blank screen" likely related to Mac command character

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -14,7 +14,7 @@ defaults:
 env:
   # TODO extract these from files instead
   PY_JLSP_VERSION: 0.9.3
-  JS_JLLSP_VERSION: 2.1.0
+  JS_JLLSP_VERSION: 2.1.1
   JS_JLG2D_VERSION: 1.0.0
 
   PYTHONUNBUFFERED: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 2.1.1` (2020-12-15)
+
+- bug fixes
+
+  - fix crash "blank screen" caused by Mac command character included in jump-to schema file ([#429])
+
+[#429]: https://github.com/krassowski/jupyterlab-lsp/issues/429
+
 ### `jupyter-lsp 0.9.3` (2020-12-13)
 
 - features

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/jupyterlab-lsp/schema/jump_to.json
+++ b/packages/jupyterlab-lsp/schema/jump_to.json
@@ -10,7 +10,7 @@
       "type": "string",
       "enum": ["Alt", "Control", "Shift", "Meta", "AltGraph", "Accel"],
       "default": "Alt",
-      "description": "Keyboard key which needs to be pressed with click to jump. The allowed keys are Alt, Control, Shift, Accel, and AltGraph. Accel corresponds to Control or Meta (⌘ Command on Mac). Linux user: Meta key is also supported. Safari users: Meta key is also supported, AltGraph is not supported. To see which physical keys are mapped, visit: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState"
+      "description": "Keyboard key which needs to be pressed with click to jump. The allowed keys are Alt, Control, Shift, Accel, and AltGraph. Accel corresponds to Control or Meta (Command on Mac). Linux user: Meta key is also supported. Safari users: Meta key is also supported, AltGraph is not supported. To see which physical keys are mapped, visit: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState"
     }
   },
   "jupyter.lab.shortcuts": [

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp-metapackage",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/krassowski/jupyterlab-lsp",
   "bugs": {


### PR DESCRIPTION
It seems that the nice Mac Command character (⌘) was breaking JupyterLab extension system because of poor handling of encoding. Probably not worth fixing in lab because of the new extension system so just removing the offending character.

## References

Hopefully fixes #428.

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
