### PR TITLE
Add jupyterlab-classic to the Binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   # runtime dependencies
   - python >=3.6,<3.9.0a0
   - jupyterlab >=3.0.0,<4.0.0a0
+  - jupyterlab-classic >=0.1.3,<0.2
   - jupyter_server >=1.1.2
   # build dependencies
   - nodejs >=12,<15


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

Add `jupyterlab-classic` to the demo Binder, as there is now experimental support for it (#465)

Testing this PR with:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jtpio/jupyterlab-lsp/jupyterlab-classic-binder?urlpath=classic%2Ftree)

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Binder changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

None
<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
