### PR TITLE
Fix handling of kernel change and restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@
 
 - bug fixes:
 
-  - fix completions with R double and triple colon prefix ([#449])
-  - fix contrast on status icon when status item is active ([#465])
-  - fix connection manager loosing track of notebooks when multiple were open ([#474])
+  - namespace completions in R (after double and triple colon) now work properly ([#449])
+  - improved status icon contrast when status item is active ([#465])
+  - connection manager now properly keeps track of notebooks when multiple notebooks are open ([#474])
+  - new cells added after kernel restart now work properly; kernel changes are handled correctly ([#478])
 
 [#449]: https://github.com/krassowski/jupyterlab-lsp/pull/449
 [#465]: https://github.com/krassowski/jupyterlab-lsp/pull/465
 [#474]: https://github.com/krassowski/jupyterlab-lsp/pull/474
+[#478]: https://github.com/krassowski/jupyterlab-lsp/pull/478
 
 ### `jupyter-lsp 1.0.1` (unreleased)
 

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -28,6 +28,7 @@ Works With Kernel Running
 
 Works When Kernel Is Shut Down
     Lab Command    Shut Down All Kernels…
+    Wait For Dialog
     Capture Page Screenshot    01-shutting-kernels.png
     Accept Default Dialog Option
     Capture Page Screenshot    02-kernels-shut.png
@@ -38,6 +39,21 @@ Works When Kernel Is Shut Down
     Completer Should Suggest    test
     # this comes from kernel:
     Completer Should Not Suggest    %%timeit
+
+Works After Kernel Restart In New Cells
+    Lab Command    Restart Kernel…
+    Wait For Dialog
+    Accept Default Dialog Option
+    Enter Cell Editor    1    line=2
+    # works in old cells
+    Trigger Completer
+    Completer Should Suggest    test
+    Lab Command    Insert Cell Below
+    Enter Cell Editor    2    line=1
+    # works in new cells
+    Press Keys    None    lis
+    Trigger Completer
+    Completer Should Suggest    list
 
 Works In File Editor
     [Setup]    Prepare File for Editing    Python    completion    completion.py

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -236,10 +236,17 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     );
 
     // recreate virtual document using current path and language
-    let virtual_document = this.create_virtual_document();
-    this.virtual_editor.virtual_document = virtual_document;
+    // as virtual editor assumes it gets the virtual document at init,
+    // just dispose virtual editor (which disposes virtual document too)
+    // and re-initialize both virtual editor and document
+    this.virtual_editor.dispose();
+
+    this.init_virtual();
+
     // reconnect
-    this.connect_document(virtual_document, true).catch(console.warn);
+    this.connect_document(this.virtual_editor.virtual_document, true).catch(
+      console.warn
+    );
   }
 
   protected on_save_state(context: any, state: DocumentRegistry.SaveState) {


### PR DESCRIPTION
## References

Fixes #475.

## Code changes

Logic for handling re-connection after kernel restart was borked as it was only re-initializing a virtual document, whereas both virtual editor and virtual editor need to be re-initialised. This fixes it

## User-facing changes

New cells added after kernel restart work again.

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
