### PR TITLE
Prepare 3.1.0 and 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 ## CHANGELOG
 
-### `@krassowski/jupyterlab-lsp 3.1.0` (unreleased)
+### `@krassowski/jupyterlab-lsp 3.1.0` (2021-01-17)
 
 - features
 
-  - added experimental detection of Julia and Jedi language servers ([#481])
   - make the extension work with `jupyterlab-classic` - experimental, not all features are functional yet ([#465])
   - new status "Server extension missing" and a dialog with advice was added to help users with atypical configurations ([#476])
   - for developers: the verbosity of console logs is now controllable from settings and set to warn by default ([#480])
@@ -25,9 +24,12 @@
 [#478]: https://github.com/krassowski/jupyterlab-lsp/pull/478
 [#479]: https://github.com/krassowski/jupyterlab-lsp/pull/479
 [#480]: https://github.com/krassowski/jupyterlab-lsp/pull/480
-[#481]: https://github.com/krassowski/jupyterlab-lsp/pull/481
 
-### `jupyter-lsp 1.0.1` (unreleased)
+### `jupyter-lsp 1.1.0` (2021-01-17)
+
+- features
+
+  - added experimental detection of Julia and Jedi language servers ([#481])
 
 - bug fixes:
 
@@ -38,6 +40,7 @@
 [#459]: https://github.com/krassowski/jupyterlab-lsp/pull/459
 [#463]: https://github.com/krassowski/jupyterlab-lsp/pull/463
 [#477]: https://github.com/krassowski/jupyterlab-lsp/pull/477
+[#481]: https://github.com/krassowski/jupyterlab-lsp/pull/481
 
 ### `@krassowski/jupyterlab-lsp 3.0.0` (2021-01-06)
 

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp-metapackage",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/krassowski/jupyterlab-lsp",
   "bugs": {

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_lsp version
 """
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/python_packages/jupyterlab_lsp/setup.cfg
+++ b/python_packages/jupyterlab_lsp/setup.cfg
@@ -29,5 +29,5 @@ zip_safe = False
 python_requires = >=3.6
 
 install_requires =
-    jupyter_lsp >=1.0.0rc0
+    jupyter_lsp >=1.1.0
     jupyterlab >=3.0.0,<4.0.0a0


### PR DESCRIPTION
Release time :tada: 

Notes:
- failure on windows is limited to the new "Completes Large Namespaces" test case - Windows CI needs less strict timeouts, to be addressed after release
- known failure on Ubuntu with Python 3.6; pinning `jupyter_server==2.0.0` is known to solve the issue; the impact is limited to one pyls plugin; this was introduced by an upstream change and affects the older version too