### PR TITLE
[wip] Fix robot PageConfig parsing, upgrading isort, pin jedi

### DIFF
--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -52,7 +52,7 @@ Create Notebok Server Config
 
 Read Page Config
     ${script} =    Get Element Attribute    id:jupyter-config-data    innerHTML
-    ${config} =    Evaluate    __import__("json").loads("""${script}""")
+    ${config} =    Evaluate    __import__("json").loads(r"""${script}""")
     Set Global Variable    ${PAGE CONFIG}    ${config}
     Set Global Variable    ${LAB VERSION}    ${config["appVersion"]}
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: jupyterlab-lsp
 
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 
 dependencies:
   # runtime dependencies
@@ -12,11 +12,7 @@ dependencies:
   # build dependencies
   - nodejs >=10.12,<15
   # for python language server (and development)
-  - black
   - flake8 >=3.5
-  # isort 5.0 has breaking API changes which affect (among others) pylint and nblint;
-  # the pin should be removed once https://github.com/PyCQA/pylint/pull/3725 is merged
-  # see https://github.com/krassowski/jupyterlab-lsp/pull/291
   - pip
   - pylint
   - pyls-black

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,16 +17,13 @@ dependencies:
   # isort 5.0 has breaking API changes which affect (among others) pylint and nblint;
   # the pin should be removed once https://github.com/PyCQA/pylint/pull/3725 is merged
   # see https://github.com/krassowski/jupyterlab-lsp/pull/291
-  - isort <5
-  - mypy
   - pip
   - pylint
+  - pyls-black
+  - pyls-isort
+  - pyls-mypy
   - python-language-server
   - ruamel_yaml
-  - pip: # not-yet-appearing-in-conda-forge
-      - pyls-black
-      - pyls-isort
-      - pyls-mypy
   # for R language server and kernel
   - r
   - r-irkernel
@@ -36,3 +33,5 @@ dependencies:
   - tectonic
   - texlab
   - chktex
+  # TODO: remove when jedi vs IPython is resolved
+  - jedi <0.18

--- a/docs/Configuring.ipynb
+++ b/docs/Configuring.ipynb
@@ -175,6 +175,8 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "#### virtual_documents_dir\n",
     "\n",
@@ -182,10 +184,9 @@
     "\n",
     "Path to virtual documents relative to the content manager root directory.\n",
     "\n",
