### PR TITLE
Fix Julia language server crashes on too broad save notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
   - diagnostics panel works after kernel restart properly ([#485])
   - workaround was added to enable `jedi-language-server` diagnostics ([#485])
+  - Julia language server will not crash when saving a non-Julia file: fixed sendSaved notification scope ([#491])
 
 ### `jupyter-lsp 1.1.1` (unreleased)
 
@@ -20,6 +21,7 @@
 
 [#485]: https://github.com/krassowski/jupyterlab-lsp/pull/485
 [#487]: https://github.com/krassowski/jupyterlab-lsp/pull/487
+[#491]: https://github.com/krassowski/jupyterlab-lsp/pull/491
 
 ### `@krassowski/jupyterlab-lsp 3.1.0` (2021-01-17)
 


### PR DESCRIPTION
## References

Fixes #490.

## User-facing changes

- Julia server won't crash on save of non-Julia notebook/file.
- Performance will increase after save as only relevant connections are being notified
- Foreign documents will properly receive the save notifications, potentially improving some R language sever functions in `%%R` cells

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [x] changelog entry
