### PR TITLE
Fix a typo preventing pinfo from working on ids with letter 's'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 3.4.2` (unreleased)
+
+- bug fixes:
+
+  - prevents throwing a highlights error when adding new cell with <kbd>Shift</kbd> + <kbd>Enter</kbd> ([#544])
+  - fixes IPython `pinfo` and `pinfo2` (`?` and `??`) for identifiers containing `s` ([#547])
+
+[#544]: https://github.com/krassowski/jupyterlab-lsp/pull/544
+[#547]: https://github.com/krassowski/jupyterlab-lsp/pull/547
+
 ### `jupyter-lsp 1.1.4` (2020-02-21)
 
 - bug fixes:

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
@@ -205,6 +205,13 @@ describe('Default IPython overrides', () => {
 
       reverse = line_magics_map.reverse.override_for(override);
       expect(reverse).to.equal('int??');
+
+      override = line_magics_map.override_for('some_func??');
+      expect(override).to.equal(
+        "get_ipython().run_line_magic('pinfo2',  'some_func')"
+      );
+      reverse = line_magics_map.reverse.override_for(override);
+      expect(reverse).to.equal('some_func??');
     });
 
     it('does not override standalone question marks', () => {

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.ts
@@ -42,7 +42,7 @@ function empty_or_escaped(x: string) {
  */
 export const LINE_MAGIC_PREFIX = '^(\\s*|\\s*\\S+\\s*=\\s*)';
 
-export const PYTHON_IDENTIFIER = '([^?s\'"\\(\\)-\\+\\/#]+)';
+export const PYTHON_IDENTIFIER = '([^?\\s\'"\\(\\)-\\+\\/#]+)';
 
 export let overrides: IScopedCodeOverride[] = [
   /**


### PR DESCRIPTION
## References

Fixes #542

## Code changes

- fixed a typo (`s` where it should have been `\\s`)
- added a test

## User-facing changes

pinfo and pinfo2 magics will be correctly handled for IPython

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
