### PR TITLE
Fix install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Use of a python `virtualenv` or a conda env is also recommended.
    R ([languageserver](https://github.com/REditorSupport/languageserver)) servers:
 
    ```bash
-   pip install python-language-server[all]
+   pip install 'python-language-server[all]'
    R -e 'install.packages("languageserver")'
    ```
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/pyls.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/pyls.py
@@ -13,7 +13,7 @@ class PythonLanguageServer(PythonModuleSpec):
             issues="https://github.com/palantir/python-language-server/issues",
         ),
         install=dict(
-            pip="pip install python-language-server[all]",
+            pip="pip install 'python-language-server[all]'",
             conda="conda install -c conda-forge python-language-server",
         ),
         extend=[


### PR DESCRIPTION
without ' ' the command fails with:
no matches found: python-language-server[all]
