### PR TITLE
Collapse paths for files deep in subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - the completer now uses `filterText` and `sortText` if available to better filter and sort completions ([#520], [#523])
   - completer `suppressInvokeIn` setting was removed; `suppressContinuousHintingIn` and `suppressTriggerCharacterIn` settings were added ([#521])
   - `suppressContinuousHintingIn` by default includes `def` to improve the experience when writing function names ([#521])
+  - long file paths are now collapsed if composed of more than two segments to avoid status popover and diagnostics panel getting too wide ([#524])
 
 - bug fixes:
   - user-invoked completion in strings works again ([#521])
@@ -21,6 +22,7 @@
 [#521]: https://github.com/krassowski/jupyterlab-lsp/pull/521
 [#522]: https://github.com/krassowski/jupyterlab-lsp/pull/522
 [#523]: https://github.com/krassowski/jupyterlab-lsp/pull/523
+[#524]: https://github.com/krassowski/jupyterlab-lsp/pull/524
 
 ### `@krassowski/jupyterlab-lsp 3.3.1` (2020-02-07)
 

--- a/packages/jupyterlab-lsp/src/components/utils.spec.ts
+++ b/packages/jupyterlab-lsp/src/components/utils.spec.ts
@@ -1,0 +1,53 @@
+import { get_breadcrumbs } from './utils';
+import { VirtualDocument } from '../virtual/document';
+import { WidgetAdapter } from '../adapters/adapter';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+
+function create_dummy_document(options: Partial<VirtualDocument.IOptions>) {
+  return new VirtualDocument({
+    language: 'python',
+    foreign_code_extractors: {},
+    overrides_registry: {},
+    path: 'Untitled.ipynb.py',
+    file_extension: 'py',
+    has_lsp_supported_file: false,
+    ...options
+  });
+}
+
+describe('get_breadcrumbs', () => {
+  it('should collapse long paths', () => {
+    let document = create_dummy_document({
+      path: 'dir1/dir2/Test.ipynb'
+    });
+    let breadcrumbs = get_breadcrumbs(document, {
+      has_multiple_editors: false
+    } as WidgetAdapter<IDocumentWidget>);
+    expect(breadcrumbs[0].props['title']).toBe('dir1/dir2/Test.ipynb');
+    expect(breadcrumbs[0].props['children']).toBe('dir1/.../Test.ipynb');
+  });
+
+  it('should trim the extra filename suffix for files created out of notebooks', () => {
+    let document = create_dummy_document({
+      path: 'Test.ipynb.py',
+      file_extension: 'py',
+      has_lsp_supported_file: false
+    });
+    let breadcrumbs = get_breadcrumbs(document, {
+      has_multiple_editors: false
+    } as WidgetAdapter<IDocumentWidget>);
+    expect(breadcrumbs[0].props['children']).toBe('Test.ipynb');
+  });
+
+  it('should not trim the filename suffix for standalone files', () => {
+    let document = create_dummy_document({
+      path: 'test.py',
+      file_extension: 'py',
+      has_lsp_supported_file: true
+    });
+    let breadcrumbs = get_breadcrumbs(document, {
+      has_multiple_editors: false
+    } as WidgetAdapter<IDocumentWidget>);
+    expect(breadcrumbs[0].props['children']).toBe('test.py');
+  });
+});

--- a/packages/jupyterlab-lsp/src/components/utils.tsx
+++ b/packages/jupyterlab-lsp/src/components/utils.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 
 export function get_breadcrumbs(
   document: VirtualDocument,
-  adapter: WidgetAdapter<IDocumentWidget>
+  adapter: WidgetAdapter<IDocumentWidget>,
+  collapse = true
 ): JSX.Element[] {
   return document.ancestry.map((document: VirtualDocument) => {
     if (!document.parent) {
@@ -16,7 +17,18 @@ export function get_breadcrumbs(
       ) {
         path = path.slice(0, -document.file_extension.length - 1);
       }
-      return <span key={document.uri}>{path}</span>;
+      const full_path = path;
+      if (collapse) {
+        let parts = path.split('/');
+        if (parts.length > 2) {
+          path = parts[0] + '/.../' + parts[parts.length - 1];
+        }
+      }
+      return (
+        <span key={document.uri} title={full_path}>
+          {path}
+        </span>
+      );
     }
     if (!document.virtual_lines.size) {
       return <span key={document.uri}>Empty document</span>;


### PR DESCRIPTION
## References

Fixes #515. The full path is displayed upon hovering over the collapsed path:

![Screenshot from 2021-02-14 16-41-21](https://user-images.githubusercontent.com/5832902/107882888-ba782680-6ee3-11eb-9443-726a3f345351.png)

## Code changes

- Added react test for `get_breadcrumbs`
- Added code to collapse the breadcrumb path if more than three parts; assumes forward slash as the paths are normalized at this point

## User-facing changes

Before:
![Screenshot from 2021-02-14 16-28-29](https://user-images.githubusercontent.com/5832902/107882513-b814cd00-6ee1-11eb-816a-b6c53a463c08.png)

After:
![Screenshot from 2021-02-14 16-26-47](https://user-images.githubusercontent.com/5832902/107882519-bea34480-6ee1-11eb-931a-84c2b1801eb2.png)

Before:
![Screenshot from 2021-02-14 16-27-42](https://user-images.githubusercontent.com/5832902/107882526-c4008f00-6ee1-11eb-98df-7e19c8362291.png)

After:
![Screenshot from 2021-02-14 16-26-16](https://user-images.githubusercontent.com/5832902/107882534-c95dd980-6ee1-11eb-9ac2-509dbe4dab7b.png)

## Backwards-incompatible changes

Adds a "collapse" toggle to `get_breadcrumbs`

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
