### PR TITLE
Completer improvements: kernel type mapping and dynamic documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## CHANGELOG
 
-### `@krassowski/jupyterlab-lsp 3.1.1` (unreleased)
+### `@krassowski/jupyterlab-lsp 3.2.0` (unreleased)
+
+- features:
+
+  - documentation panel in completer now works for R language too: implemented `completionItem/resolve` ([#487])
+  - kernel types returned by IPython and IJulia are now mapped to LSP types; you can customize the mappings in settings ([#487])
 
 - bug fixes:
 
@@ -14,6 +19,7 @@
   - `PythonModuleSpec` no longer raises exception when the server module does not exist ([#485])
 
 [#485]: https://github.com/krassowski/jupyterlab-lsp/pull/485
+[#487]: https://github.com/krassowski/jupyterlab-lsp/pull/487
 
 ### `@krassowski/jupyterlab-lsp 3.1.0` (2021-01-17)
 

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -7,6 +7,7 @@ Resource          ../Keywords.robot
 
 *** Variables ***
 ${COMPLETER_BOX}    css:.jp-Completer.jp-HoverBox
+${DOCUMENTATION_PANEL}    css:.jp-Completer-docpanel
 
 *** Test Cases ***
 Works With Kernel Running
@@ -227,6 +228,15 @@ Completes Large Namespaces
     Completer Should Suggest    abs    timeout=30s
     [Teardown]    Clean Up After Working With File    completion.R
 
+Shows Documentation With CompletionItem Resolve
+    [Setup]    Prepare File for Editing    R    completion    completion.R
+    Place Cursor In File Editor At    8    12
+    Wait Until Fully Initialized
+    Trigger Completer
+    Completer Should Suggest    print.default
+    Completer Should Include Documentation    the default method of the
+    [Teardown]    Clean Up After Working With File    completion.R
+
 *** Keywords ***
 Setup Completion Test
     Setup Notebook    Python    Completion.ipynb
@@ -275,3 +285,8 @@ Trigger Completer
     [Arguments]    ${timeout}=35s
     Press Keys    None    TAB
     Wait Until Page Contains Element    ${COMPLETER_BOX}    timeout=${timeout}
+
+Completer Should Include Documentation
+    [Arguments]    ${text}
+    Wait Until Page Contains Element    ${DOCUMENTATION_PANEL}    timeout=10s
+    Element Should Contain    ${DOCUMENTATION_PANEL}    ${text}

--- a/atest/examples/completion.R
+++ b/atest/examples/completion.R
@@ -4,3 +4,5 @@ tools::
 datasets:::
 # `base:::<tab>` → works
 base:::
+# `print.defaul<tab>` → shows documentation for `print.default`
+print.defaul

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -17,7 +17,6 @@ import {
 } from './types';
 import { render_themes_list } from './about';
 import '../style/index.css';
-import { ILSPLogConsole } from '@krassowski/jupyterlab-lsp';
 
 export class CompletionThemeManager implements ILSPCompletionThemeManager {
   protected current_icons: Map<string, LabIcon>;
@@ -164,7 +163,7 @@ const LSP_CATEGORY = 'Language server protocol';
 
 export const COMPLETION_THEME_MANAGER: JupyterFrontEndPlugin<ILSPCompletionThemeManager> = {
   id: PLUGIN_ID,
-  requires: [IThemeManager, ICommandPalette, ILSPLogConsole],
+  requires: [IThemeManager, ICommandPalette],
   activate: (
     app,
     themeManager: IThemeManager,

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -12,20 +12,24 @@ import {
   ILSPCompletionThemeManager,
   PLUGIN_ID,
   COMPLETER_THEME_PREFIX,
-  KernelKind
+  KernelKind,
+  CompletionItemKindStrings
 } from './types';
 import { render_themes_list } from './about';
 import '../style/index.css';
+import { ILSPLogConsole } from '@krassowski/jupyterlab-lsp';
 
 export class CompletionThemeManager implements ILSPCompletionThemeManager {
   protected current_icons: Map<string, LabIcon>;
   protected themes: Map<string, ICompletionTheme>;
   private current_theme_id: string;
   private icons_cache: Map<string, LabIcon>;
+  private icon_overrides: Record<string, CompletionItemKindStrings>;
 
   constructor(protected themeManager: IThemeManager) {
     this.themes = new Map();
     this.icons_cache = new Map();
+    this.icon_overrides = {};
     themeManager.themeChanged.connect(this.update_icons_set, this);
   }
 
@@ -78,12 +82,16 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
     }
     let options = this.current_theme.icons.options || {};
     if (type) {
+      if (type in this.icon_overrides) {
+        type = this.icon_overrides[type];
+      }
       type =
         type.substring(0, 1).toUpperCase() + type.substring(1).toLowerCase();
     }
     if (this.current_icons.has(type)) {
       return this.current_icons.get(type).bindprops(options);
     }
+
     if (type === KernelKind) {
       return kernelIcon;
     }
@@ -144,13 +152,19 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
       buttons: [Dialog.okButton()]
     }).catch(console.warn);
   }
+
+  set_icons_overrides(
+    iconOverrides: Record<string, CompletionItemKindStrings>
+  ) {
+    this.icon_overrides = iconOverrides;
+  }
 }
 
 const LSP_CATEGORY = 'Language server protocol';
 
 export const COMPLETION_THEME_MANAGER: JupyterFrontEndPlugin<ILSPCompletionThemeManager> = {
   id: PLUGIN_ID,
-  requires: [IThemeManager, ICommandPalette],
+  requires: [IThemeManager, ICommandPalette, ILSPLogConsole],
   activate: (
     app,
     themeManager: IThemeManager,

--- a/packages/completion-theme/src/types.ts
+++ b/packages/completion-theme/src/types.ts
@@ -116,6 +116,10 @@ export interface ILSPCompletionThemeManager {
   get_iconset(
     theme: ICompletionTheme
   ): Map<keyof ICompletionIconSet, LabIcon.ILabIcon>;
+
+  set_icons_overrides(
+    map: Record<string, CompletionItemKindStrings | 'Kernel'>
+  ): void;
 }
 
 export const ILSPCompletionThemeManager = new Token<ILSPCompletionThemeManager>(

--- a/packages/completion-theme/style/index.css
+++ b/packages/completion-theme/style/index.css
@@ -23,3 +23,8 @@
 .jp-Completer-docpanel {
   overflow: auto;
 }
+
+.lsp-completer-placeholder:after {
+  content: 'Loading...';
+  color: #7f7f7f;
+}

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -31,6 +31,54 @@
       "type": ["string", "null"],
       "default": "vscode",
       "description": "The identifier of a completer theme with icons which indicate the kind of completion. Set to null to disable icons."
+    },
+    "typesMap": {
+      "title": "Mapping of custom kernel types to valid completion kind names",
+      "description": "Mapping used for icon selection. Accepted values are the names of CompletionItemKind and 'Kernel' literal. The defaults aim to provide good initial experience for Julia, Python and R kernels.",
+      "type": "object",
+      "default": {
+        "<unknown>": "Kernel",
+        "instance": "Value",
+        "path": "File",
+        "param": "Variable",
+        "missing": "Constant",
+        "nothing": "Constant",
+        "undefinitializer": "Constant",
+        "base.devnull": "Constant"
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "string",
+          "enum": [
+            "Kernel",
+            "Text",
+            "Method",
+            "Function",
+            "Constructor",
+            "Field",
+            "Variable",
+            "Class",
+            "Interface",
+            "Module",
+            "Property",
+            "Unit",
+            "Value",
+            "Enum",
+            "Keyword",
+            "Snippet",
+            "Color",
+            "File",
+            "Reference",
+            "Folder",
+            "EnumMember",
+            "Constant",
+            "Struct",
+            "Event",
+            "Operator",
+            "TypeParameter"
+          ]
+        }
+      }
     }
   },
   "jupyter.lab.shortcuts": []

--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -4,10 +4,10 @@
 // Introduced modifications are BSD licenced, copyright JupyterLab development team.
 import * as lsProtocol from 'vscode-languageserver-protocol';
 import {
+  IDocumentInfo,
   ILspOptions,
   IPosition,
-  LspWsConnection,
-  IDocumentInfo
+  LspWsConnection
 } from 'lsp-ws-connection';
 import { until_ready } from './utils';
 
@@ -137,5 +137,22 @@ export class LSPConnection extends LspWsConnection {
       textDocumentChange
     );
     documentInfo.version++;
+  }
+
+  async getCompletionResolve(completionItem: lsProtocol.CompletionItem) {
+    if (!this.isReady || !this.isCompletionResolveProvider()) {
+      return;
+    }
+    return this.connection.sendRequest<lsProtocol.CompletionItem>(
+      'completionItem/resolve',
+      completionItem
+    );
+  }
+
+  /**
+   * Does support completionItem/resolve?.
+   */
+  public isCompletionResolveProvider(): boolean {
+    return this.serverCapabilities?.completionProvider?.resolveProvider;
   }
 }

--- a/packages/jupyterlab-lsp/src/features/completion/completion.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion.ts
@@ -243,7 +243,7 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
       this.current_index
     ];
 
-    if (active.insertText != item.insertText) {
+    if (!item || active.insertText != item.insertText) {
       return;
     }
 

--- a/packages/jupyterlab-lsp/src/features/completion/completion.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion.ts
@@ -261,18 +261,18 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
 
       docPanel.setAttribute('style', '');
     } else {
-      docPanel.setAttribute('style', 'none');
+      docPanel.setAttribute('style', 'display: none');
     }
   }
 
-  set_doc_panel_placeholder(enabled: boolean) {
+  set_doc_panel_placeholder(enable: boolean) {
     let completer = this.current_completion_handler.completer;
     const docPanel = completer.node.querySelector(DOC_PANEL_SELECTOR);
-    if (enabled) {
+    if (enable) {
       docPanel.setAttribute('style', '');
       docPanel.classList.add(DOC_PANEL_PLACEHOLDER_CLASS);
-    } else {
-      docPanel.setAttribute('style', 'none');
+    } else if (docPanel.classList.contains(DOC_PANEL_PLACEHOLDER_CLASS)) {
+      docPanel.setAttribute('style', 'display: none');
       docPanel.classList.remove(DOC_PANEL_PLACEHOLDER_CLASS);
     }
   }

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -123,14 +123,17 @@ export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
 
     this._requested_resolution = true;
 
-    connection.getCompletionResolve(this.match).then(resolvedCompletionItem => {
-      if (resolvedCompletionItem === null) {
-        return;
-      }
-      this._setDocumentation(resolvedCompletionItem.documentation);
-      this._resolved = true;
-      this.connector.lab_integration.refresh_doc_panel(this);
-    });
+    connection
+      .getCompletionResolve(this.match)
+      .then(resolvedCompletionItem => {
+        if (resolvedCompletionItem === null) {
+          return;
+        }
+        this._setDocumentation(resolvedCompletionItem.documentation);
+        this._resolved = true;
+        this.connector.lab_integration.refresh_doc_panel(this);
+      })
+      .catch(console.warn);
   }
 
   /**

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -130,12 +130,12 @@ export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
     connection
       .getCompletionResolve(this.match)
       .then(resolvedCompletionItem => {
+        this.connector.lab_integration.set_doc_panel_placeholder(false);
         if (resolvedCompletionItem === null) {
           return;
         }
         this._setDocumentation(resolvedCompletionItem.documentation);
         this._resolved = true;
-        this.connector.lab_integration.set_doc_panel_placeholder(false);
         this.connector.lab_integration.refresh_doc_panel(this);
       })
       .catch(e => {

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -92,6 +92,12 @@ export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
     return this.match.insertText || this.match.label;
   }
 
+  public supportsResolution() {
+    const connection = this.connector.get_connection(this.uri);
+
+    return connection.isCompletionResolveProvider();
+  }
+
   public needsResolution(): boolean {
     if (this.documentation) {
       return false;
@@ -105,9 +111,7 @@ export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
       return false;
     }
 
-    const connection = this.connector.get_connection(this.uri);
-
-    return connection.isCompletionResolveProvider();
+    return this.supportsResolution();
   }
 
   public isResolved() {
@@ -131,9 +135,13 @@ export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
         }
         this._setDocumentation(resolvedCompletionItem.documentation);
         this._resolved = true;
+        this.connector.lab_integration.set_doc_panel_placeholder(false);
         this.connector.lab_integration.refresh_doc_panel(this);
       })
-      .catch(console.warn);
+      .catch(e => {
+        this.connector.lab_integration.set_doc_panel_placeholder(false);
+        console.warn(e);
+      });
   }
 
   /**

--- a/packages/jupyterlab-lsp/src/features/completion/index.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/index.ts
@@ -15,6 +15,7 @@ import { CompletionCM, CompletionLabIntegration } from './completion';
 import { LabIcon } from '@jupyterlab/ui-components';
 import completionSvg from '../../../style/icons/completion.svg';
 import { ILSPCompletionThemeManager } from '@krassowski/completion-theme/lib/types';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export const completionIcon = new LabIcon({
   name: 'lsp:completion',
@@ -31,7 +32,8 @@ export const COMPLETION_PLUGIN: JupyterFrontEndPlugin<void> = {
     ICompletionManager,
     ILSPAdapterManager,
     ILSPCompletionThemeManager,
-    ILSPLogConsole
+    ILSPLogConsole,
+    IRenderMimeRegistry
   ],
   autoStart: true,
   activate: (
@@ -41,7 +43,8 @@ export const COMPLETION_PLUGIN: JupyterFrontEndPlugin<void> = {
     completionManager: ICompletionManager,
     adapterManager: ILSPAdapterManager,
     iconsThemeManager: ILSPCompletionThemeManager,
-    logConsole: ILSPLogConsole
+    logConsole: ILSPLogConsole,
+    renderMimeRegistry: IRenderMimeRegistry
   ) => {
     const settings = new FeatureSettings(settingRegistry, FEATURE_ID);
     const labIntegration = new CompletionLabIntegration(
@@ -50,7 +53,8 @@ export const COMPLETION_PLUGIN: JupyterFrontEndPlugin<void> = {
       settings,
       adapterManager,
       iconsThemeManager,
-      logConsole.scope('CompletionLab')
+      logConsole.scope('CompletionLab'),
+      renderMimeRegistry
     );
 
     featureManager.register({

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Completer } from '@jupyterlab/completer';
+import { CompletionLabIntegration } from './completion';
+import { Signal } from '@lumino/signaling';
+import { LazyCompletionItem } from './completion_handler';
+
+export class LSPCompletionRenderer
+  extends Completer.Renderer
+  implements Completer.IRenderer {
+  public activeChanged: Signal<LSPCompletionRenderer, LazyCompletionItem>;
+
+  constructor(protected options: LSPCompletionRenderer.IOptions) {
+    super();
+    this.activeChanged = new Signal(this);
+  }
+
+  createCompletionItemNode(
+    item: LazyCompletionItem,
+    orderedTypes: string[]
+  ): HTMLLIElement {
+    const li = super.createCompletionItemNode(item, orderedTypes);
+
+    // make sure that an instance reference, and not an object copy is being used;
+    item = item.self;
+
+    // only monitor nodes that have item.self as others are not LazyCompletionItems
+    // and only monitor those that need documentation retrieval
+    if (item && !item.documentation) {
+      let inactive = true;
+      const observer = new MutationObserver(mutations => {
+        if (li.classList.contains('jp-mod-active')) {
+          if (inactive) {
+            inactive = false;
+            this.activeChanged.emit(item);
+          }
+        } else {
+          inactive = true;
+        }
+      });
+      observer.observe(li, {
+        attributes: true,
+        attributeFilter: ['class']
+      });
+    }
+
+    return li;
+  }
+}
+
+export namespace LSPCompletionRenderer {
+  export interface IOptions {
+    integrator: CompletionLabIntegration;
+  }
+}

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -66,7 +66,7 @@ export class LSPCompletionRenderer
         .catch(this.options.console.warn);
       return this.options.markdownRenderer.node;
     } else {
-      let node = new HTMLDivElement();
+      let node = document.createElement('div');
       node.textContent = item.documentation;
       return node;
     }

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -5,6 +5,8 @@ import { Completer } from '@jupyterlab/completer';
 import { CompletionLabIntegration } from './completion';
 import { Signal } from '@lumino/signaling';
 import { LazyCompletionItem } from './completion_handler';
+import { IRenderMime } from '@jupyterlab/rendermime';
+import { ILSPLogConsole } from '../../tokens';
 
 export class LSPCompletionRenderer
   extends Completer.Renderer
@@ -47,10 +49,34 @@ export class LSPCompletionRenderer
 
     return li;
   }
+
+  createDocumentationNode(item: LazyCompletionItem): HTMLElement {
+    if (item.isDocumentationMarkdown) {
+      this.options.markdownRenderer
+        .renderModel({
+          data: {
+            'text/markdown': item.documentation
+          },
+          trusted: false,
+          metadata: {},
+          setData(options: IRenderMime.IMimeModel.ISetDataOptions) {
+            // empty
+          }
+        })
+        .catch(this.options.console.warn);
+      return this.options.markdownRenderer.node;
+    } else {
+      let node = new HTMLDivElement();
+      node.textContent = item.documentation;
+      return node;
+    }
+  }
 }
 
 export namespace LSPCompletionRenderer {
   export interface IOptions {
     integrator: CompletionLabIntegration;
+    markdownRenderer: IRenderMime.IRenderer;
+    console: ILSPLogConsole;
   }
 }

--- a/packages/lsp-ws-connection/src/ws-connection.ts
+++ b/packages/lsp-ws-connection/src/ws-connection.ts
@@ -1,5 +1,8 @@
 import * as events from 'events';
-import { LocationLink } from 'vscode-languageserver-protocol';
+import {
+  CompletionItemTag,
+  LocationLink
+} from 'vscode-languageserver-protocol';
 import * as protocol from 'vscode-languageserver-protocol';
 import { ConsoleLogger, listen, MessageConnection } from 'vscode-ws-jsonrpc';
 import {
@@ -163,8 +166,11 @@ export class LspWsConnection
               snippetSupport: false,
               commitCharactersSupport: true,
               documentationFormat: ['markdown', 'plaintext'],
-              deprecatedSupport: false,
-              preselectSupport: false
+              deprecatedSupport: true,
+              preselectSupport: false,
+              tagSupport: {
+                valueSet: [CompletionItemTag.Deprecated]
+              }
             },
             contextSupport: false
           },


### PR DESCRIPTION
## References

- provides mechanism for mapping between some kernel types and LSP types for icons selection, fixes #333
  - motivated by IJulia returning very different types than LSP types and IPython returning `<unknown>` if it cannot match a type
- implements `completionItem/resolve` to allow for:
  - display of documentation panel with R language server which does not send documentation in the first request but requires `completionItem/resolve`
  - faster completion (#272) once pyls or jedi-language-server implement `completionItem/resolve` too
  - [x] store original completionItem and resolve using exactly it?
  - [x] add test with R language server
  - [ ] open issues on pyls and jedi proposing to implement `completionItem/resolve`; create a PR in the repo that will accept such a contribution (help welcome!)
- makes use of newly exposed `Completer.IRenderer`, for implementation of active item tracking and implements makrdown rendering of documentation in `Completer.IRenderer`
- add support for deprecation via `CompletionItemTag.Deprecated`
  - [x] declare tag support
  - [ ] check if any supported server implements it and if yes, test it; checked that do not support: jedi, julia, pyls, R; maybe javascript/typescript server? 

Related upstream PR:
- https://github.com/jupyterlab/jupyterlab/pull/8930
- https://github.com/jupyterlab/jupyterlab/pull/9643
- https://github.com/jupyterlab/jupyterlab/pull/9663

## Code changes

Added `LazyCompletionItem` class implementing `CompletionHandler.ICompletionItem` but also doing much more to workaround the limited flexibility of upstream (see the self-reference trick to workaround https://github.com/jupyterlab/jupyterlab/pull/9643). The new object-oriented code reduced complexity of the completion handler making it considerable more pleasant and enabled implementation of `completionItem/resolve`.

## User-facing changes

- Documentation panel renders markdown if server provided markdown
  - only for `completionItem/resolve` retrieved docs for now
  - for all servers once https://github.com/jupyterlab/jupyterlab/pull/9663 gets merged and released
- Documentation panel works with R :tada: (and other language servers that use `completionItem/resolve`, e.g. javascript/typescript)

![R-docs](https://user-images.githubusercontent.com/5832902/105607056-9d44b200-5d94-11eb-82b0-1dbd520dba3e.gif)


## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
