### PR TITLE
Fix truncated stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@
 
   - send periodic pings on websocket channels to maintain connection ([#459], thanks @franckchen)
   - R languageserver is no longer incorrectly shown as available when not installed ([#463])
+  - fix completion of very large namespaces (e.g. in R's base or in JavaScript) due to truncated message relay ([#477])
 
 [#459]: https://github.com/krassowski/jupyterlab-lsp/pull/459
 [#463]: https://github.com/krassowski/jupyterlab-lsp/pull/463
+[#477]: https://github.com/krassowski/jupyterlab-lsp/pull/477
 
 ### `@krassowski/jupyterlab-lsp 3.0.0` (2021-01-06)
 

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -203,6 +203,14 @@ Completes Correctly With R Double And Triple Colon
     Wait Until Keyword Succeeds    40x    0.5s    File Editor Line Should Equal    3    datasets:::.packageName
     [Teardown]    Clean Up After Working With File    completion.R
 
+Completes Large Namespaces
+    [Setup]    Prepare File for Editing    R    completion    completion.R
+    Place Cursor In File Editor At    6    7
+    Wait Until Fully Initialized
+    Trigger Completer
+    Completer Should Suggest    abs    timeout=30s
+    [Teardown]    Clean Up After Working With File    completion.R
+
 *** Keywords ***
 Setup Completion Test
     Setup Notebook    Python    Completion.ipynb
@@ -235,8 +243,8 @@ Select Completer Suggestion
     Click Element    ${suggestion} code
 
 Completer Should Suggest
-    [Arguments]    ${text}
-    Wait Until Page Contains Element    ${COMPLETER_BOX} .jp-Completer-item[data-value="${text}"]    timeout=10s
+    [Arguments]    ${text}    ${timeout}=10s
+    Wait Until Page Contains Element    ${COMPLETER_BOX} .jp-Completer-item[data-value="${text}"]    timeout=${timeout}
     Capture Page Screenshot    ${text.replace(' ', '_')}.png
 
 Completer Should Include Icon

--- a/atest/examples/completion.R
+++ b/atest/examples/completion.R
@@ -2,3 +2,5 @@
 tools::
 # `datasets:::<tab>` → select `.packageName` → `datasets:::.packageName`
 datasets:::
+# `base:::<tab>` → works
+base:::

--- a/docs/Configuring.ipynb
+++ b/docs/Configuring.ipynb
@@ -210,6 +210,9 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Example: Scala Language Server (metals) integration with jupyterlab-lsp\n",
     "\n",
@@ -225,11 +228,13 @@
     "$ ./coursier launch --fork almond -- --install\n",
     "$ rm -f coursier\n",
     "```\n",
+    "\n",
     "Spark Magic kernel:\n",
     "\n",
     "```bash\n",
     "pip install sparkmagic\n",
     "```\n",
+    "\n",
     "Now, install the spark kernel:\n",
     "\n",
     "```bash\n",
@@ -247,7 +252,8 @@
     "\n",
     "(Might need to use the --force-fetch flag if you are getting dependency issues.)\n",
     "\n",
-    "Step 3: Configure the metals server in jupyterlab-lsp. Enter the following in the jupyter_server_config.json:\n",
+    "Step 3: Configure the metals server in jupyterlab-lsp. Enter the following in\n",
+    "the jupyter_server_config.json:\n",
     "\n",
     "```python\n",
     "{\n",
@@ -264,11 +270,10 @@
     "}\n",
     "```\n",
     "\n",
-    "You are good to go now! Just start `jupyter lab` and create a notebook with either the Spark or the Scala kernel and you should be able to see the metals server initialised from the bottom left corner."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "You are good to go now! Just start `jupyter lab` and create a notebook with\n",
+    "either the Spark or the Scala kernel and you should be able to see the metals\n",
+    "server initialised from the bottom left corner."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## References

Fixes #450, enabling parsing of large responses from R server (e.g. completion on base) and any responses from javascript/typescript language servers

## Code changes

Turns out `BufferedIOBase.read()` does buffering... And we need to read in chunks until we consume all needed chunks.

## User-facing changes

Completion for R works better, completion for javascript works. May also help some Python packages with huge namespaces, e.g numpy. It will also improve perceived completion speed.

![long_namespace_completion_works](https://user-images.githubusercontent.com/5832902/104797105-8bbb4300-57b3-11eb-985f-4fb8b4458932.gif)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted
- [x] tested - TODO a robot test for R base completion.
- [ ] documented
- [x] changelog entry
