### PR TITLE
Add pip-only install/CLI smoke test

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -20,6 +20,7 @@ env:
 
   PYTHONUNBUFFERED: 1
   ATEST_RETRIES: 3
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
   # TODO: replace once mambaforge "just works" with setup-miniconda
   MAMBAFORGE_URL: https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge
@@ -184,7 +185,7 @@ jobs:
           mkdir dist
           cp python_packages/*/dist/* packages/*/*.tgz dist/
           cd dist
-          sha256sum * > SHA256SUMS
+          sha256sum * | tee SHA256SUMS
 
       - name: Publish builds
         uses: actions/upload-artifact@v2
@@ -321,3 +322,55 @@ jobs:
           name: ${{ job.status }} Robot ${{ matrix.os }} Python ${{ matrix.python }} ${{ github.run_number }}
           path: ./atest/output
         if: always()
+
+  smoke:
+    name: smoke ${{ matrix.os }} py${{ matrix.python }}
+    runs-on: ${{ matrix.os }}-latest
+    needs: [build, lint]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+        python: ['3.6', '3.9', 'pypy3']
+        exclude:
+          - os: windows
+            python: pypy3
+        include:
+          - python: '3.6'
+            dist: 'jupyter*lsp*.tar.gz'
+          - python: 'pypy3'
+            dist: 'jupyter*lsp*.tar.gz'
+          - python: '3.9'
+            dist: 'jupyter*lsp*.whl'
+          - os: windows
+            py_cmd: python
+          - os: macos
+            py_cmd: python3
+          - os: ubuntu
+            py_cmd: python
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: 'x64'
+      - uses: actions/download-artifact@v2
+        with:
+          name: jupyterlab-lsp dist ${{ github.run_number }}
+          path: ./dist
+      - name: Install the prerequisites
+        run: ${{ matrix.py_cmd }} -m pip install pip wheel
+      - name: Install the package
+        run: cd dist && ${{ matrix.py_cmd }} -m pip install -vv ${{ matrix.dist }}
+      - name: Validate environment
+        run: |
+          set -eux
+          ${{ matrix.py_cmd }} -m pip freeze
+          ${{ matrix.py_cmd }} -m pip check
+      - name: Validate the install
+        run: |
+          set -eux
+          jupyter labextension list
+          jupyter server extension list
+          jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp.*enabled.*ok" -
+          jupyter server extension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -


### PR DESCRIPTION
## References

- for https://github.com/krassowski/jupyterlab-lsp/pull/452#issuecomment-755289990
  - will re-target to #452 once green

## Code changes

Adds a `pip`-only install test to CI (doesn't even do a checkout). By making these rely on `lint` _and_ `build`, I'm hoping the acceptance jobs start first, so that this doesn't add to the bottom-line wall-clock time... even still, may want to cache pip, etc.

The existing `pip check` in the acceptance job is _still_ good to keep, as we want to know if our test dependencies have drifted or conflict with each other.

Ideally we'd _just_ install the `jupyterlab-lsp` tarball, to ensure the `install_requires` is configured properly, but I don't know how to make pip do that _and_ not pull in old versions of a locally-built dependency.

## User-facing changes

N/A, but should help non-dev installs go more smoothly.

## Backwards-incompatible changes

N/A

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [ ] changelog entry
