### PR TITLE
Fix connection manager loosing track of notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG
 
-### `@krassowski/jupyterlab-lsp 3.0.1` (unreleased)
+### `@krassowski/jupyterlab-lsp 3.1.0` (unreleased)
 
 - features
 
@@ -10,9 +10,11 @@
 
   - fix completions with R double and triple colon prefix ([#449])
   - fix contrast on status icon when status item is active ([#465])
+  - fix connection manager loosing track of notebooks when multiple were open ([#474])
 
 [#449]: https://github.com/krassowski/jupyterlab-lsp/pull/449
 [#465]: https://github.com/krassowski/jupyterlab-lsp/pull/465
+[#474]: https://github.com/krassowski/jupyterlab-lsp/pull/474
 
 ### `jupyter-lsp 1.0.1` (unreleased)
 

--- a/atest/04_Interface/Statusbar.robot
+++ b/atest/04_Interface/Statusbar.robot
@@ -19,6 +19,18 @@ Statusbar Popup Opens
     Element Should Contain    ${POPOVER}    initialized
     [Teardown]    Clean Up After Working With File    Python.ipynb
 
+Status Changes Between Notebooks
+    Setup Notebook    Python    Python.ipynb
+    Wait Until Fully Initialized
+    Lab Command    New Notebook
+    # Kernel selection dialog shows up, accept Python as default kernel
+    Accept Default Dialog Option
+    Element Should Contain    ${STATUSBAR}    Waiting...
+    Wait Until Fully Initialized
+    Switch To Tab    Python.ipynb
+    Wait Until Fully Initialized
+    [Teardown]    Clean Up After Working With File    Python.ipynb
+
 Status Changes Correctly Between Editors
     Prepare File for Editing    Python    status    example.py
     Wait Until Fully Initialized

--- a/atest/04_Interface/Statusbar.robot
+++ b/atest/04_Interface/Statusbar.robot
@@ -23,6 +23,7 @@ Status Changes Between Notebooks
     Setup Notebook    Python    Python.ipynb
     Wait Until Fully Initialized
     Lab Command    New Notebook
+    Wait For Dialog
     # Kernel selection dialog shows up, accept Python as default kernel
     Accept Default Dialog Option
     Element Should Contain    ${STATUSBAR}    Waiting...

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -413,7 +413,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
 
     // TODO only send the difference, using connection.sendSelectiveChange()
     let connection = this.connection_manager.connections.get(
-      virtual_document.id_path
+      virtual_document.uri
     );
     let adapter = this.adapters.get(virtual_document.id_path);
 
@@ -596,7 +596,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     );
     return {
       document,
-      connection: this.connection_manager.connections.get(document.id_path),
+      connection: this.connection_manager.connections.get(document.uri),
       virtual_position,
       root_position,
       features: this.get_features(document),

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -130,7 +130,7 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
         // TODO: add a config buttons next to the language header
         let list = documents.map((document, i) => {
           let connection = this.model.connection_manager.connections.get(
-            document.id_path
+            document.uri
           );
 
           let status = '';
@@ -542,8 +542,8 @@ export namespace LSPStatus {
       // detected documents with LSP servers available
       let documents_with_servers = new Set<VirtualDocument>();
 
-      detected_documents.forEach((document, id_path) => {
-        let connection = this._connection_manager.connections.get(id_path);
+      detected_documents.forEach((document, uri) => {
+        let connection = this._connection_manager.connections.get(uri);
         if (!connection) {
           absent_documents.add(document);
           return;
@@ -657,7 +657,7 @@ export namespace LSPStatus {
 
     change_adapter(adapter: WidgetAdapter<IDocumentWidget> | null) {
       if (this._adapter != null) {
-        this._adapter.status_message.changed.connect(this._onChange);
+        this._adapter.status_message.changed.disconnect(this._onChange);
       }
 
       if (adapter != null) {
@@ -671,6 +671,9 @@ export namespace LSPStatus {
       return this._connection_manager;
     }
 
+    /**
+     * Note: it is ever only set once, as connection_manager is a singleton.
+     */
     set connection_manager(connection_manager) {
       if (this._connection_manager != null) {
         this._connection_manager.connected.disconnect(this._onChange);

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -40,7 +40,7 @@ export class LSPConnector
   implements CompletionHandler.ICompletionItemsConnector {
   isDisposed = false;
   private _editor: CodeEditor.IEditor;
-  private _connections: Map<VirtualDocument.id_path, LSPConnection>;
+  private _connections: Map<VirtualDocument.uri, LSPConnection>;
   private _context_connector: ContextConnector;
   private _kernel_connector: KernelConnector;
   private _kernel_and_context_connector: CompletionConnector;
@@ -222,7 +222,7 @@ export class LSPConnector
     document: VirtualDocument,
     position_in_token: number
   ): Promise<CompletionHandler.ICompletionItemsReply> {
-    let connection = this._connections.get(document.id_path);
+    let connection = this._connections.get(document.uri);
 
     console.log('[LSP][Completer] Fetching');
     console.log('[LSP][Completer] Token:', token, start, end);

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -734,7 +734,7 @@ export class VirtualDocument {
     return this.parent.id_path + '-' + this.virtual_id;
   }
 
-  get uri(): string {
+  get uri(): VirtualDocument.uri {
     const encodedPath = encodeURI(this.path);
     if (!this.parent) {
       return encodedPath;
@@ -816,6 +816,10 @@ export namespace VirtualDocument {
    * for documents which should be interpreted as one when stretched across cells.
    */
   export type virtual_id = string;
+  /**
+   * Identifier composed of the file path and id_path.
+   */
+  export type uri = string;
 }
 
 export function collect_documents(


### PR DESCRIPTION
which were not correctly scoped by path by switching away from `id_path` which was refactored to not contain the actual file path to `uri` which does contain the file path and `id_path`.

## References

Fixes #469

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
