### PR TITLE
Add new status "no server extension"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - features
 
   - make the extension work with `jupyterlab-classic` - experimental, not all features are functional yet ([#465])
+  - new status "Server extension missing" and a dialog with advice was added to help users with atypical configurations ([#476])
 
 - bug fixes:
 
@@ -15,6 +16,7 @@
 [#449]: https://github.com/krassowski/jupyterlab-lsp/pull/449
 [#465]: https://github.com/krassowski/jupyterlab-lsp/pull/465
 [#474]: https://github.com/krassowski/jupyterlab-lsp/pull/474
+[#476]: https://github.com/krassowski/jupyterlab-lsp/pull/476
 
 ### `jupyter-lsp 1.0.1` (unreleased)
 

--- a/atest/04_Interface/BackendFailure.robot
+++ b/atest/04_Interface/BackendFailure.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Suite Setup       Setup Server and Browser    server_extension_enabled=${False}
+Resource          ../Keywords.robot
+
+*** Variables ***
+${STATUSBAR}      css:div.lsp-statusbar-item
+${POPOVER}        css:.lsp-popover
+
+*** Test Cases ***
+Handles Server Extension Failure
+    Setup Notebook    Python    Python.ipynb    wait=${False}
+    Element Should Contain    ${STATUSBAR}    Server extension missing
+    Click Element    ${STATUSBAR}
+    Wait For Dialog
+    Accept Default Dialog Option
+    Page Should Not Contain Element    ${POPOVER}
+    [Teardown]    Clean Up After Working With File    Python.ipynb

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -35,6 +35,9 @@ import { DocumentLocator } from './utils';
 import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
 import { LanguageServerManager } from '../manager';
 import { codeCheckIcon, codeClockIcon, codeWarningIcon } from './icons';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { SERVER_EXTENSION_404 } from '../errors';
+import okButton = Dialog.okButton;
 
 interface IServerStatusProps {
   server: SCHEMA.LanguageServerSession;
@@ -317,11 +320,19 @@ export class LSPStatus extends VDomRenderer<LSPStatus.Model> {
     if (this._popup) {
       this._popup.dispose();
     }
-    this._popup = showPopup({
-      body: new LSPPopup(this.model),
-      anchor: this,
-      align: 'left'
-    });
+    if (this.model.status.status == 'no_server_extension') {
+      showDialog({
+        title: 'LSP server extension not found',
+        body: SERVER_EXTENSION_404,
+        buttons: [okButton()]
+      }).catch(console.warn);
+    } else {
+      this._popup = showPopup({
+        body: new LSPPopup(this.model),
+        anchor: this,
+        align: 'left'
+      });
+    }
   };
 }
 
@@ -364,6 +375,7 @@ export class StatusButtonExtension
 }
 
 type StatusCode =
+  | 'no_server_extension'
   | 'waiting'
   | 'initializing'
   | 'initialized'
@@ -389,6 +401,7 @@ type StatusMap = Record<StatusCode, string>;
 type StatusIconClass = Record<StatusCode, string>;
 
 const classByStatus: StatusIconClass = {
+  no_server_extension: 'error',
   waiting: 'inactive',
   initialized: 'ready',
   initializing: 'preparing',
@@ -397,6 +410,7 @@ const classByStatus: StatusIconClass = {
 };
 
 const iconByStatus: Record<StatusCode, LabIcon> = {
+  no_server_extension: codeWarningIcon,
   waiting: codeClockIcon,
   initialized: codeCheckIcon,
   initializing: codeClockIcon,
@@ -405,6 +419,7 @@ const iconByStatus: Record<StatusCode, LabIcon> = {
 };
 
 const shortMessageByStatus: StatusMap = {
+  no_server_extension: 'Server extension missing',
   waiting: 'Waiting...',
   initialized: 'Fully initialized',
   initialized_but_some_missing: 'Initialized (additional servers needed)',
@@ -569,7 +584,9 @@ export namespace LSPStatus {
       });
 
       let status: StatusCode;
-      if (detected_documents.size === 0) {
+      if (this.language_server_manager.statusCode === 404) {
+        status = 'no_server_extension';
+      } else if (detected_documents.size === 0) {
         status = 'waiting';
       } else if (initialized_documents.size === detected_documents.size) {
         status = 'initialized';

--- a/packages/jupyterlab-lsp/src/errors.tsx
+++ b/packages/jupyterlab-lsp/src/errors.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+function external_link(url: string, label: string) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="lsp-external-link"
+    >
+      {label}
+    </a>
+  );
+}
+
+const migration_guide_url =
+  'https://jupyter-server.readthedocs.io/en/latest/operators/migrate-from-nbserver.html';
+const jupyter_hub_migration_url =
+  'https://github.com/jupyterhub/jupyterhub/pull/3329/files';
+
+export const SERVER_EXTENSION_404 = (
+  <div>
+    <p>
+      It appears that the required Jupyter server extension (
+      <code>jupyter-lsp</code>) is not installed (or not enabled) in this
+      environment.
+    </p>
+    <h3>What are the likely reasons?</h3>
+    <ul>
+      <li>
+        It might be that you just installed it and need to restart JupyterLab to
+        make it available on startup.
+      </li>
+      <li>
+        Alternatively, you may be using an older <code>notebook</code> server
+        instead of the new <code>jupyter_server</code>; please refer to the{' '}
+        {external_link(migration_guide_url, 'migration guide')} or if you are a
+        JupyterHub user please ensure that you start the JupyterLab using{' '}
+        <code>jupyter_server</code> and not the old <code>notebook</code>, as
+        documented in{' '}
+        {external_link(jupyter_hub_migration_url, 'this pull request')}.
+      </li>
+      <li>
+        There may be schema errors or language server errors preventing the
+        extension from loading - please check the logs of JupyterLab (in the
+        console where you execute <code>jupyter lab</code>
+      </li>
+    </ul>
+    <h3>How do I check if the extension is installed?</h3>
+    <p>
+      Please ensure that <code>jupyter server extension list</code> includes
+      jupyter-lsp and that it is enabled. If it is enabled please try to restart
+      JupyterLab.
+    </p>
+  </div>
+);

--- a/packages/jupyterlab-lsp/src/tokens.ts
+++ b/packages/jupyterlab-lsp/src/tokens.ts
@@ -57,6 +57,7 @@ export interface ILanguageServerManager {
   ): TLanguageServerId;
   fetchSessions(): Promise<void>;
   statusUrl: string;
+  statusCode: number;
 }
 
 export interface ILanguageServerConfiguration {
@@ -73,6 +74,15 @@ export namespace ILanguageServerManager {
   export interface IOptions {
     settings?: ServerConnection.ISettings;
     baseUrl?: string;
+    /**
+     * Number of connection retries to fetch the sessions.
+     * Default 2.
+     */
+    retries?: number;
+    /**
+     * The interval for retries, default 10 seconds.
+     */
+    retriesInterval?: number;
   }
   export interface IGetServerIdOptions {
     language?: TLanguageId;

--- a/packages/jupyterlab-lsp/style/index.css
+++ b/packages/jupyterlab-lsp/style/index.css
@@ -13,3 +13,7 @@
   transform: scaleX(-1);
   transform-origin: center center;
 }
+
+.lsp-external-link {
+  color: var(--jp-content-link-color);
+}

--- a/packages/jupyterlab-lsp/style/statusbar.css
+++ b/packages/jupyterlab-lsp/style/statusbar.css
@@ -106,6 +106,10 @@ h5 {
   fill: var(--jp-warn-color0);
 }
 
+.lsp-status-icon.error svg g {
+  fill: var(--jp-error-color0);
+}
+
 .lsp-status-icon.inactive svg g {
   fill: var(--jp-layout-color3);
 }


### PR DESCRIPTION
## References

Fixes #453 and hopefully will reduce the influx of issues cause by the recent ecosystem changes.

## Code changes

- Added new status based on /lsp endpoint response code (only active for 404)
  - the session retrieval now has 2 retries (10 second interval) to make it less likely that we refuse to cooperate when there was a temporary network issue, especially for users working over a proxy etc. It might be increased to more retries if we want to.
- Clicking on button opens dialog with useful info rather than a weird empty popup
- The new status uses red error color code
- Added test for backend failure which required to disable all global jupyter config when an argument is passed) as this was enabling the backend extension

## User-facing changes

![server_missing](https://user-images.githubusercontent.com/5832902/104796881-f66b7f00-57b1-11eb-80b9-f8faf562cebd.gif)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