-    "Its default value can be set with `JP_LSP_VIRTUAL_DIR` environment variable and fallback to `.virtual_documents`."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+    "Its default value can be set with `JP_LSP_VIRTUAL_DIR` environment variable and\n",
+    "fallback to `.virtual_documents`."
+   ]
   },
   {
    "cell_type": "markdown",

--- a/py_src/jupyter_lsp/manager.py
+++ b/py_src/jupyter_lsp/manager.py
@@ -6,7 +6,11 @@ from typing import Dict, Text, Tuple
 
 import entrypoints
 from notebook.transutils import _
-from traitlets import Bool, Dict as Dict_, Instance, List as List_, Unicode, default
+from traitlets import Bool
+from traitlets import Dict as Dict_
+from traitlets import Instance
+from traitlets import List as List_
+from traitlets import Unicode, default
 
 from .constants import (
     EP_LISTENER_ALL_V1,

--- a/py_src/jupyter_lsp/non_blocking.py
+++ b/py_src/jupyter_lsp/non_blocking.py
@@ -9,8 +9,8 @@ import os
 
 if os.name == "nt":  # pragma: no cover
     import msvcrt
-    from ctypes import windll, byref, wintypes, WinError, POINTER
-    from ctypes.wintypes import HANDLE, DWORD, BOOL
+    from ctypes import POINTER, WinError, byref, windll, wintypes
+    from ctypes.wintypes import BOOL, DWORD, HANDLE
 else:  # pragma: no cover
     import fcntl
 

--- a/py_src/jupyter_lsp/types.py
+++ b/py_src/jupyter_lsp/types.py
@@ -20,7 +20,9 @@ from typing import (
 )
 
 from notebook.transutils import _
-from traitlets import Instance, List as List_, Unicode, default
+from traitlets import Instance
+from traitlets import List as List_
+from traitlets import Unicode, default
 from traitlets.config import LoggingConfigurable
 
 LanguageServerSpec = Dict[Text, Any]

--- a/requirements/atest.yml
+++ b/requirements/atest.yml
@@ -2,7 +2,7 @@ name: jupyterlab-lsp
 
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 
 dependencies:
   - robotframework-seleniumlibrary

--- a/requirements/docs.yml
+++ b/requirements/docs.yml
@@ -9,6 +9,7 @@ dependencies:
   - pandas
   - pip
   - pytest
+  - pytest-check-links
   - python-graphviz
   - recommonmark
   - sphinx
@@ -16,6 +17,4 @@ dependencies:
   - sphinx-autobuild
   - sphinx-autodoc-typehints
   - sphinx-copybutton
-  - pip:
-      - pytest-check-links
-      - sphinx-markdown-tables
+  - sphinx-markdown-tables

--- a/requirements/docs.yml
+++ b/requirements/docs.yml
@@ -2,7 +2,7 @@ name: jupyterlab-lsp-docs
 
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 
 dependencies:
   - nbsphinx

--- a/requirements/github-actions.yml
+++ b/requirements/github-actions.yml
@@ -35,3 +35,5 @@ dependencies:
   - geckodriver
   - robotframework >=3.2
   - robotframework-seleniumlibrary
+  # TODO: remove when jedi vs IPython is resolved
+  - jedi <0.18

--- a/requirements/github-actions.yml
+++ b/requirements/github-actions.yml
@@ -2,7 +2,7 @@ name: jupyterlab-lsp
 
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 
 dependencies:
   - jupyterlab {lab}

--- a/requirements/lint.yml
+++ b/requirements/lint.yml
@@ -9,7 +9,7 @@ dependencies:
   # isort 5.0 has breaking API changes which affect (among others) pylint and nblint;
   # the pin should be removed once https://github.com/PyCQA/pylint/pull/3725 is merged
   # see https://github.com/krassowski/jupyterlab-lsp/pull/291
-  - isort <5
+  - isort
   - mypy
   - robotframework-lint >=1.1
   - robotframework >=3.2

--- a/requirements/lint.yml
+++ b/requirements/lint.yml
@@ -2,13 +2,10 @@ name: jupyterlab-lsp
 
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 
 dependencies:
   - black
-  # isort 5.0 has breaking API changes which affect (among others) pylint and nblint;
-  # the pin should be removed once https://github.com/PyCQA/pylint/pull/3725 is merged
-  # see https://github.com/krassowski/jupyterlab-lsp/pull/291
   - isort
   - mypy
   - robotframework-lint >=1.1

--- a/scripts/bump_versions.py
+++ b/scripts/bump_versions.py
@@ -7,7 +7,8 @@ from difflib import context_diff
 from pathlib import Path
 from typing import List
 
-from integrity import CHANGELOG, PIPE_FILE as PIPELINE
+from integrity import CHANGELOG
+from integrity import PIPE_FILE as PIPELINE
 
 ROOT = Path.cwd()
 

--- a/scripts/integrity.py
+++ b/scripts/integrity.py
@@ -27,10 +27,8 @@ sys.path.insert(0, str(ROOT))
 if True:
     # a workaround for isort 4.0 limitations
     # see https://github.com/timothycrosley/isort/issues/468
-    from versions import (  # noqa
-        REQUIRED_JUPYTERLAB as LAB_SPEC,
-        JUPYTER_LSP_VERSION as PY_VERSION,
-    )
+    from versions import JUPYTER_LSP_VERSION as PY_VERSION
+    from versions import REQUIRED_JUPYTERLAB as LAB_SPEC  # noqa
 
 REQS = ROOT / "requirements"
 BINDER = ROOT / "binder"

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -52,7 +52,7 @@ def lint():
         map(
             call,
             [
-                ["isort", "-rc", *ALL_PY],
+                ["isort", *ALL_PY],
                 ["black", *ALL_PY],
                 ["flake8", *ALL_PY],
                 # ["pylint", *ALL_PY],

--- a/scripts/nblint.py
+++ b/scripts/nblint.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import black
 import isort
-from isort.api import sort_code_string
 import nbformat
 
 OK = 0
@@ -21,6 +20,7 @@ DOCS_IPYNB = [
 NODE = shutil.which("node")
 
 ISORT_CONFIG = isort.settings.Config(settings_path=ROOT / "setup.cfg")
+
 
 def blacken(source):
     return black.format_str(source, mode=black.FileMode(line_length=88))
@@ -63,7 +63,7 @@ def nblint():
                     changes += 1
                 if source.startswith("%"):
                     continue
-                new = isort.sort_code_string(source, config=ISORT_CONFIG)
+                new = isort.api.sort_code_string(source, config=ISORT_CONFIG)
                 new = blacken(new).rstrip()
                 if new != source:
                     cell["source"] = new.splitlines(True)

--- a/scripts/nblint.py
+++ b/scripts/nblint.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import black
 import isort
+from isort.api import sort_code_string
 import nbformat
 
 OK = 0
@@ -19,6 +20,7 @@ DOCS_IPYNB = [
 ]
 NODE = shutil.which("node")
 
+ISORT_CONFIG = isort.settings.Config(settings_path=ROOT / "setup.cfg")
 
 def blacken(source):
     return black.format_str(source, mode=black.FileMode(line_length=88))
@@ -61,7 +63,7 @@ def nblint():
                     changes += 1
                 if source.startswith("%"):
                     continue
-                new = isort.SortImports(file_contents=source).output
+                new = isort.sort_code_string(source, config=ISORT_CONFIG)
                 new = blacken(new).rstrip()
                 if new != source:
                     cell["source"] = new.splitlines(True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,9 +69,7 @@ addopts =
     --flake8
 
 [isort]
-combine_as_imports = True
-include_trailing_comma = True
-line_length = 88
+profile = black
 multi_line_output = 3
 
 [pycodestyle]

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ addopts =
 [isort]
 profile = black
 multi_line_output = 3
+known_first_party = jupyter_lsp
 
 [pycodestyle]
 ignore = E203,W503,C0330


### PR DESCRIPTION
Sorry this kinda ended up as a mess (should have been a one-character PR, ha), but i had to rebuild my env, and some things were going a bit wacky. This has me running all the way to failing some acceptance tests for other reasons, but figured it was worth getting out, if only for cherry-picking the good parts.

## References

- fixes #444

## Code changes

- fix robot parsing of JSON which might contain single `\` escapes
- upgrade isort
- pin jedi
- get isort and and all the fixings from `conda-forge` only with `nodefaults` instead of `defaults`

## User-facing changes

n/a

## Backwards-incompatible changes

n/a

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [ ] changelog entry
