### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@
 
 - bug fixes:
 
-- diagnostics panel works after kernel restart properly
-- workaround was added to enable jedi-language-server diagnostics
+  - diagnostics panel works after kernel restart properly ([#485])
+  - workaround was added to enable `jedi-language-server` diagnostics ([#485])
 
 ### `jupyter-lsp 1.1.1` (unreleased)
 
 - bug fixes:
 
-  - PythonSpec no longer raises exception when the server module does not exist
+  - `PythonModuleSpec` no longer raises exception when the server module does not exist ([#485])
+
+[#485]: https://github.com/krassowski/jupyterlab-lsp/pull/485
 
 ### `@krassowski/jupyterlab-lsp 3.1.0` (2021-01-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 3.1.1` (unreleased)
+
+- bug fixes:
+
+- diagnostics panel works after kernel restart properly
+- workaround was added to enable jedi-language-server diagnostics
+
+### `jupyter-lsp 1.1.1` (unreleased)
+
+- bug fixes:
+
+  - PythonSpec no longer raises exception when the server module does not exist
+
 ### `@krassowski/jupyterlab-lsp 3.1.0` (2021-01-17)
 
 - features

--- a/atest/04_Interface/DiagnosticsPanel.robot
+++ b/atest/04_Interface/DiagnosticsPanel.robot
@@ -28,6 +28,16 @@ Diagnostics Panel Works After Rename
     Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    ${EXPECTED_COUNT}
     Clean Up After Working With File    PanelRenamed.ipynb
 
+Diagnostics Panel Works After Kernel Restart
+    [Documentation]    Test for #475 bug
+    Close Diagnostics Panel
+    Lab Command    Restart Kernel…
+    Wait For Dialog
+    Accept Default Dialog Option
+    Wait Until Page Contains Element    css:.cm-lsp-diagnostic[title*="${DIAGNOSTIC}"]    timeout=20s
+    Open Diagnostics Panel
+    Wait Until Keyword Succeeds    10 x    1s    Should Have Expected Rows Count    ${EXPECTED_COUNT}
+
 Diagnostics Panel Can Be Restored
     Close Diagnostics Panel
     Open Diagnostics Panel

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -223,7 +223,7 @@ Completes Large Namespaces
     [Setup]    Prepare File for Editing    R    completion    completion.R
     Place Cursor In File Editor At    6    7
     Wait Until Fully Initialized
-    Wait Until Keyword Succeeds    3x    2s    Trigger Completer    timeout=45s
+    Wait Until Keyword Succeeds    3x    2s    Trigger Completer    timeout=90s
     Completer Should Suggest    abs    timeout=30s
     [Teardown]    Clean Up After Working With File    completion.R
 

--- a/packages/jupyterlab-lsp/schema/syntax_highlighting.json
+++ b/packages/jupyterlab-lsp/schema/syntax_highlighting.json
@@ -9,7 +9,7 @@
       "title": "Threshold of foreign code coverage for changing the mode in an editor",
       "type": "number",
       "default": 0.5,
-      "description": "If a code editor includes a code fragment in another language (for example a %%markdown magic in IPython) with appropriate foreign code extractor defined , and the extend of this code (coverage of the editor) passes the threshold, the syntax highlighting (i.e. the mode) will change to provide highlighting for the language of the foreign code."
+      "description": "If a code editor includes a code fragment in another language (for example a %%markdown magic in IPython) with appropriate foreign code extractor defined, and the extend of this code (coverage of the editor) passes the threshold, the syntax highlighting (i.e. the mode) will change to provide highlighting for the language of the foreign code."
     }
   },
   "jupyter.lab.shortcuts": []

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -489,7 +489,7 @@ export namespace LSPStatus {
           server => server.spec.languages.indexOf(language) !== -1
         );
         if (servers.length > 1) {
-          console.warn('More than one server per language for' + language);
+          console.warn('More than one server per language for', language);
         }
         if (servers.length === 0) {
           continue;

--- a/packages/jupyterlab-lsp/src/connection_manager.ts
+++ b/packages/jupyterlab-lsp/src/connection_manager.ts
@@ -306,7 +306,7 @@ export class DocumentConnectionManager {
         );
       } catch {
         this.console.warn(
-          `LSP: Connection to ${virtual_document.uri} timed out after ${firstTimeoutSeconds} seconds, will continue retrying for another ${secondTimeoutMinutes} minutes`
+          `Connection to ${virtual_document.uri} timed out after ${firstTimeoutSeconds} seconds, will continue retrying for another ${secondTimeoutMinutes} minutes`
         );
         try {
           await until_ready(
@@ -316,7 +316,7 @@ export class DocumentConnectionManager {
           );
         } catch {
           this.console.warn(
-            `LSP: Connection to ${virtual_document.uri} timed out again after ${secondTimeoutMinutes} minutes, giving up`
+            `Connection to ${virtual_document.uri} timed out again after ${secondTimeoutMinutes} minutes, giving up`
           );
           return;
         }

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -276,6 +276,9 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
     this.wrapper_handlers.set('focusin', this.switchDiagnosticsPanelSource);
     this.unique_editor_ids = new DefaultMap(() => this.unique_editor_ids.size);
     this.settings.changed.connect(this.refreshDiagnostics, this);
+    this.adapter.adapterConnected.connect(() =>
+      this.switchDiagnosticsPanelSource()
+    );
     super.register();
   }
 
@@ -300,7 +303,8 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
 
   switchDiagnosticsPanelSource = () => {
     if (
-      diagnostics_panel.content.model.virtual_editor === this.virtual_editor
+      diagnostics_panel.content.model.virtual_editor === this.virtual_editor &&
+      diagnostics_panel.content.model.diagnostics == this.diagnostics_db
     ) {
       return;
     }
@@ -596,7 +600,9 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
   };
 
   public refreshDiagnostics() {
-    this.setDiagnostics(this.last_response);
+    if (this.last_response) {
+      this.setDiagnostics(this.last_response);
+    }
     diagnostics_panel.update();
   }
 

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -275,10 +275,6 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
     this.connection_handlers.set('diagnostic', this.handleDiagnostic);
     this.wrapper_handlers.set('focusin', this.switchDiagnosticsPanelSource);
     this.unique_editor_ids = new DefaultMap(() => this.unique_editor_ids.size);
-    if (!diagnostics_databases.has(this.virtual_editor)) {
-      diagnostics_databases.set(this.virtual_editor, new DiagnosticsDatabase());
-    }
-    this.diagnostics_db = diagnostics_databases.get(this.virtual_editor);
     this.settings.changed.connect(this.refreshDiagnostics, this);
     super.register();
   }
@@ -294,7 +290,13 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
    *
    * Maps virtual_document.uri to IEditorDiagnostic[].
    */
-  public diagnostics_db: DiagnosticsDatabase;
+  public get diagnostics_db(): DiagnosticsDatabase {
+    // Note that virtual_editor can change at runtime (kernel restart)
+    if (!diagnostics_databases.has(this.virtual_editor)) {
+      diagnostics_databases.set(this.virtual_editor, new DiagnosticsDatabase());
+    }
+    return diagnostics_databases.get(this.virtual_editor);
+  }
 
   switchDiagnosticsPanelSource = () => {
     if (

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -378,6 +378,12 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
       let code = diagnostic.code;
       if (
         typeof code !== 'undefined' &&
+        // pygls servers return code null if value is missing (rather than undefined)
+        // which is a departure from the LSP specs: https://microsoft.github.io/language-server-protocol/specification#diagnostic
+        // there is an open issue: https://github.com/openlawlibrary/pygls/issues/124
+        // and PR: https://github.com/openlawlibrary/pygls/pull/132
+        // this also affects hover tooltips.
+        code !== null &&
         ignoredDiagnosticsCodes.has(code.toString())
       ) {
         return false;

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
@@ -93,6 +93,9 @@ class PythonModuleSpec(SpecBase):
     def __call__(self, mgr: LanguageServerManagerAPI) -> KeyedLanguageServerSpecs:
         spec = __import__("importlib").util.find_spec(self.python_module)
 
+        if not spec:
+            return {}
+
         if not spec.origin:  # pragma: no cover
             return {}
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_detect.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_detect.py
@@ -32,17 +32,7 @@ def test_r_package_detection():
 
 
 def test_missing_python_module_spec():
-    """Prevent failure in module detection raising error:
-
-    Failed to fetch commands from language server spec finder`python-language-server`:
-        'NoneType' object has no attribute 'origin'
-    Traceback (most recent call last):
-      File "../lib/python3.8/site-packages/jupyter_lsp/manager.py", line 209, in _autodetect_language_servers
-        specs = spec_finder(self)
-      File "../lib/python3.8/site-packages/jupyter_lsp/specs/utils.py", line 96, in __call__
-        if not spec.origin:  # pragma: no cover
-    AttributeError: 'NoneType' object has no attribute 'origin'
-    """
+    """Prevent failure in module detection raising error"""
 
     class NonInstalledPythonServer(PythonModuleSpec):
         python_module = "not_installed_python_module"

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_detect.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_detect.py
@@ -1,6 +1,7 @@
 import shutil
 
 from jupyter_lsp.specs.r_languageserver import RLanguageServer
+from jupyter_lsp.specs.utils import PythonModuleSpec
 
 
 def test_no_detect(manager):
@@ -28,3 +29,23 @@ def test_r_package_detection():
 
     non_installed_server = NonInstalledRServer()
     assert non_installed_server.is_installed(cmd=existing_runner) is False
+
+
+def test_missing_python_module_spec():
+    """Prevent failure in module detection raising error:
+
+    Failed to fetch commands from language server spec finder`python-language-server`:
+        'NoneType' object has no attribute 'origin'
+    Traceback (most recent call last):
+      File "../lib/python3.8/site-packages/jupyter_lsp/manager.py", line 209, in _autodetect_language_servers
+        specs = spec_finder(self)
+      File "../lib/python3.8/site-packages/jupyter_lsp/specs/utils.py", line 96, in __call__
+        if not spec.origin:  # pragma: no cover
+    AttributeError: 'NoneType' object has no attribute 'origin'
+    """
+
+    class NonInstalledPythonServer(PythonModuleSpec):
+        python_module = "not_installed_python_module"
+
+    not_installed_server = NonInstalledPythonServer()
+    assert not_installed_server(mgr=None) == {}


### PR DESCRIPTION
## References

- Fixes #475
- Allows to display the jedi-language-server diagnostics despite of the spec violation (related to #437)
- Fixes an issue with `PythonModuleSpec` when pyls is **not** installed:

```
Failed to fetch commands from language server spec finder`python-language-server`:
    'NoneType' object has no attribute 'origin'
Traceback (most recent call last):
  File "../lib/python3.8/site-packages/jupyter_lsp/manager.py", line 209, in _autodetect_language_servers
    specs = spec_finder(self)
  File "../lib/python3.8/site-packages/jupyter_lsp/specs/utils.py", line 96, in __call__
    if not spec.origin:  # pragma: no cover
AttributeError: 'NoneType' object has no attribute 'origin'
```

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
