### PR TITLE
Attempt to fix truncated Jedi LSP responses

### DIFF
--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -289,4 +289,4 @@ Trigger Completer
 Completer Should Include Documentation
     [Arguments]    ${text}
     Wait Until Page Contains Element    ${DOCUMENTATION_PANEL}    timeout=10s
-    Element Should Contain    ${DOCUMENTATION_PANEL}    ${text}
+    Wait Until Keyword Succeeds    10 x    1 s    Element Should Contain    ${DOCUMENTATION_PANEL}    ${text}

--- a/python_packages/jupyter_lsp/jupyter_lsp/session.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/session.py
@@ -137,6 +137,7 @@ class LanguageServerSession(LoggingConfigurable):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             env=self.substitute_env(self.spec.get("env", {}), os.environ),
+            bufsize=0,
         )
 
     def init_queues(self):

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -61,7 +61,7 @@ class LspStdIoReader(LspStdIoBase):
 
     @default("max_wait")
     def _default_max_wait(self):
-        return 0.5 if os.name == "nt" else self.min_wait * 2
+        return 0.1 if os.name == "nt" else self.min_wait * 2
 
     async def sleep(self):
         """Simple exponential backoff for sleeping"""
@@ -138,7 +138,8 @@ class LspStdIoReader(LspStdIoBase):
             raw = b"".join(raw_parts)
             if len(raw) != length:  # pragma: no cover
                 self.log.warning(
-                    f"Readout and content-length mismatch:" f" {len(raw)} vs {length}"
+                    f"Readout and content-length mismatch: {len(raw)} vs {length};"
+                    f"remaining empties: {max_empties}; remaining parts: {max_parts}"
                 )
 
         return raw

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -98,9 +98,10 @@ class LspStdIoReader(LspStdIoBase):
                 await self.sleep()
 
     def _read_content(
-        self, length: int, max_parts=100, max_empty_parts_in_a_row=50
+        self, length: int, max_parts=100, max_empties=50
     ) -> Optional[bytes]:
-        """Read the full length of the message unless exceeding max_parts.
+        """Read the full length of the message unless exceeding max_parts or
+           max_empties empty reads occur.
 
         See https://github.com/krassowski/jupyterlab-lsp/issues/450
 
@@ -119,13 +120,11 @@ class LspStdIoReader(LspStdIoBase):
         raw_parts: List[bytes] = []
         received_size = 0
         while (
-            received_size < length
-            and len(raw_parts) < max_parts
-            and max_empty_parts_in_a_row > 0
+            received_size < length and len(raw_parts) < max_parts and max_empties > 0
         ):
             part = self.stream.read(length)
             if part is None:
-                max_empty_parts_in_a_row -= 1
+                max_empties -= 1
                 continue  # pragma: no cover
             received_size += len(part)
             raw_parts.append(part)

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -119,7 +119,7 @@ class LspStdIoReader(LspStdIoBase):
         while received_size < length and len(raw_parts) < max_parts and max_empty_parts_in_a_row > 0:
             part = self.stream.read(length)
             if part is None:
-                --max_empty_parts_in_a_row 
+                max_empty_parts_in_a_row -= 1
                 continue  # pragma: no cover
             received_size += len(part)
             raw_parts.append(part)

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -100,7 +100,7 @@ class LspStdIoReader(LspStdIoBase):
                 await self.sleep()
 
     async def _read_content(
-        self, length: int, max_parts=500, max_empties=50
+        self, length: int, max_parts=1000, max_empties=200
     ) -> Optional[bytes]:
         """Read the full length of the message unless exceeding max_parts or
            max_empties empty reads occur.

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -31,8 +31,8 @@ class LspStdIoBase(LoggingConfigurable):
     executor = None
 
     stream = Instance(
-        io.BufferedIOBase, help="the stream to read/write"
-    )  # type: io.BufferedIOBase
+        io.RawIOBase, help="the stream to read/write"
+    )  # type: io.RawIOBase
     queue = Instance(Queue, help="queue to get/put")
 
     def __repr__(self):  # pragma: no cover

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -61,7 +61,7 @@ class LspStdIoReader(LspStdIoBase):
 
     @default("max_wait")
     def _default_max_wait(self):
-        return 2.0 if os.name == "nt" else self.min_wait
+        return 0.5 if os.name == "nt" else self.min_wait * 2
 
     async def sleep(self):
         """Simple exponential backoff for sleeping"""

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -97,7 +97,9 @@ class LspStdIoReader(LspStdIoBase):
                 self.log.exception("%s couldn't enqueue message: %s", self, message)
                 await self.sleep()
 
-    def _read_content(self, length: int, max_parts=100, max_empty_parts_in_a_row=50) -> Optional[bytes]:
+    def _read_content(
+        self, length: int, max_parts=100, max_empty_parts_in_a_row=50
+    ) -> Optional[bytes]:
         """Read the full length of the message unless exceeding max_parts.
 
         See https://github.com/krassowski/jupyterlab-lsp/issues/450
