### PR TITLE
Sorted completions, improve completions marking and filtering and doc panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 3.4.0` (unreleased)
+
+- features:
+
+  - the priority of the completions from kernel can now be changed by switching new `kernelCompletionsFirst` setting ([#520])
+  - completer panel will now always render markdown documentation if available ([#520])
+    - the implementation re-renders the panel as it is the best we can do until [jupyterlab#9663](https://github.com/jupyterlab/jupyterlab/pull/9663) is merged
+  - the completer now uses `filterText` and `sortText` if available to better filter and sort completions ([#520])
+
+- bug fixes:
+  - completer documentation will now consistently show up after filtering the completion items ([#520])
+  - completions containing HTML-like syntax will be displayed properly (an upstream issue) ([#520])
+
+[#520]: https://github.com/krassowski/jupyterlab-lsp/pull/520
+
 ### `@krassowski/jupyterlab-lsp 3.3.1` (2020-02-07)
 
 - bug fixes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,7 @@ python scripts/atest.py --suite "05_Features.Completion"
 ##### Run a single test
 
 ```bash
-python scripts/atest.py --test "Works With Kernel Running"
+python scripts/atest.py --test "Works When Kernel Is Idle"
 ```
 
 ##### Run test with a tag

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -33,19 +33,19 @@ Can Prioritize Kernel Completions
     Configure JupyterLab Plugin    {"kernelCompletionsFirst": true, "kernelResponseTimeout": -1}    plugin id=${COMPLETION PLUGIN ID}
     Enter Cell Editor    1    line=2
     Trigger Completer
-    Completer Should Suggest  %%timeit
-    ${lsp_position} =    Get Completion Item Vertical Position  test
-    ${kernel_position} =    Get Completion Item Vertical Position  %%timeit
-    Should Be True  ${kernel_position} < ${lsp_position}
+    Completer Should Suggest    %%timeit
+    ${lsp_position} =    Get Completion Item Vertical Position    test
+    ${kernel_position} =    Get Completion Item Vertical Position    %%timeit
+    Should Be True    ${kernel_position} < ${lsp_position}
 
 Can Prioritize LSP Completions
     Configure JupyterLab Plugin    {"kernelCompletionsFirst": false, "kernelResponseTimeout": -1}    plugin id=${COMPLETION PLUGIN ID}
     Enter Cell Editor    1    line=2
     Trigger Completer
-    Completer Should Suggest  %%timeit
-    ${lsp_position} =    Get Completion Item Vertical Position  test
-    ${kernel_position} =    Get Completion Item Vertical Position  %%timeit
-    Should Be True  ${kernel_position} > ${lsp_position}
+    Completer Should Suggest    %%timeit
+    ${lsp_position} =    Get Completion Item Vertical Position    test
+    ${kernel_position} =    Get Completion Item Vertical Position    %%timeit
+    Should Be True    ${kernel_position} > ${lsp_position}
 
 Invalidates On Cell Change
     Enter Cell Editor    1    line=2
@@ -272,9 +272,13 @@ Completes Large Namespaces
 
 Shows Documentation With CompletionItem Resolve
     [Setup]    Prepare File for Editing    R    completion    completion.R
-    Place Cursor In File Editor At    8    12
+    Place Cursor In File Editor At    8    7
     Wait Until Fully Initialized
     Trigger Completer
+    Completer Should Suggest    print.data.frame
+    Completer Should Include Documentation    Print a data frame.
+    # should remain visible after typing:
+    Press Keys    None    efa
     Completer Should Suggest    print.default
     Completer Should Include Documentation    the default method of the
     [Teardown]    Clean Up After Working With File    completion.R
@@ -317,8 +321,8 @@ Completer Should Suggest
 
 Get Completion Item Vertical Position
     [Arguments]    ${text}
-    ${position} =  Get Vertical Position     ${COMPLETER_BOX} .jp-Completer-item[data-value="${text}"]
-    [Return]  ${position}
+    ${position} =    Get Vertical Position    ${COMPLETER_BOX} .jp-Completer-item[data-value="${text}"]
+    [Return]    ${position}
 
 Completer Should Include Icon
     [Arguments]    ${icon}

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -251,10 +251,10 @@ Completes Correctly With R Double And Triple Colon
     Place Cursor In File Editor At    2    7
     Wait Until Fully Initialized
     Trigger Completer
-    Completer Should Suggest    assertCondition
-    Select Completer Suggestion    assertCondition
-    Wait Until Keyword Succeeds    40x    0.5s    File Editor Line Should Equal    1    tools::assertCondition
-    # tripple colont
+    Completer Should Suggest    .print.via.format
+    Select Completer Suggestion    .print.via.format
+    Wait Until Keyword Succeeds    40x    0.5s    File Editor Line Should Equal    1    tools::.print.via.format
+    # tripple colon
     Place Cursor In File Editor At    4    11
     Trigger Completer
     Completer Should Suggest    .packageName

--- a/atest/examples/completion.R
+++ b/atest/examples/completion.R
@@ -1,4 +1,4 @@
-# `tools::<tab>` → select `assertCondition` → `tools::assertCondition`
+# `tools::<tab>` → select `.print.via.format` → `tools::.print.via.format`
 tools::
 # `datasets:::<tab>` → select `.packageName` → `datasets:::.packageName`
 datasets:::

--- a/atest/examples/completion.R
+++ b/atest/examples/completion.R
@@ -4,5 +4,5 @@ tools::
 datasets:::
 # `base:::<tab>` → works
 base:::
-# `print.defaul<tab>` → shows documentation for `print.default`
-print.defaul
+# `print.d<tab>` → shows documentation for `print.data.frame` → press `efa` → shows documentation for `print.default`
+print.d

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -42,7 +42,12 @@
       "title": "Completer theme",
       "type": ["string", "null"],
       "default": "vscode",
-      "description": "The identifier of a completer theme with icons which indicate the kind of completion. Set to null to disable icons."
+      "description": "The identifier of a completer theme with icons which indicate the kind of completion. Set to null to disable icons. Search for 'completer themes' in the command palette for a command displaying available themes."
+    },
+    "kernelCompletionsFirst": {
+      "title": "Prioritize completions from kernel",
+      "default": false,
+      "description": "In case of ties when sorting completions, should the kernel completions receive higher priority than the language server completions?"
     },
     "typesMap": {
       "title": "Mapping of custom kernel types to valid completion kind names",

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -58,7 +58,6 @@ export class LSPConnector
   items: CompletionHandler.ICompletionItems;
 
   get kernel_completions_first(): boolean {
-    // TODO: test this in acceptance tests!
     return this.options.settings.composite.kernelCompletionsFirst;
   }
 

--- a/packages/jupyterlab-lsp/src/features/completion/item.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/item.ts
@@ -1,0 +1,167 @@
+import { CompletionHandler } from '@jupyterlab/completer';
+import { LabIcon } from '@jupyterlab/ui-components';
+import * as lsProtocol from 'vscode-languageserver-types';
+import { LSPConnector } from './completion_handler';
+
+export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
+  private _detail: string;
+  private _documentation: string;
+  private _is_documentation_markdown: boolean;
+  private _requested_resolution: boolean;
+  private _resolved: boolean;
+  /**
+   * Self-reference to make sure that the instance for will remain accessible
+   * after any copy operation (whether via spread syntax or Object.assign)
+   * performed by the JupyterLab completer internals.
+   */
+  public self: LazyCompletionItem;
+  private _currentInsertText: string;
+
+  get isDocumentationMarkdown(): boolean {
+    return this._is_documentation_markdown;
+  }
+
+  /**
+   * User facing completion.
+   * If insertText is not set, this will be inserted.
+   */
+  public label: string;
+
+  constructor(
+    /**
+     * Type of this completion item.
+     */
+    public type: string,
+    /**
+     * LabIcon object for icon to be rendered with completion type.
+     */
+    public icon: LabIcon,
+    private match: lsProtocol.CompletionItem,
+    private connector: LSPConnector,
+    private uri: string
+  ) {
+    this.label = match.label;
+    this._setDocumentation(match.documentation);
+    this._requested_resolution = false;
+    this._resolved = false;
+    this._detail = match.detail;
+    this.self = this;
+  }
+
+  private _setDocumentation(documentation: string | lsProtocol.MarkupContent) {
+    if (lsProtocol.MarkupContent.is(documentation)) {
+      this._documentation = documentation.value;
+      this._is_documentation_markdown = documentation.kind === 'markdown';
+    } else {
+      this._documentation = documentation;
+      this._is_documentation_markdown = false;
+    }
+  }
+
+  /**
+   * Completion to be inserted.
+   */
+  get insertText(): string {
+    return this._currentInsertText || this.match.insertText || this.match.label;
+  }
+
+  set insertText(text: string) {
+    this._currentInsertText = text;
+  }
+
+  get sortText(): string {
+    return this.match.sortText || this.match.label;
+  }
+
+  get filterText(): string {
+    return this.match.filterText;
+  }
+
+  public supportsResolution() {
+    const connection = this.connector.get_connection(this.uri);
+
+    return connection.isCompletionResolveProvider();
+  }
+
+  get detail(): string {
+    return this._detail;
+  }
+
+  public needsResolution(): boolean {
+    if (this.documentation) {
+      return false;
+    }
+
+    if (this._resolved) {
+      return false;
+    }
+
+    if (this._requested_resolution) {
+      return false;
+    }
+
+    return this.supportsResolution();
+  }
+
+  public isResolved() {
+    return this._resolved;
+  }
+
+  public fetchDocumentation(): void {
+    if (!this.needsResolution()) {
+      return;
+    }
+
+    const connection = this.connector.get_connection(this.uri);
+
+    this._requested_resolution = true;
+
+    connection
+      .getCompletionResolve(this.match)
+      .then(resolvedCompletionItem => {
+        this.connector.lab_integration.set_doc_panel_placeholder(false);
+        if (resolvedCompletionItem === null) {
+          return;
+        }
+        this._setDocumentation(resolvedCompletionItem.documentation);
+        this._detail = resolvedCompletionItem.detail;
+        // TODO: implement in pyls and enable with proper LSP communication
+        // this.label = resolvedCompletionItem.label;
+        this._resolved = true;
+        this.connector.lab_integration.refresh_doc_panel(this);
+      })
+      .catch(e => {
+        this.connector.lab_integration.set_doc_panel_placeholder(false);
+        console.warn(e);
+      });
+  }
+
+  /**
+   * A human-readable string with additional information
+   * about this item, like type or symbol information.
+   */
+  get documentation(): string {
+    if (!this.connector.should_show_documentation) {
+      return null;
+    }
+    if (this._documentation) {
+      return this._documentation;
+    }
+    return null;
+  }
+
+  /**
+   * Indicates if the item is deprecated.
+   */
+  get deprecated(): boolean {
+    if (this.match.deprecated) {
+      return this.match.deprecated;
+    }
+    return (
+      this.match.tags &&
+      this.match.tags.some(
+        tag => tag == lsProtocol.CompletionItemTag.Deprecated
+      )
+    );
+  }
+}

--- a/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
@@ -1,0 +1,76 @@
+import { LSPCompleterModel } from './model';
+import { expect } from 'chai';
+import { LazyCompletionItem } from './item';
+import * as lsProtocol from 'vscode-languageserver-types';
+
+describe('LSPCompleterModel', () => {
+  let model: LSPCompleterModel;
+
+  function create_dummy_item(
+    match: lsProtocol.CompletionItem,
+    type: string = 'dummy'
+  ) {
+    return new LazyCompletionItem(type, null, match, null, null);
+  }
+
+  const jupyter_icon_completion = create_dummy_item({
+    label: '<i class="jp-icon-jupyter"></i> Jupyter',
+    filterText: 'i font icon jupyter Jupyter',
+    documentation: 'A Jupyter icon implemented with <i> tag'
+  });
+  const test_a_completion = create_dummy_item({
+    label: 'test',
+    sortText: 'a'
+  });
+  const test_b_completion = create_dummy_item({
+    label: 'test',
+    sortText: 'b'
+  });
+  const test_c_completion = create_dummy_item({
+    label: 'test',
+    sortText: 'c'
+  });
+
+  beforeEach(() => {
+    model = new LSPCompleterModel();
+  });
+
+  it('marks html correctly', () => {
+    model.setCompletionItems([jupyter_icon_completion]);
+    model.query = 'Jup';
+
+    let markedItems = model.completionItems();
+    expect(markedItems[0].label).to.be.equal(
+      '&lt;i class="jp-icon-jupyter"&gt;&lt;/i&gt; <mark>Jup</mark>yter'
+    );
+  });
+
+  it('ties are solved with sortText', () => {
+    model.setCompletionItems([
+      test_a_completion,
+      test_c_completion,
+      test_b_completion
+    ]);
+    model.query = 'test';
+    let sortedItems = model.completionItems();
+    expect(sortedItems.map(item => item.sortText)).to.deep.equal([
+      'a',
+      'b',
+      'c'
+    ]);
+  });
+
+  it('filters use filterText', () => {
+    model.setCompletionItems([jupyter_icon_completion]);
+    // font is in filterText but not in label
+    model.query = 'font';
+
+    let filteredItems = model.completionItems();
+    expect(filteredItems.length).to.equal(1);
+
+    // class is in label but not in filterText
+    model.query = 'class';
+    filteredItems = model.completionItems();
+    expect(filteredItems.length).to.equal(0);
+  });
+});

--- a/packages/jupyterlab-lsp/src/features/completion/model.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { CompleterModel, CompletionHandler } from '@jupyterlab/completer';
+import { StringExt } from '@lumino/algorithm';
+import { LazyCompletionItem } from './item';
+
+interface ICompletionMatch<T extends CompletionHandler.ICompletionItem> {
+  /**
+   * A score which indicates the strength of the match.
+   *
+   * A lower score is better. Zero is the best possible score.
+   */
+  score: number;
+  item: T;
+}
+
+function escapeHTML(text: string) {
+  let node = document.createElement('span');
+  node.textContent = text;
+  return node.innerHTML;
+}
+
+/**
+ * This will be contributed upstream
+ */
+export class GenericCompleterModel<
+  T extends CompletionHandler.ICompletionItem
+> extends CompleterModel {
+  public caseSensitive = true;
+
+  completionItems(): T[] {
+    let query = this.query;
+    this.query = '';
+    let unfilteredItems = super.completionItems() as T[];
+    this.query = query;
+
+    //if (query) {
+    // always want to sort
+    // TODO does this behave strangely with %%<tab> if always sorting?
+    return this._sortAndFilter(query, unfilteredItems);
+    //}
+    //return unfilteredItems;
+  }
+
+  setCompletionItems(newValue: T[]) {
+    super.setCompletionItems(newValue);
+  }
+
+  private _markFragment(value: string): string {
+    return `<mark>${value}</mark>`;
+  }
+
+  protected getFilterText(item: T) {
+    return this.getHighlightableLabelRegion(item);
+  }
+
+  protected getHighlightableLabelRegion(item: T) {
+    // TODO: ideally label and params would be separated so we don't have to do
+    //  things like these which are not language-agnostic
+    //  (assume that params follow after first opening parenthesis which may not be the case);
+    //  the upcoming LSP 3.17 includes CompletionItemLabelDetails
+    //  which separates parameters from the label
+    // With ICompletionItems, the label may include parameters, so we exclude them from the matcher.
+    // e.g. Given label `foo(b, a, r)` and query `bar`,
+    // don't count parameters, `b`, `a`, and `r` as matches.
+    const index = item.label.indexOf('(');
+    return index > -1 ? item.label.substring(0, index) : item.label;
+  }
+
+  private _sortAndFilter(query: string, items: T[]): T[] {
+    let results: ICompletionMatch<T>[] = [];
+
+    for (let item of items) {
+      // See if label matches query string
+
+      let matched: boolean;
+
+      if (query) {
+        const filterText = this.getFilterText(item);
+        let filterMatch = StringExt.matchSumOfSquares(filterText, query);
+        matched = !!filterMatch;
+      } else {
+        matched = true;
+      }
+
+      // Filter non-matching items. Filtering may happen on a criterion different than label.
+      if (matched) {
+        // If the matches are substrings of label, highlight them
+        // in this part of the label that can be highlighted (must be a prefix),
+        // which is intended to avoid highlighting matches in function arguments etc.
+        const labelPrefix = escapeHTML(this.getHighlightableLabelRegion(item));
+
+        let match = StringExt.matchSumOfSquares(labelPrefix, query);
+        let label: string;
+        let score: number;
+
+        if (match) {
+          // Highlight label text if there's a match
+          // there won't be a match if filter text includes additional keywords
+          // for easier search that are not a part of the label
+          let marked = StringExt.highlight(
+            escapeHTML(item.label),
+            match.indices,
+            this._markFragment
+          );
+          label = marked.join('');
+          score = match.score;
+        } else {
+          label = item.label;
+          score = 0;
+        }
+        // preserve getters (allow for lazily retrieved documentation)
+        const itemClone = Object.create(
+          Object.getPrototypeOf(item),
+          Object.getOwnPropertyDescriptors(item)
+        );
+        itemClone.label = label;
+        // If no insertText is present, preserve original label value
+        // by setting it as the insertText.
+        itemClone.insertText = item.insertText ? item.insertText : item.label;
+
+        results.push({
+          item: itemClone,
+          score: score
+        });
+      }
+    }
+
+    results.sort(this.compareMatches);
+
+    return results.map(x => x.item);
+  }
+
+  protected compareMatches(
+    a: ICompletionMatch<T>,
+    b: ICompletionMatch<T>
+  ): number {
+    const delta = a.score - b.score;
+    if (delta !== 0) {
+      return delta;
+    }
+    return a.item.insertText?.localeCompare(b.item.insertText ?? '') ?? 0;
+  }
+}
+
+export class LSPCompleterModel extends GenericCompleterModel<
+  LazyCompletionItem
+> {
+  constructor() {
+    super();
+  }
+
+  protected getFilterText(item: LazyCompletionItem): string {
+    if (item.filterText) {
+      return item.filterText;
+    }
+    return super.getFilterText(item);
+  }
+
+  protected compareMatches(
+    a: ICompletionMatch<LazyCompletionItem>,
+    b: ICompletionMatch<LazyCompletionItem>
+  ): number {
+    const delta = a.score - b.score;
+    if (delta !== 0) {
+      return delta;
+    }
+    // solve ties using sortText
+
+    // note: locale compare is case-insensitive
+    return a.item.sortText.localeCompare(b.item.sortText);
+  }
+}

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -4,9 +4,9 @@
 import { Completer } from '@jupyterlab/completer';
 import { CompletionLabIntegration } from './completion';
 import { Signal } from '@lumino/signaling';
-import { LazyCompletionItem } from './completion_handler';
 import { IRenderMime } from '@jupyterlab/rendermime';
 import { ILSPLogConsole } from '../../tokens';
+import { LazyCompletionItem } from './item';
 
 export class LSPCompletionRenderer
   extends Completer.Renderer
@@ -27,9 +27,8 @@ export class LSPCompletionRenderer
     // make sure that an instance reference, and not an object copy is being used;
     item = item.self;
 
-    // only monitor nodes that have item.self as others are not LazyCompletionItems
-    // and only monitor those that need documentation retrieval
-    if (item && !item.documentation) {
+    // only monitor nodes that have item.self as others are not our completion items
+    if (item) {
       let inactive = true;
       const observer = new MutationObserver(mutations => {
         if (li.classList.contains('jp-mod-active')) {


### PR DESCRIPTION
- implements sorting of completions solving point 4 of #495 by taking use of `sortText` if provided (jets tested and indirectly integration-tested)
- makes use of `filterText` if provided (jest tested)
- allows user to choose whether in presence of ties (i.e. two suggestions having the same match score) the kernel suggestions should go first or last (the latter by default) (integration tested)
- ensures that a full copy of item object gets created during filtering so that the documentation can still be retrieved dynamically (adds integration test for that)
- always re-renders the docpanel so that the markdown is always rendered (while waiting for https://github.com/jupyterlab/jupyterlab/pull/9663 to be merged)
- allows to render labels that contain HTML tags (https://github.com/jupyterlab/jupyterlab/issues/9790)

## Code changes

- Use a custom completer model (`LSPCompleterModel`) and create a generic template `GenericCompleterModel` which will make the live much easier once upstreamed for 4.0 (https://github.com/jupyterlab/jupyterlab/issues/9763); at this point it is experimental API to be upstreamed so if anyone depending on our codebase looks at it - please do not rely on this API just yet.
- adds a second pass of `matchSumOfSquares` to allow for matching on `filterText` which does not have to be a substring of `label`; there is a price to pay for the second match calculation on numpy completions, but the total cost is over an order of magnitude lower of the current limiting factor of SVG rendering and item rendering in general.

## User-facing changes

TBD. So many nice things :)

## Backwards-incompatible changes

- moved `LazyCompletionItem` to a file of its own (`item.ts`); better to make this change early
- added  `LSPCompleterModel`

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
