### PR TITLE
Source-aware completions and more completer settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - features:
 
   - adds `%%bigquery` IPython cell magic support for BigQuery ([#553], thanks @julioyildo)
+  - completions filtering can be set to case-insensitive in settings ([#549])
+  - completions filtering can hide exact matches ([#549])
+  - the extra information displayed next to the completion label now can include 'detail' (usually module/package of origin), and can be customized in settings ([#549])
 
 - bug fixes:
 
@@ -18,6 +21,7 @@
 
 [#544]: https://github.com/krassowski/jupyterlab-lsp/pull/544
 [#547]: https://github.com/krassowski/jupyterlab-lsp/pull/547
+[#549]: https://github.com/krassowski/jupyterlab-lsp/pull/549
 [#553]: https://github.com/krassowski/jupyterlab-lsp/pull/553
 [#560]: https://github.com/krassowski/jupyterlab-lsp/pull/560
 [#562]: https://github.com/krassowski/jupyterlab-lsp/pull/562

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -70,6 +70,13 @@
       "type": "boolean",
       "description": "Should perfect matches be included in the completion suggestions list?"
     },
+    "labelExtra": {
+      "title": "Text to display next to completion label",
+      "default": "auto",
+      "type": "string",
+      "enum": ["detail", "type", "source", "auto"],
+      "description": "What to display next to the completion label, one of: 'detail', 'type', 'source', 'auto'. The default 'auto' will display whichever information is available."
+    },
     "typesMap": {
       "title": "Mapping of custom kernel types to valid completion kind names",
       "description": "Mapping used for icon selection. The kernel types (keys) are case-insensitive. Accepted values are the names of CompletionItemKind and 'Kernel' literal. The defaults aim to provide good initial experience for Julia, Python and R kernels.",

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -58,6 +58,18 @@
       "default": false,
       "description": "In case of ties when sorting completions, should the kernel completions receive higher priority than the language server completions?"
     },
+    "caseSensitive": {
+      "title": "Case-sensitive filtering",
+      "default": true,
+      "type": "boolean",
+      "description": "Should completion filtering be case-sensitive?"
+    },
+    "includePerfectMatches": {
+      "title": "Include perfect matches",
+      "default": true,
+      "type": "boolean",
+      "description": "Should perfect matches be included in the completion suggestions list?"
+    },
     "typesMap": {
       "title": "Mapping of custom kernel types to valid completion kind names",
       "description": "Mapping used for icon selection. The kernel types (keys) are case-insensitive. Accepted values are the names of CompletionItemKind and 'Kernel' literal. The defaults aim to provide good initial experience for Julia, Python and R kernels.",

--- a/packages/jupyterlab-lsp/src/features/completion/completion.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion.ts
@@ -111,6 +111,8 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
       completionThemeManager.set_icons_overrides(
         this.settings.composite.typesMap
       );
+      this.model.settings.caseSensitive = this.settings.composite.caseSensitive;
+      this.model.settings.includePerfectMatches = this.settings.composite.includePerfectMatches;
     });
   }
 
@@ -195,7 +197,10 @@ export class CompletionLabIntegration implements IFeatureLabIntegration {
     ) as CompletionHandler;
     let completer = this.completer;
     completer.addClass('lsp-completer');
-    completer.model = new LSPCompleterModel();
+    completer.model = new LSPCompleterModel({
+      caseSensitive: this.settings.composite.caseSensitive,
+      includePerfectMatches: this.settings.composite.includePerfectMatches
+    });
   }
 
   protected get completer() {

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -429,7 +429,7 @@ export class LSPConnector
         return {
           label: item.text as string,
           insertText: item.text as string,
-          type: item.type as string,
+          type: item.type === '<unknown>' ? undefined : (item.type as string),
           icon: this.icon_for(item.type as string),
           sortText: this.kernel_completions_first ? 'a' : 'z'
         };

--- a/packages/jupyterlab-lsp/src/features/completion/item.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/item.ts
@@ -3,7 +3,35 @@ import { LabIcon } from '@jupyterlab/ui-components';
 import * as lsProtocol from 'vscode-languageserver-types';
 import { LSPConnector } from './completion_handler';
 
-export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
+/**
+ * To be upstreamed
+ */
+export interface ICompletionsSource {
+  /**
+   * The name displayed in the GUI
+   */
+  name: string;
+  /**
+   * The higher the number the higher the priority
+   */
+  priority: number;
+  /**
+   * The icon to be displayed if no type icon is present
+   */
+  fallbackIcon?: LabIcon;
+}
+
+/**
+ * To be upstreamed
+ */
+export interface IExtendedCompletionItem
+  extends CompletionHandler.ICompletionItem {
+  insertText: string;
+  sortText: string;
+  source?: ICompletionsSource;
+}
+
+export class LazyCompletionItem implements IExtendedCompletionItem {
   private _detail: string;
   private _documentation: string;
   private _is_documentation_markdown: boolean;
@@ -26,6 +54,8 @@ export class LazyCompletionItem implements CompletionHandler.ICompletionItem {
    * If insertText is not set, this will be inserted.
    */
   public label: string;
+
+  public source: ICompletionsSource;
 
   constructor(
     /**

--- a/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
@@ -30,9 +30,16 @@ describe('LSPCompleterModel', () => {
     label: 'test',
     sortText: 'c'
   });
+  const test_test_completion = create_dummy_item({
+    label: 'test_test',
+    sortText: 'test_test'
+  });
 
   beforeEach(() => {
-    model = new LSPCompleterModel();
+    model = new LSPCompleterModel({
+      caseSensitive: true,
+      includePerfectMatches: true
+    });
   });
 
   it('returns escaped when no query', () => {
@@ -68,6 +75,33 @@ describe('LSPCompleterModel', () => {
       'b',
       'c'
     ]);
+  });
+
+  it('ignores perfect matches when asked', () => {
+    model = new LSPCompleterModel({
+      includePerfectMatches: false
+    });
+
+    model.setCompletionItems([test_a_completion, test_test_completion]);
+    model.query = 'test';
+    let items = model.completionItems();
+    // should not include the perfect match 'test'
+    expect(items.length).to.equal(1);
+    expect(items.map(item => item.sortText)).to.deep.equal(['test_test']);
+  });
+
+  it('case-sensitivity can be changed', () => {
+    model = new LSPCompleterModel();
+    model.setCompletionItems([test_a_completion]);
+    model.query = 'Test';
+
+    model.settings.caseSensitive = true;
+    let items = model.completionItems();
+    expect(items.length).to.equal(0);
+
+    model.settings.caseSensitive = false;
+    items = model.completionItems();
+    expect(items.length).to.equal(1);
   });
 
   it('filters use filterText', () => {

--- a/packages/jupyterlab-lsp/src/features/completion/model.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.ts
@@ -79,7 +79,8 @@ export class GenericCompleterModel<
       if (query) {
         filterText = this.getFilterText(item);
         filterMatch = StringExt.matchSumOfSquares(filterText, query);
-        matched = !!filterMatch;
+        // ignore perfect matches (those are not useful)
+        matched = !!filterMatch && filterText != query;
       } else {
         matched = true;
       }

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -8,26 +8,107 @@ import { IRenderMime } from '@jupyterlab/rendermime';
 import { ILSPLogConsole } from '../../tokens';
 import { LazyCompletionItem } from './item';
 
+export interface ICompletionData {
+  item: LazyCompletionItem;
+  element: HTMLLIElement;
+}
+
 export class LSPCompletionRenderer
   extends Completer.Renderer
   implements Completer.IRenderer {
-  public activeChanged: Signal<LSPCompletionRenderer, LazyCompletionItem>;
+  // signals
+  public activeChanged: Signal<LSPCompletionRenderer, ICompletionData>;
+  public itemShown: Signal<LSPCompletionRenderer, ICompletionData>;
+  // observers
+  private visibilityObserver: IntersectionObserver;
+  private activityObserver: MutationObserver;
+  // element data maps (with weak references for better GC)
+  private elementToItem: WeakMap<HTMLLIElement, LazyCompletionItem>;
+  private wasActivated: WeakMap<HTMLLIElement, boolean>;
+
+  protected ITEM_PLACEHOLDER_CLASS = 'lsp-detail-placeholder';
+  protected EXTRA_INFO_CLASS = 'jp-Completer-typeExtended';
 
   constructor(protected options: LSPCompletionRenderer.IOptions) {
     super();
     this.activeChanged = new Signal(this);
+    this.itemShown = new Signal(this);
+    this.elementToItem = new WeakMap();
+    this.wasActivated = new WeakMap();
+
+    this.visibilityObserver = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          let li = entry.target as HTMLLIElement;
+          let item = this.elementToItem.get(li);
+          this.itemShown.emit({
+            item: item,
+            element: li
+          });
+        });
+      },
+      {
+        threshold: 0.25
+      }
+    );
+
+    // note: there should be no need to unobserve deleted elements as per:
+    // https://stackoverflow.com/a/51106262/6646912
+    this.activityObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        let li = mutation.target;
+        if (!(li instanceof HTMLLIElement)) {
+          return;
+        }
+        let inactive = !this.wasActivated.get(li);
+
+        if (li.classList.contains('jp-mod-active')) {
+          if (inactive) {
+            this.wasActivated.set(li, true);
+            let item = this.elementToItem.get(li);
+            this.activeChanged.emit({
+              item: item,
+              element: li
+            });
+          }
+        } else {
+          this.wasActivated.set(li, false);
+        }
+      });
+    });
   }
 
   protected getExtraInfo(item: LazyCompletionItem): string {
-    switch (this.options.integrator.settings.composite.labelExtra) {
+    const labelExtra = this.options.integrator.settings.composite.labelExtra;
+    switch (labelExtra) {
       case 'detail':
-        return item.detail;
+        return item?.detail;
       case 'type':
-        return item.type;
+        return item?.type?.toLowerCase?.();
       case 'source':
-        return item.source.name;
+        return item?.source?.name;
       case 'auto':
-        return [item.detail, item.type, item.source.name].filter(x => !!x)[0];
+        return [
+          item?.detail,
+          item?.type?.toLowerCase?.(),
+          item?.source?.name
+        ].filter(x => !!x)[0];
+      default:
+        this.options.console.warn(
+          'labelExtra does not match any of the expected values',
+          labelExtra
+        );
+    }
+  }
+
+  public updateExtraInfo(item: LazyCompletionItem, li: HTMLLIElement) {
+    const extraText = this.getExtraInfo(item);
+    if (extraText) {
+      const extraElement = li.getElementsByClassName(this.EXTRA_INFO_CLASS)[0];
+      extraElement.textContent = extraText;
     }
   }
 
@@ -38,30 +119,22 @@ export class LSPCompletionRenderer
     const li = super.createCompletionItemNode(item, orderedTypes);
 
     // make sure that an instance reference, and not an object copy is being used;
-    item = item.self;
+    const lsp_item = item.self;
 
     // only monitor nodes that have item.self as others are not our completion items
-    if (item) {
-      let inactive = true;
-      const observer = new MutationObserver(mutations => {
-        if (li.classList.contains('jp-mod-active')) {
-          if (inactive) {
-            inactive = false;
-            this.activeChanged.emit(item);
-          }
-        } else {
-          inactive = true;
-        }
-      });
-      observer.observe(li, {
+    if (lsp_item) {
+      lsp_item.element = li;
+      this.elementToItem.set(li, lsp_item);
+      this.activityObserver.observe(li, {
         attributes: true,
         attributeFilter: ['class']
       });
+      this.visibilityObserver.observe(li);
+      // TODO: build custom li from ground up
+      // this.updateExtraInfo(lsp_item, li)
+    } else {
+      this.updateExtraInfo(item, li);
     }
-
-    const extraText = this.getExtraInfo(item);
-    const extraElement = li.querySelector('.jp-Completer-typeExtended');
-    extraElement.textContent = extraText;
 
     return li;
   }

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -131,7 +131,7 @@ export class LSPCompletionRenderer
       });
       this.visibilityObserver.observe(li);
       // TODO: build custom li from ground up
-      // this.updateExtraInfo(lsp_item, li)
+      this.updateExtraInfo(lsp_item, li);
     } else {
       this.updateExtraInfo(item, li);
     }

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -18,6 +18,19 @@ export class LSPCompletionRenderer
     this.activeChanged = new Signal(this);
   }
 
+  protected getExtraInfo(item: LazyCompletionItem): string {
+    switch (this.options.integrator.settings.composite.labelExtra) {
+      case 'detail':
+        return item.detail;
+      case 'type':
+        return item.type;
+      case 'source':
+        return item.source.name;
+      case 'auto':
+        return [item.detail, item.type, item.source.name].filter(x => !!x)[0];
+    }
+  }
+
   createCompletionItemNode(
     item: LazyCompletionItem,
     orderedTypes: string[]
@@ -45,6 +58,10 @@ export class LSPCompletionRenderer
         attributeFilter: ['class']
       });
     }
+
+    const extraText = this.getExtraInfo(item);
+    const extraElement = li.querySelector('.jp-Completer-typeExtended');
+    extraElement.textContent = extraText;
 
     return li;
   }


### PR DESCRIPTION
## References

Small step towards #495 and #236. Fixes #492.

## Code changes

- [x] trim spaces in insertText when merging completions (was the source of duplicated completions as Python kernel was returning 'return' and 'return ')
- [x] generalised completion merging code so that plugin in kite or another will be easier in the future
- [x] extend `CompletionHandler.ICompletionItemsReply` to include source information (`ICompletionsReply`)
- [x] define `ICompletionsSource` for source metadata storage
- [x] extend `CompletionHandler.ICompletionItem` to include source info and others (`IExtendedCompletionItem`)
- [ ] source in `IExtendedCompletionItem` and `ICompletionsReply` can be null/undefined at different stages. How to handle this safely for future us?

## User-facing changes

- [x] detail is now shown instead of the type by default; if no detail is available, then type or source ("Kernel" for kernel completions) is shown instead.

![detail-and-source-opt](https://user-images.githubusercontent.com/5832902/111923947-bcf90d80-8a99-11eb-9489-179f327b1778.gif)


- [x] exposed settings:
  - [x] `caseSensitive`: old behaviour retained by default
  - [x] `includePerfectMatches`: old behaviour retained by default
  - [x] `labelExtra`: new behaviour - display detail from LSP rather than the type in the completion label

![new-completion-settings](https://user-images.githubusercontent.com/5832902/111923951-c4201b80-8a99-11eb-983b-6657a972391a.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted
- [x] tested
- [ ] documented
- [x] changelog entry