@@ -116,7 +118,11 @@ class LspStdIoReader(LspStdIoBase):
         raw = None
         raw_parts: List[bytes] = []
         received_size = 0
-        while received_size < length and len(raw_parts) < max_parts and max_empty_parts_in_a_row > 0:
+        while (
+            received_size < length
+            and len(raw_parts) < max_parts
+            and max_empty_parts_in_a_row > 0
+        ):
             part = self.stream.read(length)
             if part is None:
                 max_empty_parts_in_a_row -= 1

--- a/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/stdio.py
@@ -97,7 +97,7 @@ class LspStdIoReader(LspStdIoBase):
                 self.log.exception("%s couldn't enqueue message: %s", self, message)
                 await self.sleep()
 
-    def _read_content(self, length: int, max_parts=1000) -> Optional[bytes]:
+    def _read_content(self, length: int, max_parts=100, max_empty_parts_in_a_row=50) -> Optional[bytes]:
         """Read the full length of the message unless exceeding max_parts.
 
         See https://github.com/krassowski/jupyterlab-lsp/issues/450
@@ -116,10 +116,11 @@ class LspStdIoReader(LspStdIoBase):
         raw = None
         raw_parts: List[bytes] = []
         received_size = 0
-        while received_size < length and len(raw_parts) < max_parts:
+        while received_size < length and len(raw_parts) < max_parts and max_empty_parts_in_a_row > 0:
             part = self.stream.read(length)
             if part is None:
-                break  # pragma: no cover
+                --max_empty_parts_in_a_row 
+                continue  # pragma: no cover
             received_size += len(part)
             raw_parts.append(part)
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
@@ -28,7 +28,7 @@ class CommunicatorSpawner:
     def spawn_writer(self, message: str, repeats: int = 1, interval=None):
         length = len(message) * repeats
         commands_file = self.tmp_path / "writer.py"
-        commands_file.write(
+        commands_file.write_text(
             WRITER_TEMPLATE.format(
                 length=length, repeats=repeats, interval=interval or 0, message=message
             )

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
@@ -72,7 +72,7 @@ async def test_reader(message, repeats, interval, communicator_spawner):
         message=message, repeats=repeats, interval=interval
     )
     reader = LspStdIoReader(stream=process.stdout, queue=queue)
-    timeout = 2 + (interval or 1) * repeats * 10
+    timeout = 3 + reader.max_wait * repeats * 10
 
     communicate_and_close(process)
     await asyncio.wait_for(reader.read(), timeout=timeout)

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
@@ -22,27 +22,27 @@ print()
 
 
 class CommunicatorSpawner:
-    def __init__(self, tmpdir):
-        self.tmpdir = tmpdir
+    def __init__(self, tmp_path):
+        self.tmp_path = tmp_path
 
     def spawn_writer(self, message: str, repeats: int = 1, interval=None):
         length = len(message) * repeats
-        commands_file = self.tmpdir / "writer.py"
+        commands_file = self.tmp_path / "writer.py"
         commands_file.write(
             WRITER_TEMPLATE.format(
                 length=length, repeats=repeats, interval=interval or 0, message=message
             )
         )
         return subprocess.Popen(
-            ["python", "-u", commands_file.realpath()],
+            ["python", "-u", str(commands_file)],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
 
 
 @pytest.fixture
-def communicator_spawner(tmpdir):
-    return CommunicatorSpawner(tmpdir)
+def communicator_spawner(tmp_path):
+    return CommunicatorSpawner(tmp_path)
 
 
 def communicate_and_close(process, wait=1):
@@ -72,7 +72,7 @@ async def test_reader(message, repeats, interval, communicator_spawner):
         message=message, repeats=repeats, interval=interval
     )
     reader = LspStdIoReader(stream=process.stdout, queue=queue)
-    timeout = 2 + (interval or 1) * repeats * 2
+    timeout = 2 + (interval or 1) * repeats * 10
 
     communicate_and_close(process)
     await asyncio.wait_for(reader.read(), timeout=timeout)

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
@@ -32,7 +32,7 @@ class CommunicatorSpawner:
             )
         )
         return subprocess.Popen(
-            ["python", "-u", str(commands_file)], stdout=subprocess.PIPE
+            ["python", "-u", str(commands_file)], stdout=subprocess.PIPE, bufsize=0
         )
 
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_stdio.py
@@ -1,0 +1,81 @@
+import asyncio
+import subprocess
+import time
+from threading import Thread
+
+import pytest
+from tornado.queues import Queue
+
+from jupyter_lsp.stdio import LspStdIoReader
+
+WRITER_TEMPLATE = """
+from time import sleep
+
+print('Content-Length: {length}')
+print()
+
+for repeat in range({repeats}):
+    sleep({interval})
+    print('{message}', end='')
+print()
+"""
+
+
+class CommunicatorSpawner:
+    def __init__(self, tmpdir):
+        self.tmpdir = tmpdir
+
+    def spawn_writer(self, message: str, repeats: int = 1, interval=None):
+        length = len(message) * repeats
+        commands_file = self.tmpdir / "writer.py"
+        commands_file.write(
+            WRITER_TEMPLATE.format(
+                length=length, repeats=repeats, interval=interval or 0, message=message
+            )
+        )
+        return subprocess.Popen(
+            ["python", "-u", commands_file.realpath()],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+
+
+@pytest.fixture
+def communicator_spawner(tmpdir):
+    return CommunicatorSpawner(tmpdir)
+
+
+def communicate_and_close(process, wait=1):
+    def communicate_and_close():
+        time.sleep(wait)
+        process.communicate()
+
+    thread = Thread(target=communicate_and_close)
+    thread.start()
+
+
+@pytest.mark.parametrize(
+    "message,repeats,interval",
+    [
+        ["short", 1, None],
+        ["ab" * 10_0000, 1, None],
+        ["ab", 2, 0.01],
+        ["ab", 45, 0.01],
+    ],
+    ids=["short", "long", "intermittent", "intensive-intermittent"],
+)
+@pytest.mark.asyncio
+async def test_reader(message, repeats, interval, communicator_spawner):
+    queue = Queue()
+
+    process = communicator_spawner.spawn_writer(
+        message=message, repeats=repeats, interval=interval
+    )
+    reader = LspStdIoReader(stream=process.stdout, queue=queue)
+    timeout = 2 + (interval or 1) * repeats * 2
+
+    communicate_and_close(process)
+    await asyncio.wait_for(reader.read(), timeout=timeout)
+
+    result = queue.get_nowait()
+    assert result == message * repeats


### PR DESCRIPTION

<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#450

## Code changes


This patch attempts to fix the truncated Jedi LSP responses which
produce warning messages about content-length mismatch. It does so
by looping around and trying again upon an empty read. The theory
is that the content producer is just not ready with more data yet.

- add function parameter 'max_empty_parts_in_a_row' with a default
value of 50.  This will be decremented on each empty read.
- change the default value of the 'max_parts' parameter to 100
since we should get larger chunks on each successful read.

Either of these values could be adjusted based on experience.


