### PR TITLE
Limit the width of the completer items

### DIFF
--- a/packages/completion-theme/style/index.css
+++ b/packages/completion-theme/style/index.css
@@ -24,6 +24,20 @@
   overflow: auto;
 }
 
+.jp-Completer-match {
+  max-width: 400px;
+  overflow-x: hidden;
+  white-space: nowrap;
+  display: block;
+  text-overflow: ellipsis;
+}
+
+.jp-mod-active .jp-Completer-match {
+  max-width: 600px;
+  white-space: break-spaces;
+  height: auto;
+}
+
 .lsp-completer-placeholder:after {
   content: 'Loading...';
   color: #7f7f7f;


### PR DESCRIPTION
## References

Fixes 13 from #495. The idea is that in extreme cases the completer covers the entire window width, which is annoying when someone has two files open side-by-side and looks at the other file, or has the context help open and wants to look at it; in other extreme cases the documentation panels get squished and is not usable.

## Code changes

Added CSS only; sadly not scoped to LSP as we cannot modify the completer class easily (needs changes upstream).

## User-facing changes

Before:
![cycle-before](https://user-images.githubusercontent.com/5832902/107132373-4253a480-68d6-11eb-9da2-4d719c2c1bc3.gif)

After:
![cycle-after](https://user-images.githubusercontent.com/5832902/107132375-47185880-68d6-11eb-833a-4ea6a2f29de6.gif)

- when item is not active it is collapsed at 400px with ellipsis indicator
- when item is active the completer gets expanded to a maximum of 600px
- when it is not enough the line breaks and the label gets wrapped on spaces

I do not like the wrapping behaviour too much though (suggestions welcome!).

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
