### PR TITLE
Handle case where getCursor() returns null in highlighter

### DIFF
--- a/packages/jupyterlab-lsp/src/features/highlights.ts
+++ b/packages/jupyterlab-lsp/src/features/highlights.ts
@@ -145,6 +145,11 @@ export class HighlightsCM extends CodeMirrorIntegration {
       return;
     }
 
+    if (!root_position) {
+      this.console.warn('no root position available');
+      return;
+    }
+
     const token = this.virtual_editor.get_token_at(root_position);
 
     // if token has not changed, no need to update highlight, unless it is an empty token

--- a/packages/jupyterlab-lsp/src/features/highlights.ts
+++ b/packages/jupyterlab-lsp/src/features/highlights.ts
@@ -145,7 +145,7 @@ export class HighlightsCM extends CodeMirrorIntegration {
       return;
     }
 
-    if (!root_position) {
+    if (root_position == null) {
       this.console.warn('no root position available');
       return;
     }


### PR DESCRIPTION

## References

Fixes #543 

## Code changes

onCursorActivity currently assumes that getCursor() will throw an exception if it was unable to obtain a valid cursor position. This is not the case. There are a few instances where it will return either undefined or null. In particular, if there is not yet an editor available. This change checks root_position and ensures it has a valid value.

## User-facing changes

none

## Backwards-incompatible changes

none

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [ ] changelog entry
