### PR TITLE
include second = for pip install

### DIFF
--- a/docs/Installation.ipynb
+++ b/docs/Installation.ipynb
@@ -250,7 +250,7 @@
     "##### pip\n",
     "\n",
     "```bash\n",
-    "pip install jupyterlab-lsp={JUPYTERLAB_LSP_VERSION}\n",
+    "pip install jupyterlab-lsp=={JUPYTERLAB_LSP_VERSION}\n",
     "```"
    ]
   },

--- a/scripts/integrity.py
+++ b/scripts/integrity.py
@@ -195,7 +195,8 @@ def test_changelog_versions(pkg, version):
         ],  # zero because jupyterlab-lsp is good enough
         [PY_SERVER_NAME + "-python", "=", PY_SERVER_VERSION, 1],
         [JS_LSP_NAME, "@", JS_LSP_VERSION, 1],  # TODO: update docker instructions
-        [PY_FRONT_NAME, "=", JS_LSP_VERSION, 3],
+        [PY_FRONT_NAME, "=", JS_LSP_VERSION, 2],  # conda install
+        [PY_FRONT_NAME, "==", JS_LSP_VERSION, 1],  # pip install
     ],
 )
 def test_installation_versions(the_installation_notebook, pkg, sep, version, expected):


### PR DESCRIPTION
`pip install jupyterlab-lsp=3.4.1` is missing one `=`

This is just a type in the docs, and I wanted to give you a heads up :)

<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
