### PR TITLE
Only search for label match if different from insertText match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,20 @@
   - the priority of the completions from kernel can now be changed by switching new `kernelCompletionsFirst` setting ([#520])
   - completer panel will now always render markdown documentation if available ([#520])
     - the implementation re-renders the panel as it is the best we can do until [jupyterlab#9663](https://github.com/jupyterlab/jupyterlab/pull/9663) is merged
-  - the completer now uses `filterText` and `sortText` if available to better filter and sort completions ([#520])
+  - the completer now uses `filterText` and `sortText` if available to better filter and sort completions ([#520], [#523])
   - completer `suppressInvokeIn` setting was removed; `suppressContinuousHintingIn` and `suppressTriggerCharacterIn` settings were added ([#521])
   - `suppressContinuousHintingIn` by default includes `def` to improve the experience when writing function names ([#521])
 
 - bug fixes:
   - user-invoked completion in strings works again ([#521])
   - completer documentation will now consistently show up after filtering the completion items ([#520])
-  - completions containing HTML-like syntax will be displayed properly (an upstream issue) ([#520])
+  - completions containing HTML-like syntax will be displayed properly (an upstream issue) ([#520], [#523])
   - diagnostics panel will no longer break when foreign documents (e.g. `%%R` cell magics) are removed ([#522])
 
 [#520]: https://github.com/krassowski/jupyterlab-lsp/pull/520
 [#521]: https://github.com/krassowski/jupyterlab-lsp/pull/521
 [#522]: https://github.com/krassowski/jupyterlab-lsp/pull/522
+[#523]: https://github.com/krassowski/jupyterlab-lsp/pull/523
 
 ### `@krassowski/jupyterlab-lsp 3.3.1` (2020-02-07)
 

--- a/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
@@ -35,6 +35,16 @@ describe('LSPCompleterModel', () => {
     model = new LSPCompleterModel();
   });
 
+  it('returns escaped when no query', () => {
+    model.setCompletionItems([jupyter_icon_completion]);
+    model.query = '';
+
+    let markedItems = model.completionItems();
+    expect(markedItems[0].label).to.be.equal(
+      '&lt;i class="jp-icon-jupyter"&gt;&lt;/i&gt; Jupyter'
+    );
+  });
+
   it('marks html correctly', () => {
     model.setCompletionItems([jupyter_icon_completion]);
     model.query = 'Jup';
@@ -72,5 +82,24 @@ describe('LSPCompleterModel', () => {
     model.query = 'class';
     filteredItems = model.completionItems();
     expect(filteredItems.length).to.equal(0);
+  });
+
+  it('marks appropriate part of label when filterText matches', () => {
+    model.setCompletionItems([jupyter_icon_completion]);
+    // font is in filterText but not in label
+    model.query = 'font';
+
+    // nothing should get highlighted
+    let markedItems = model.completionItems();
+    expect(markedItems[0].label).to.be.equal(
+      '&lt;i class="jp-icon-jupyter"&gt;&lt;/i&gt; Jupyter'
+    );
+
+    // i is in both label and filterText
+    model.query = 'i';
+    markedItems = model.completionItems();
+    expect(markedItems[0].label).to.be.equal(
+      '&lt;<mark>i</mark> class="jp-icon-jupyter"&gt;&lt;/i&gt; Jupyter'
+    );
   });
 });


### PR DESCRIPTION
Only search for label match if different from insertText match and escape HTML label when no query is used.

## References

Follow-up after #520 

## Code changes

- avoid matching again if the label prefix and insertText are the same
- escape HTML in label if no query is passed (so it is not removed by sanitizer)

## User-facing changes

- better filtering performance while retaining the benefit of using server-provided insertText
- completion of HTML/XML etc should work consistently

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
