### PR TITLE
Completion and signature invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@
 
 - bug fixes:
 
+  - completion and signature suggestions get invalidated when editor changes ([#507])
+  - signature suggestions now invalidate on cursor move to another line or backwards too ([#507])
   - LaTeX is now rendered in documentation panel of completer ([#506])
   - completion response returned as plain text use pre tag to retain whitespace formatting ([#506])
   - pre-formatted code font size was reduced to match font-size of the text in completion panel ([#506])
 
 [#506]: https://github.com/krassowski/jupyterlab-lsp/pull/506
+[#507]: https://github.com/krassowski/jupyterlab-lsp/pull/507
 
 ### `jupyter-lsp 1.1.3` (unreleased)
 

--- a/atest/03_Notebook.robot
+++ b/atest/03_Notebook.robot
@@ -91,6 +91,7 @@ Adding Text To Cells After Kernel Restart
     Setup Notebook    Python    ${file}
     ${virtual_path} =    Set Variable    ${VIRTUALDOCS DIR}${/}${file}
     Wait Until Created    ${virtual_path}
+    Restart Kernel
     Enter Cell Editor    1
     Lab Command    Insert Cell Below
     Enter Cell Editor    2    line=1

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -29,6 +29,22 @@ Works When Kernel Is Idle
     ${content} =    Get Cell Editor Content    1
     Should Contain    ${content}    TabError
 
+Invalidates On Cell Change
+    Enter Cell Editor    1    line=2
+    Press Keys    None    TAB
+    Enter Cell Editor    2
+    # just to increase chances of caching this on CI (which is slow)
+    Sleep    5s
+    Completer Should Not Suggest    test
+
+Invalidates On Focus Loss
+    Enter Cell Editor    1    line=2
+    Press Keys    None    TAB
+    Enter Cell Editor    2
+    # just to increase chances of caching this on CI (which is slow)
+    Sleep    5s
+    Completer Should Not Suggest    test
+
 Uses LSP Completions When Kernel Resoponse Times Out
     Configure JupyterLab Plugin    {"kernelResponseTimeout": 1, "waitForBusyKernel": true}    plugin id=${COMPLETION PLUGIN ID}
     Should Complete While Kernel Is Busy
@@ -87,7 +103,6 @@ Continious Hinting Works
 Autocompletes If Only One Option
     Enter Cell Editor    3    line=1
     Press Keys    None    cle
-    Wait Until Fully Initialized
     # First tab brings up the completer
     Press Keys    None    TAB
     Completer Should Suggest    clear
@@ -99,7 +114,6 @@ Autocompletes If Only One Option
 Does Not Autocomplete If Multiple Options
     Enter Cell Editor    3    line=1
     Press Keys    None    c
-    Wait Until Fully Initialized
     # First tab brings up the completer
     Press Keys    None    TAB
     Completer Should Suggest    copy

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -302,11 +302,6 @@ Completer Should Include Documentation
     Wait Until Keyword Succeeds    10 x    1 s    Element Should Contain    ${DOCUMENTATION_PANEL}    ${text}
     Element Should Contain    ${DOCUMENTATION_PANEL}    ${text}
 
-Restart Kernel
-    Lab Command    Restart Kernel…
-    Wait For Dialog
-    Accept Default Dialog Option
-
 Count Completer Hints
     ${count} =    Get Element Count    css:.jp-Completer-item
     [Return]    ${count}

--- a/atest/05_Features/Signature.robot
+++ b/atest/05_Features/Signature.robot
@@ -16,3 +16,12 @@ Triggers Signature Help After A Keystroke
     Wait Until Keyword Succeeds    20x    0.5s    Page Should Contain Element    ${SIGNATURE_BOX}
     Element Should Contain    ${SIGNATURE_BOX}    Important docstring of abc()
     [Teardown]    Clean Up After Working With File    Signature.ipynb
+
+Invalidates On Cell Change
+    Setup Notebook    Python    Signature.ipynb
+    Enter Cell Editor    1    line=6
+    Press Keys    None    (
+    Enter Cell Editor    2
+    # just to increase chances of caching this on CI (which is slow)
+    Sleep    5s
+    Page Should Not Contain Element    ${SIGNATURE_BOX}

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -419,3 +419,8 @@ Open New Notebook
     Wait For Dialog
     # Kernel selection dialog shows up, accept Python as default kernel
     Accept Default Dialog Option
+
+Restart Kernel
+    Lab Command    Restart Kernel…
+    Wait For Dialog
+    Accept Default Dialog Option

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -619,7 +619,9 @@ export class LSPConnector
     cursor_at_request: CodeEditor.IPosition
   ) {
     if (!this._editor.hasFocus()) {
-      this.console.debug('Ignoring completion response: the corresponding editor lost focus')
+      this.console.debug(
+        'Ignoring completion response: the corresponding editor lost focus'
+      );
       return {
         start: reply.start,
         end: reply.end,
@@ -635,7 +637,9 @@ export class LSPConnector
       cursor_at_request.line != cursor_now.line ||
       cursor_now.column < cursor_at_request.column
     ) {
-      this.console.debug('Ignoring completion response: cursor has receded or changed line')
+      this.console.debug(
+        'Ignoring completion response: cursor has receded or changed line'
+      );
       return {
         start: reply.start,
         end: reply.end,

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -618,6 +618,15 @@ export class LSPConnector
     token: CodeEditor.IToken,
     cursor_at_request: CodeEditor.IPosition
   ) {
+    if (!this._editor.hasFocus()) {
+      this.console.debug('Ignoring completion response: the corresponding editor lost focus')
+      return {
+        start: reply.start,
+        end: reply.end,
+        items: []
+      };
+    }
+
     const cursor_now = this._editor.getCursorPosition();
 
     // if the cursor advanced in the same line, the previously retrieved completions may still be useful
@@ -626,6 +635,7 @@ export class LSPConnector
       cursor_at_request.line != cursor_now.line ||
       cursor_now.column < cursor_at_request.column
     ) {
+      this.console.debug('Ignoring completion response: cursor has receded or changed line')
       return {
         start: reply.start,
         end: reply.end,

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -109,7 +109,7 @@ export class SignatureCM extends CodeMirrorIntegration {
 
     let root_position = position_at_request;
 
-    // if the cursor advanced in the same line, the previously retrieved completions may still be useful
+    // if the cursor advanced in the same line, the previously retrieved signature may still be useful
     // if the line changed or cursor moved backwards then no reason to keep the suggestions
     if (
       position_at_request.line != root_position.line ||


### PR DESCRIPTION
## References

Invalidate completion result and signature just before displaying them if the current editor/cell lost focus; also invalidate signature if the cursor receded or changed line. Fixes 5.2 and 5.3 from https://github.com/krassowski/jupyterlab-lsp/issues/495.

## Code changes

- Added check of focus of active editor for completion and signature
- Added an argument for `handleSignature` to pass the cursor position at query time
- Added some debug messages
- Fixed kernel restart test missing restart

## User-facing changes

Signature and completions do not pop-up at unexpected times any longer

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
