### PR TITLE
Fix/diagnostics panel crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
 - bug fixes:
   - completer documentation will now consistently show up after filtering the completion items ([#520])
   - completions containing HTML-like syntax will be displayed properly (an upstream issue) ([#520])
+  - diagnostics panel will no longer break when foreign documents (e.g. `%%R` cell magics) are removed ([#522])
 
 [#520]: https://github.com/krassowski/jupyterlab-lsp/pull/520
+[#522]: https://github.com/krassowski/jupyterlab-lsp/pull/522
 
 ### `@krassowski/jupyterlab-lsp 3.3.1` (2020-02-07)
 

--- a/atest/04_Interface/DiagnosticsPanel.robot
+++ b/atest/04_Interface/DiagnosticsPanel.robot
@@ -9,6 +9,8 @@ Test Teardown     Clean Up
 ${EXPECTED_COUNT}    1
 ${DIAGNOSTIC}     W291 trailing whitespace (pycodestyle)
 ${DIAGNOSTIC MESSAGE}    trailing whitespace
+${DIAGNOSTIC MESSAGE R}    Closing curly-braces should always be on their own line
+${R CELL}         %%R\n{}
 ${MENU COLUMNS}    xpath://div[contains(@class, 'lm-Menu-itemLabel')][contains(text(), "columns")]
 ${LAB MENU}       css:.lm-Menu
 
@@ -77,6 +79,22 @@ Diagnostic Message Can Be Copied
     Select Menu Entry    Copy diagnostic
     Close Diagnostics Panel
     Wait Until Element Contains    css:.lsp-statusbar-item    Successfully copied    timeout=10s
+
+Diagnostics Panel Works After Removing Foreign Document
+    Enter Cell Editor    2
+    Lab Command    Insert Cell Below
+    Enter Cell Editor    3
+    Press Keys    None    ${R CELL}
+    Wait Until Keyword Succeeds    10 x    1s    Element Should Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE}
+    Wait Until Keyword Succeeds    10 x    1s    Element Should Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE R}
+    Lab Command    Delete Cells
+    # regain focus by entering cell
+    Enter Cell Editor    2
+    # trigger 7 document updates to trigger the garbage collector that removes unused documents
+    # (search for VirtualDocument.remainining_lifetime for more)
+    Press Keys    None    1234567
+    Wait Until Keyword Succeeds    10 x    1s    Element Should Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE}
+    Wait Until Keyword Succeeds    10 x    1s    Element Should Not Contain    ${DIAGNOSTICS PANEL}    ${DIAGNOSTIC MESSAGE R}
 
 *** Keywords ***
 Expand Menu Entry

--- a/packages/jupyterlab-lsp/src/components/utils.tsx
+++ b/packages/jupyterlab-lsp/src/components/utils.tsx
@@ -65,7 +65,11 @@ export function DocumentLocator(props: {
   let target: HTMLElement = null;
   if (adapter.has_multiple_editors) {
     let first_line = document.virtual_lines.get(0);
-    target = adapter.get_editor_wrapper(first_line.editor);
+    if (first_line) {
+      target = adapter.get_editor_wrapper(first_line.editor);
+    } else {
+      console.warn('Could not get first line of ', document);
+    }
   }
   let breadcrumbs = get_breadcrumbs(document, adapter);
   return (

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -279,7 +279,16 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
     this.adapter.adapterConnected.connect(() =>
       this.switchDiagnosticsPanelSource()
     );
+    this.virtual_document.foreign_document_closed.connect(
+      (document, context) => {
+        this.clearDocumentDiagnostics(context.foreign_document);
+      }
+    );
     super.register();
+  }
+
+  clearDocumentDiagnostics(document: VirtualDocument) {
+    this.diagnostics_db.set(document, []);
   }
 
   private unique_editor_ids: DefaultMap<CodeMirror.Editor, number>;

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -252,7 +252,7 @@ export class VirtualDocument {
     this.unused_standalone_documents = new DefaultMap(
       () => new Array<VirtualDocument>()
     );
-    this._remaining_lifetime = 10;
+    this._remaining_lifetime = 6;
     this.foreign_document_closed = new Signal(this);
     this.foreign_document_opened = new Signal(this);
     this.changed = new Signal(this);


### PR DESCRIPTION
## References

Fixes #516

## Code changes

- Added event listener to listen for closure of foreign documents and remove their diagnostics
- Added a safety net (if + console.warn) in case we get an empty document again for another reason
- Reduced default `remaining_lifetime` of foreign documents to 6. This is an arbitrary number but it feels right given that we are balancing the benefit of having faster restoration of features if foreign document temporarily stopped matching the regular expression as user is modifying it and the con of the diagnostics in the panel not disappearing immediately

## User-facing changes

Diagnostics panel will work reliably when removing transclusions/foreign documents

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
