### PR TITLE
More completer improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 3.3.0` (unreleased)
+
+- features:
+
+  - added a timeout for kernel completion, with the default of 600ms ([#496])
+  - added an option to skip waiting for kernel completions if busy, off by default ([#496])
+
+- bug fixes:
+
+  - delayed completion suggestions will no longer show up if cursor moved to another line ([#496])
+  - changes in notebooks after kernel restart or file rename will now be recorded by the language server again ([#496])
+
+[#496]: https://github.com/krassowski/jupyterlab-lsp/pull/496
+
 ### `@krassowski/jupyterlab-lsp 3.2.0` (2021-01-24)
 
 - features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
   - delayed completion suggestions will no longer show up if cursor moved to another line ([#496])
   - changes in notebooks after kernel restart or file rename will now be recorded by the language server again ([#496])
+  - when either of kernel providers: kernel or LSP server fails, the completion from the other will still be shown ([#496])
 
 [#496]: https://github.com/krassowski/jupyterlab-lsp/pull/496
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ Advanced static-analysis autocompletion without a running kernel
 
 ![autocompletion](https://raw.githubusercontent.com/krassowski/jupyterlab-lsp/master/examples/screenshots/autocompletion.png)
 
-> When a kernel is available the suggestions from the kernel (such as keys of a
-> dict and columns of a DataFrame autocompletion) are merged with the suggestions
-> from the Language Server (currently only in notebook).
+#### The runtime kernel suggestions are still there
+
+When a kernel is available the suggestions from the kernel (such as keys of a
+dict and columns of a DataFrame autocompletion) are merged with the suggestions
+from the Language Server (currently only in notebook).
+
+If the kernel is too slow to respond promptly only the LSP static analysis suggestions will be shown (default threshold: 0.6s).
+You can configure the completer to not attempt to fetch the kernel completions if the kernel is busy (skipping the 0.6s timeout).
 
 ### Rename
 

--- a/atest/03_Notebook.robot
+++ b/atest/03_Notebook.robot
@@ -66,8 +66,41 @@ Foreign Extractors
 Code Overrides
     ${file} =    Set Variable    Code overrides.ipynb
     Setup Notebook    Python    ${file}
-    ${virtual_path} =    Set Variable    ${VIRTUALDOCS DIR}${/}Code overrides.ipynb
+    ${virtual_path} =    Set Variable    ${VIRTUALDOCS DIR}${/}${file}
     Wait Until Created    ${virtual_path}
     Wait Until Keyword Succeeds    10x    1s    File Should Not Be Empty    ${virtual_path}
     ${document} =    Get File    ${virtual_path}
     Should Be Equal    ${document}    get_ipython().run_line_magic("ls", "")\n\n\nget_ipython().run_line_magic("pip", " freeze")\n
+    [Teardown]    Clean Up After Working With File    Code overrides.ipynb
+
+Adding Text To Cells Is Reflected In Virtual Document
+    ${file} =    Set Variable    Empty.ipynb
+    Setup Notebook    Python    ${file}
+    ${virtual_path} =    Set Variable    ${VIRTUALDOCS DIR}${/}${file}
+    Wait Until Created    ${virtual_path}
+    Enter Cell Editor    1
+    Press Keys    None    cell_1
+    Lab Command    Insert Cell Below
+    Enter Cell Editor    2
+    Press Keys    None    cell_2
+    Wait Until Keyword Succeeds    3x    1s    File Content Should Be Equal    ${virtual_path}    cell_1\n\n\ncell_2\n
+    [Teardown]    Clean Up After Working With File    Empty.ipynb
+
+Adding Text To Cells After Kernel Restart
+    ${file} =    Set Variable    Empty.ipynb
+    Setup Notebook    Python    ${file}
+    ${virtual_path} =    Set Variable    ${VIRTUALDOCS DIR}${/}${file}
+    Wait Until Created    ${virtual_path}
+    Enter Cell Editor    1
+    Lab Command    Insert Cell Below
+    Enter Cell Editor    2    line=1
+    Press Keys    None    text
+    Wait Until Keyword Succeeds    3x    1s    File Content Should Be Equal    ${virtual_path}    \n\n\ntext\n
+    [Teardown]    Clean Up After Working With File    Empty.ipynb
+
+*** Keywords ***
+File Content Should Be Equal
+    [Arguments]    ${file}    ${text}
+    Wait Until Keyword Succeeds    5x    1s    File Should Not Be Empty    ${file}
+    ${document} =    Get File    ${file}
+    Should Be Equal    ${document}    ${text}

--- a/atest/04_Interface/Statusbar.robot
+++ b/atest/04_Interface/Statusbar.robot
@@ -22,10 +22,7 @@ Statusbar Popup Opens
 Status Changes Between Notebooks
     Setup Notebook    Python    Python.ipynb
     Wait Until Fully Initialized
-    Lab Command    New Notebook
-    Wait For Dialog
-    # Kernel selection dialog shows up, accept Python as default kernel
-    Accept Default Dialog Option
+    Open New Notebook
     Element Should Contain    ${STATUSBAR}    Waiting...
     Wait Until Fully Initialized
     Switch To Tab    Python.ipynb

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -143,6 +143,7 @@ Completion Works For Tokens Separated By Space
 
 Kernel And LSP Completions Merge Prefix Conflicts Are Resolved
     [Documentation]    Reconciliate Python kernel returning prefixed completions and LSP (pyls) not-prefixed ones
+    Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForBusyKernel": false}    plugin id=${COMPLETION PLUGIN ID}
     # For more details see: https://github.com/krassowski/jupyterlab-lsp/issues/30#issuecomment-576003987
     # `import os.pat<tab>` → `import os.pathsep`
     Enter Cell Editor    15    line=1

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -8,9 +8,10 @@ Resource          ../Keywords.robot
 *** Variables ***
 ${COMPLETER_BOX}    css:.jp-Completer.jp-HoverBox
 ${DOCUMENTATION_PANEL}    css:.jp-Completer-docpanel
+${KERNEL_BUSY_INDICATOR}    css:.jp-NotebookPanel-toolbar div[title="Kernel Busy"]
 
 *** Test Cases ***
-Works With Kernel Running
+Works With Kernel Is Idle
     [Documentation]    The suggestions from kernel and LSP should get integrated.
     Enter Cell Editor    1    line=2
     Capture Page Screenshot    01-entered-cell.png
@@ -27,6 +28,15 @@ Works With Kernel Running
     ${content} =    Get Cell Editor Content    1
     Should Contain    ${content}    TabError
 
+Uses LSP Completions When Kernel Resoponse Times Out
+    Configure JupyterLab Plugin    {"kernelResponseTimeout": 1, "waitForKernelIfBusy": true}    plugin id=${COMPLETION PLUGIN ID}
+    Should Complete While Kernel Is Busy
+
+Uses LSP Completions When Kernel Is Busy
+    [Documentation]    When kernel is not available the best thing is to show some suggestions (LSP) rather than none.
+    Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForKernelIfBusy": false}    plugin id=${COMPLETION PLUGIN ID}
+    Should Complete While Kernel Is Busy
+
 Works When Kernel Is Shut Down
     Lab Command    Shut Down All Kernels…
     Wait For Dialog
@@ -42,9 +52,7 @@ Works When Kernel Is Shut Down
     Completer Should Not Suggest    %%timeit
 
 Works After Kernel Restart In New Cells
-    Lab Command    Restart Kernel…
-    Wait For Dialog
-    Accept Default Dialog Option
+    Restart Kernel
     Enter Cell Editor    1    line=2
     # works in old cells
     Trigger Completer
@@ -290,3 +298,29 @@ Completer Should Include Documentation
     [Arguments]    ${text}
     Wait Until Page Contains Element    ${DOCUMENTATION_PANEL}    timeout=10s
     Element Should Contain    ${DOCUMENTATION_PANEL}    ${text}
+
+Restart Kernel
+    Lab Command    Restart Kernel…
+    Wait For Dialog
+    Accept Default Dialog Option
+
+Count Completer Hints
+    ${count} =    Get Element Count    css:.jp-Completer-item
+    [Return]    ${count}
+
+Should Complete While Kernel Is Busy
+    # Run the cell with sleep(10)
+    Enter Cell Editor    17
+    # for some reason the lab command selects another cell along the way...
+    # Lab Command    Run Selected Cells And Don't Advance
+    Press Keys    None    CTRL+ENTER
+    # Confirm that the kernel is busy
+    Wait Until Page Contains Element    ${KERNEL_BUSY_INDICATOR}    timeout=3s
+    # Enter a cell with "t"
+    Enter Cell Editor    18
+    # Check if completion worked
+    Enter Cell Editor    1    line=2
+    Trigger Completer    timeout=3s
+    Completer Should Suggest    test    timeout=3s
+    # Confirm that the kernel indicator was busy all along
+    Page Should Contain Element    ${KERNEL_BUSY_INDICATOR}

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -12,6 +12,7 @@ ${KERNEL_BUSY_INDICATOR}    css:.jp-NotebookPanel-toolbar div[title="Kernel Busy
 
 *** Test Cases ***
 Works When Kernel Is Idle
+    Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForBusyKernel": false}    plugin id=${COMPLETION PLUGIN ID}
     [Documentation]    The suggestions from kernel and LSP should get integrated.
     Enter Cell Editor    1    line=2
     Capture Page Screenshot    01-entered-cell.png

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -11,7 +11,7 @@ ${DOCUMENTATION_PANEL}    css:.jp-Completer-docpanel
 ${KERNEL_BUSY_INDICATOR}    css:.jp-NotebookPanel-toolbar div[title="Kernel Busy"]
 
 *** Test Cases ***
-Works With Kernel Is Idle
+Works When Kernel Is Idle
     [Documentation]    The suggestions from kernel and LSP should get integrated.
     Enter Cell Editor    1    line=2
     Capture Page Screenshot    01-entered-cell.png
@@ -29,12 +29,12 @@ Works With Kernel Is Idle
     Should Contain    ${content}    TabError
 
 Uses LSP Completions When Kernel Resoponse Times Out
-    Configure JupyterLab Plugin    {"kernelResponseTimeout": 1, "waitForKernelIfBusy": true}    plugin id=${COMPLETION PLUGIN ID}
+    Configure JupyterLab Plugin    {"kernelResponseTimeout": 1, "waitForBusyKernel": true}    plugin id=${COMPLETION PLUGIN ID}
     Should Complete While Kernel Is Busy
 
 Uses LSP Completions When Kernel Is Busy
     [Documentation]    When kernel is not available the best thing is to show some suggestions (LSP) rather than none.
-    Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForKernelIfBusy": false}    plugin id=${COMPLETION PLUGIN ID}
+    Configure JupyterLab Plugin    {"kernelResponseTimeout": -1, "waitForBusyKernel": false}    plugin id=${COMPLETION PLUGIN ID}
     Should Complete While Kernel Is Busy
 
 Works When Kernel Is Shut Down
@@ -309,18 +309,18 @@ Count Completer Hints
     [Return]    ${count}
 
 Should Complete While Kernel Is Busy
-    # Run the cell with sleep(10)
+    # Run the cell with sleep(20)
     Enter Cell Editor    17
     # for some reason the lab command selects another cell along the way...
     # Lab Command    Run Selected Cells And Don't Advance
     Press Keys    None    CTRL+ENTER
     # Confirm that the kernel is busy
-    Wait Until Page Contains Element    ${KERNEL_BUSY_INDICATOR}    timeout=3s
+    Wait Until Page Contains Element    ${KERNEL_BUSY_INDICATOR}    timeout=5s
     # Enter a cell with "t"
     Enter Cell Editor    18
     # Check if completion worked
     Enter Cell Editor    1    line=2
-    Trigger Completer    timeout=3s
-    Completer Should Suggest    test    timeout=3s
+    Trigger Completer    timeout=10s
+    Completer Should Suggest    test
     # Confirm that the kernel indicator was busy all along
     Page Should Contain Element    ${KERNEL_BUSY_INDICATOR}

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -413,3 +413,9 @@ Measure Cursor Position
 Switch To Tab
     [Arguments]    ${file}
     Click Element    ${JLAB XP DOCK TAB}\[contains(., '${file}')]
+
+Open New Notebook
+    Lab Command    New Notebook
+    Wait For Dialog
+    # Kernel selection dialog shows up, accept Python as default kernel
+    Accept Default Dialog Option

--- a/atest/examples/Completion.ipynb
+++ b/atest/examples/Completion.ipynb
@@ -124,6 +124,32 @@
    "source": [
     "import os.pat"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LSP completion works when kernel is busy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from time import sleep\n",
+    "sleep(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t"
+   ]
   }
  ],
  "metadata": {

--- a/atest/examples/Completion.ipynb
+++ b/atest/examples/Completion.ipynb
@@ -139,7 +139,7 @@
    "outputs": [],
    "source": [
     "from time import sleep\n",
-    "sleep(10)"
+    "sleep(20)"
    ]
   },
   {

--- a/atest/examples/Empty.ipynb
+++ b/atest/examples/Empty.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -24,7 +24,19 @@
         "type": "string"
       },
       "default": ["comment", "string"],
-      "description": "An array of CodeMirror tokens for which the auto-invoke should be suppressed. The token names vary between languages (modes)."
+      "description": "An array of CodeMirror tokens for which the auto-invoke should be suppressed. Adding 'def' will prevent continuous hinting when writing a function name in Python, Julia, JavaScript and other languages. The token names vary between languages (modes)."
+    },
+    "kernelResponseTimeout": {
+      "title": "Kernel completion response timeout",
+      "default": 600,
+      "type": "number",
+      "description": "The time to wait for the kernel completions suggestions in milliseconds. Set to 0 to disable kernel completions, or to -1 to wait indefinitely (not recommended)."
+    },
+    "waitForBusyKernel": {
+      "title": "Wait for kernel if busy",
+      "default": true,
+      "type": "boolean",
+      "description": "Should an attempt to get the kernel response (with timeout as specified by kernelResponseTimeout) be made if kernel is busy? If you often write code in notebook while computations are running for long time (e.g. training models), turning this off might give you faster response times."
     },
     "theme": {
       "title": "Completer theme",

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -221,6 +221,14 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
       this
     );
 
+    // pretend that all editors were removed to trigger the disconnection of even handlers
+    // they will be connected again on new connection
+    for (let editor of this.editors) {
+      this.editorRemoved.emit({
+        editor: editor
+      });
+    }
+
     for (let adapter of this.adapters.values()) {
       adapter.dispose();
     }
@@ -392,6 +400,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
       return;
     }
     this.virtual_editor = virtual_editor;
+    this.connect_contentChanged_signal();
   }
 
   /**
@@ -538,7 +547,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
    * (range) updates this can be still implemented by comparison of before/after states of the
    * virtual documents, which is even more resilient and -obviously - editor-independent.
    */
-  connect_contentChanged_signal() {
+  private connect_contentChanged_signal() {
     this.widget.context.model.contentChanged.connect(
       this.onContentChanged,
       this

--- a/packages/jupyterlab-lsp/src/adapters/file_editor/file_editor.ts
+++ b/packages/jupyterlab-lsp/src/adapters/file_editor/file_editor.ts
@@ -46,7 +46,6 @@ export class FileEditorAdapter extends WidgetAdapter<
     this.editor = editor_widget.content;
 
     this.init_virtual();
-    this.connect_contentChanged_signal();
 
     this.console.log('file ready for connection:', this.path);
 


### PR DESCRIPTION
## References

Solves points: 1, 2 and 5 in #495.

## Code changes

- added a timeout for kernel completion (implemented as promise race)
- added a check of kernel status allowing user to choose to not wait for kernel if it is busy (by default the above timeout is used)
- the completions list could arrive after the cursor has moved; there was no check for the cursor change; the check is now added and if the cursor moved to another line or to an earlier character in the line the request will be invalidated (by an empty response mock)
- fixed issues related to handlers disposal/re-connection after kernel restart/file rename:
   - `context.model.contentChanged` was not being re-connected after connection restart due to rename/kernel restart; this was the culprit of the (5) bug
   - `editorAdded` and `editorRemoved` were never being disconnected which could have led to them being connected twice. To avoid this `block_added_handlers` and `block_removed_handlers` are now stored and disconnected when needed. This can also slightly improve memory management in long sessions.
   - `editorRemoved` is now being called on disconnect
 
While two fall-backs were already present for the completion failures:
  - if LSP or kernel completions failed, a fallback query was sent to kernel
  - if kernel completions could not be set up the LSP completions were used alone

the former entailed two requests to kernel (longer wait time for completion) and did not really solve the issue of kernel failure (if the kernel failed, it is likely it will fail again); this PR includes `allSettled`-like construct (additional catches added on promises prior to Promise.all + checks for errors). It is hoped that it will improve the user experience in cases when either of connectors fails to deliver completions.

## User-facing changes

Completions work more reliably :)

## Backwards-incompatible changes

- `connect_contentChanged_signal` of virtual editors is now private and handled in the abstract `VirtualEditor` implementation; it should not be 

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
