### PR TITLE
localize strings for jupyterlab-lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ### `@krassowski/jupyterlab-lsp 3.5.1` (unreleased)
 
+- features:
+
+  - added translation support ([#557], thanks @JessicaBarh)
+
 - bug fixes:
 
-  - fixes name of jupyterlab-lsp package displayed in JupyterLab UI ([#570])
-  - remove vendored CodeMirror from distribution ([#576])
+  - fixed name of jupyterlab-lsp package displayed in JupyterLab UI ([#570], thanks @marimeireles)
+  - removed vendored CodeMirror from distribution ([#576])
 
+[#557]: https://github.com/krassowski/jupyterlab-lsp/pull/557
 [#570]: https://github.com/krassowski/jupyterlab-lsp/pull/570
 [#576]: https://github.com/krassowski/jupyterlab-lsp/pull/576
 

--- a/packages/code-jumpers/package.json
+++ b/packages/code-jumpers/package.json
@@ -36,7 +36,8 @@
     "@jupyterlab/docregistry": "^3.0.0",
     "@jupyterlab/fileeditor": "^3.0.0",
     "@jupyterlab/notebook": "^3.0.0",
-    "@jupyterlab/observables": "^4.0.0"
+    "@jupyterlab/observables": "^4.0.0",
+    "@jupyterlab/translation": "^3.0.0"
   },
   "devDependencies": {
     "@jupyterlab/apputils": "^3.0.0",
@@ -48,6 +49,7 @@
     "@jupyterlab/notebook": "^3.0.0",
     "@jupyterlab/observables": "^4.0.0",
     "@jupyterlab/testutils": "^3.0.0",
+    "@jupyterlab/translation": "^3.0.0",
     "rimraf": "^3.0.2",
     "typescript": "~4.1.3",
     "@babel/preset-env": "^7.4.3"

--- a/packages/completion-theme/src/about.tsx
+++ b/packages/completion-theme/src/about.tsx
@@ -5,6 +5,7 @@ import {
   COMPLETER_THEME_PREFIX
 } from './types';
 import { LabIcon } from '@jupyterlab/ui-components';
+import { TranslationBundle } from '@jupyterlab/translation';
 
 function render_licence(licence: ILicenseInfo): ReactElement {
   return (
@@ -20,6 +21,7 @@ function render_licence(licence: ILicenseInfo): ReactElement {
 type IconSetGetter = (theme: ICompletionTheme) => Map<string, LabIcon>;
 
 function render_theme(
+  trans: TranslationBundle,
   theme: ICompletionTheme,
   get_set: IconSetGetter,
   is_current: boolean
@@ -41,17 +43,20 @@ function render_theme(
     >
       <h4>
         {theme.name}
-        {is_current ? ' (current)' : ''}
+        {is_current ? trans.__(' (current)') : ''}
       </h4>
       <ul>
         <li key={'id'}>
           ID: <code>{theme.id}</code>
         </li>
-        <li key={'licence'}>Licence: {render_licence(theme.icons.licence)}</li>
+        <li key={'licence'}>
+          {trans.__('Licence: ')}
+          {render_licence(theme.icons.licence)}
+        </li>
         <li key={'dark'}>
           {typeof theme.icons.dark === 'undefined'
             ? ''
-            : 'Includes dedicated dark mode icons set'}
+            : trans.__('Includes dedicated dark mode icons set')}
         </li>
       </ul>
       <div className={'lsp-completer-theme-icons'}>{icons}</div>
@@ -59,13 +64,16 @@ function render_theme(
   );
 }
 
-export function render_themes_list(props: {
-  themes: ICompletionTheme[];
-  current: ICompletionTheme;
-  get_set: IconSetGetter;
-}): React.ReactElement {
+export function render_themes_list(
+  trans: TranslationBundle,
+  props: {
+    themes: ICompletionTheme[];
+    current: ICompletionTheme;
+    get_set: IconSetGetter;
+  }
+): React.ReactElement {
   let themes = props.themes.map(theme =>
-    render_theme(theme, props.get_set, theme == props.current)
+    render_theme(trans, theme, props.get_set, theme == props.current)
   );
   return <div>{themes}</div>;
 }

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -6,6 +6,7 @@ import {
   showDialog
 } from '@jupyterlab/apputils';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 import {
   ICompletionIconSet,
   ICompletionTheme,
@@ -17,7 +18,6 @@ import {
 } from './types';
 import { render_themes_list } from './about';
 import '../style/index.css';
-import { ITranslator } from '@jupyterlab/translation';
 
 export class CompletionThemeManager implements ILSPCompletionThemeManager {
   protected current_icons: Map<string, LabIcon>;
@@ -25,12 +25,14 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
   private current_theme_id: string;
   private icons_cache: Map<string, LabIcon>;
   private icon_overrides: Map<string, CompletionItemKindStrings>;
+  private trans: TranslationBundle;
 
-  constructor(protected themeManager: IThemeManager) {
+  constructor(protected themeManager: IThemeManager, trans: TranslationBundle) {
     this.themes = new Map();
     this.icons_cache = new Map();
     this.icon_overrides = new Map();
     themeManager.themeChanged.connect(this.update_icons_set, this);
+    this.trans = trans;
   }
 
   protected is_theme_light() {
@@ -143,13 +145,13 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
    */
   display_themes() {
     showDialog({
-      title: 'LSP Completer Themes',
-      body: render_themes_list({
+      title: this.trans.__('LSP Completer Themes'),
+      body: render_themes_list(this.trans, {
         themes: [...this.themes.values()],
         current: this.current_theme,
         get_set: this.get_iconset.bind(this)
       }),
-      buttons: [Dialog.okButton()]
+      buttons: [Dialog.okButton({ label: this.trans.__('OK') })]
     }).catch(console.warn);
   }
 
@@ -176,9 +178,9 @@ export const COMPLETION_THEME_MANAGER: JupyterFrontEndPlugin<ILSPCompletionTheme
     commandPalette: ICommandPalette,
     translator: ITranslator
   ) => {
-    let manager = new CompletionThemeManager(themeManager);
-    const command_id = 'lsp:completer-about-themes';
     const trans = translator.load('jupyterlab-lsp');
+    let manager = new CompletionThemeManager(themeManager, trans);
+    const command_id = 'lsp:completer-about-themes';
     app.commands.addCommand(command_id, {
       label: trans.__('Display the completer themes'),
       execute: () => {

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from './types';
 import { render_themes_list } from './about';
 import '../style/index.css';
+import { ITranslator } from '@jupyterlab/translation';
 
 export class CompletionThemeManager implements ILSPCompletionThemeManager {
   protected current_icons: Map<string, LabIcon>;
@@ -168,16 +169,18 @@ const LSP_CATEGORY = 'Language server protocol';
 
 export const COMPLETION_THEME_MANAGER: JupyterFrontEndPlugin<ILSPCompletionThemeManager> = {
   id: PLUGIN_ID,
-  requires: [IThemeManager, ICommandPalette],
+  requires: [IThemeManager, ICommandPalette, ITranslator],
   activate: (
     app,
     themeManager: IThemeManager,
-    commandPalette: ICommandPalette
+    commandPalette: ICommandPalette,
+    translator: ITranslator
   ) => {
     let manager = new CompletionThemeManager(themeManager);
     const command_id = 'lsp:completer-about-themes';
+    const trans = translator.load('jupyterlab-lsp');
     app.commands.addCommand(command_id, {
-      label: 'Display the completer themes',
+      label: trans.__('Display the completer themes'),
       execute: () => {
         manager.display_themes();
       }

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -18,6 +18,7 @@ import { IFeatureEditorIntegration, IFeature } from '../feature';
 import { EditorAdapter } from '../editor_integration/editor_adapter';
 import IEditor = CodeEditor.IEditor;
 import { LanguageIdentifier } from '../lsp';
+import { nullTranslator, TranslationBundle } from '@jupyterlab/translation';
 
 export class StatusMessage {
   /**
@@ -91,6 +92,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
   public isConnected: boolean;
   public connection_manager: DocumentConnectionManager;
   public status_message: StatusMessage;
+  public trans: TranslationBundle;
   protected isDisposed = false;
   console: ILSPLogConsole;
 
@@ -126,6 +128,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     this.status_message = new StatusMessage();
     this.isConnected = false;
     this.console = extension.console.scope('WidgetAdapter');
+    this.trans = (extension.translator || nullTranslator).load('jupyterlab-lsp');
 
     // set up signal connections
     this.widget.context.saveState.connect(this.on_save_state, this);

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -128,7 +128,9 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     this.status_message = new StatusMessage();
     this.isConnected = false;
     this.console = extension.console.scope('WidgetAdapter');
-    this.trans = (extension.translator || nullTranslator).load('jupyterlab-lsp');
+    this.trans = (extension.translator || nullTranslator).load(
+      'jupyterlab-lsp'
+    );
 
     // set up signal connections
     this.widget.context.saveState.connect(this.on_save_state, this);

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -22,7 +22,6 @@ import { IVirtualEditor } from '../virtual/editor';
 
 import IEditor = CodeEditor.IEditor;
 
-
 export class StatusMessage {
   /**
    * The text message to be shown on the statusbar

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -581,7 +581,8 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
         connection: connection,
         status_message: this.status_message,
         settings: feature.settings,
-        adapter: this
+        adapter: this,
+        trans: this.trans
       });
       adapter_features.push(integration);
     }

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -142,17 +142,14 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
 
           let status = '';
           if (connection?.isInitialized) {
-            status = this.model.trans.__('initialized');
+            status = 'initialized';
           } else if (connection?.isConnected) {
-            status = this.model.trans.__('connected');
+            status = 'connected';
           } else {
-            status = this.model.trans.__('not connected');
+            status = 'not connected';
           }
 
-          const icon =
-            status === this.model.trans.__('initialized')
-              ? circleIcon
-              : circleEmptyIcon;
+          const icon = status === 'initialized' ? circleIcon : circleEmptyIcon;
 
           return (
             <li key={i}>
@@ -161,7 +158,7 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
                 adapter={this.model.adapter}
               />
               <span className={'lsp-document-status'}>
-                {status}
+                {this.model.trans.__(status)}
                 <icon.react
                   tag="span"
                   className="lsp-document-status-icon"

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -41,7 +41,6 @@ import { VirtualDocument, collect_documents } from '../virtual/document';
 import { codeCheckIcon, codeClockIcon, codeWarningIcon } from './icons';
 import { DocumentLocator } from './utils';
 
-
 import okButton = Dialog.okButton;
 
 interface IServerStatusProps {

--- a/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
@@ -25,6 +25,7 @@ import { StatusMessage, WidgetAdapter } from '../adapters/adapter';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { IEditorChange } from '../virtual/editor';
 import { ILSPLogConsole } from '../tokens';
+import { TranslationBundle } from '@jupyterlab/translation';
 
 function toDocumentChanges(changes: {
   [uri: string]: lsProtocol.TextEdit[];
@@ -114,6 +115,8 @@ export abstract class CodeMirrorIntegration
   protected adapter: WidgetAdapter<IDocumentWidget>;
   protected console: ILSPLogConsole;
 
+  protected trans: TranslationBundle;
+
   get settings(): IFeatureSettings<any> {
     return this.feature.settings;
   }
@@ -130,7 +133,8 @@ export abstract class CodeMirrorIntegration
     this.status_message = options.status_message;
     this.adapter = options.adapter;
     this.console = this.adapter.console.scope(options.feature.name);
-
+    this.trans = options.trans;
+    
     this.editor_handlers = new Map();
     this.connection_handlers = new Map();
     this.wrapper_handlers = new Map();

--- a/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
@@ -134,7 +134,7 @@ export abstract class CodeMirrorIntegration
     this.adapter = options.adapter;
     this.console = this.adapter.console.scope(options.feature.name);
     this.trans = options.trans;
-    
+
     this.editor_handlers = new Map();
     this.connection_handlers = new Map();
     this.wrapper_handlers = new Map();

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -1,3 +1,4 @@
+import { ITranslator } from '@jupyterlab/translation';
 import {
   CodeMirrorEditor,
   CodeMirrorEditorFactory,
@@ -101,6 +102,7 @@ export class MockExtension implements ILSPExtension {
   foreign_code_extractors: IForeignCodeExtractorsRegistry;
   code_overrides: ICodeOverridesRegistry;
   console: ILSPLogConsole;
+  translator: ITranslator;
 
   constructor() {
     this.app = null;

--- a/packages/jupyterlab-lsp/src/feature.ts
+++ b/packages/jupyterlab-lsp/src/feature.ts
@@ -10,6 +10,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { Signal } from '@lumino/signaling';
+import { TranslationBundle } from '@jupyterlab/translation'
 
 export interface IFeatureCommand {
   /**
@@ -196,6 +197,7 @@ export interface IEditorIntegrationOptions {
   connection: LSPConnection;
   status_message: StatusMessage;
   settings: IFeatureSettings<any>;
+  trans: TranslationBundle;
 }
 
 export interface IFeatureLabIntegration {

--- a/packages/jupyterlab-lsp/src/feature.ts
+++ b/packages/jupyterlab-lsp/src/feature.ts
@@ -10,7 +10,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { Signal } from '@lumino/signaling';
-import { TranslationBundle } from '@jupyterlab/translation'
+import { TranslationBundle } from '@jupyterlab/translation';
 
 export interface IFeatureCommand {
   /**

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -46,13 +46,12 @@ function escapeRegExp(string: string) {
   return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
 }
 
-let trans: TranslationBundle;
-
 class DiagnosticsPanel {
   private _content: DiagnosticsListing = null;
   private _widget: MainAreaWidget<DiagnosticsListing> = null;
   feature: DiagnosticsCM;
   is_registered = false;
+  trans: TranslationBundle;
 
   get widget() {
     if (this._widget == null || this._widget.content.model == null) {
@@ -69,12 +68,14 @@ class DiagnosticsPanel {
   }
 
   protected init_widget() {
-    this._content = new DiagnosticsListing(new DiagnosticsListing.Model(trans));
+    this._content = new DiagnosticsListing(
+      new DiagnosticsListing.Model(this.trans)
+    );
     this._content.model.diagnostics = new DiagnosticsDatabase();
     this._content.addClass('lsp-diagnostics-panel-content');
     const widget = new MainAreaWidget({ content: this._content });
     widget.id = 'lsp-diagnostics-panel';
-    widget.title.label = trans.__('Diagnostics Panel');
+    widget.title.label = this.trans?.__('Diagnostics Panel');
     widget.title.closable = true;
     widget.title.icon = diagnosticsIcon;
     return widget;
@@ -102,7 +103,7 @@ class DiagnosticsPanel {
 
     /** Columns Menu **/
     let columns_menu = new Menu({ commands: app.commands });
-    columns_menu.title.label = trans.__('Panel columns');
+    columns_menu.title.label = this.trans.__('Panel columns');
 
     app.commands.addCommand(CMD_COLUMN_VISIBILITY, {
       execute: args => {
@@ -131,7 +132,7 @@ class DiagnosticsPanel {
 
     /** Diagnostics Menu **/
     let ignore_diagnostics_menu = new Menu({ commands: app.commands });
-    ignore_diagnostics_menu.title.label = trans.__(
+    ignore_diagnostics_menu.title.label = this.trans.__(
       'Ignore diagnostics like this'
     );
 
@@ -175,7 +176,10 @@ class DiagnosticsPanel {
           return '';
         }
         const diagnostic = row.data.diagnostic;
-        return trans.__(`Ignore diagnostics with "%1" code`, diagnostic.code);
+        return this.trans.__(
+          'Ignore diagnostics with "%1" code',
+          diagnostic.code
+        );
       }
     });
     app.commands.addCommand(CMD_IGNORE_DIAGNOSTIC_MSG, {
@@ -204,7 +208,7 @@ class DiagnosticsPanel {
           return '';
         }
         const diagnostic = row.data.diagnostic;
-        return trans.__(
+        return this.trans.__(
           'Ignore diagnostics with "%1" message',
           diagnostic.message
         );
@@ -216,7 +220,7 @@ class DiagnosticsPanel {
         const row = get_row();
         this.widget.content.jump_to(row);
       },
-      label: trans.__('Jump to location'),
+      label: this.trans.__('Jump to location'),
       icon: jumpToIcon
     });
 
@@ -231,7 +235,7 @@ class DiagnosticsPanel {
           .writeText(message)
           .then(() => {
             this.content.model.status_message.set(
-              trans.__(`Successfully copied "%1" to clipboard`, message)
+              this.trans.__(`Successfully copied "%1" to clipboard`, message)
             );
           })
           .catch(() => {
@@ -239,14 +243,14 @@ class DiagnosticsPanel {
               'Could not copy with clipboard.writeText interface, falling back'
             );
             window.prompt(
-              trans.__(
+              this.trans.__(
                 'Your browser protects clipboard from write operations; please copy the message manually'
               ),
               message
             );
           });
       },
-      label: trans.__("Copy diagnostics' message"),
+      label: this.trans.__("Copy diagnostics' message"),
       icon: copyIcon
     });
 
@@ -321,7 +325,7 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
   }
 
   switchDiagnosticsPanelSource = () => {
-    trans = this.adapter.trans;
+    diagnostics_panel.trans = this.adapter.trans;
     if (
       diagnostics_panel.content.model.virtual_editor === this.virtual_editor &&
       diagnostics_panel.content.model.diagnostics == this.diagnostics_db

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -111,7 +111,7 @@ class DiagnosticsPanel {
         column.is_visible = !column.is_visible;
         widget.update();
       },
-      label: args => args['name'] as string,
+      label: args => this.trans.__(`${args['name']}`) as string,
       isToggled: args => {
         let column = get_column(args['name'] as string);
         return column.is_visible;

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -22,6 +22,7 @@ import diagnosticsSvg from '../../../style/icons/diagnostics.svg';
 import { Menu } from '@lumino/widgets';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { jumpToIcon } from '../jump_to';
+import { TranslationBundle } from '@jupyterlab/translation';
 
 export const diagnosticsIcon = new LabIcon({
   name: 'lsp:diagnostics',
@@ -45,6 +46,8 @@ function escapeRegExp(string: string) {
   return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
 }
 
+let trans: TranslationBundle;
+
 class DiagnosticsPanel {
   private _content: DiagnosticsListing = null;
   private _widget: MainAreaWidget<DiagnosticsListing> = null;
@@ -66,12 +69,12 @@ class DiagnosticsPanel {
   }
 
   protected init_widget() {
-    this._content = new DiagnosticsListing(new DiagnosticsListing.Model());
+    this._content = new DiagnosticsListing(new DiagnosticsListing.Model(trans));
     this._content.model.diagnostics = new DiagnosticsDatabase();
     this._content.addClass('lsp-diagnostics-panel-content');
     const widget = new MainAreaWidget({ content: this._content });
     widget.id = 'lsp-diagnostics-panel';
-    widget.title.label = 'Diagnostics Panel';
+    widget.title.label = trans.__('Diagnostics Panel');
     widget.title.closable = true;
     widget.title.icon = diagnosticsIcon;
     return widget;
@@ -99,7 +102,7 @@ class DiagnosticsPanel {
 
     /** Columns Menu **/
     let columns_menu = new Menu({ commands: app.commands });
-    columns_menu.title.label = 'Panel columns';
+    columns_menu.title.label = trans.__('Panel columns');
 
     app.commands.addCommand(CMD_COLUMN_VISIBILITY, {
       execute: args => {
@@ -128,7 +131,9 @@ class DiagnosticsPanel {
 
     /** Diagnostics Menu **/
     let ignore_diagnostics_menu = new Menu({ commands: app.commands });
-    ignore_diagnostics_menu.title.label = 'Ignore diagnostics like this';
+    ignore_diagnostics_menu.title.label = trans.__(
+      'Ignore diagnostics like this'
+    );
 
     let get_row = (): IDiagnosticsRow => {
       let tr = app.contextMenuHitTest(
@@ -170,7 +175,7 @@ class DiagnosticsPanel {
           return '';
         }
         const diagnostic = row.data.diagnostic;
-        return `Ignore diagnostics with "${diagnostic.code}" code`;
+        return trans.__(`Ignore diagnostics with "%1" code`, diagnostic.code);
       }
     });
     app.commands.addCommand(CMD_IGNORE_DIAGNOSTIC_MSG, {
@@ -199,7 +204,10 @@ class DiagnosticsPanel {
           return '';
         }
         const diagnostic = row.data.diagnostic;
-        return `Ignore diagnostics with "${diagnostic.message}" message`;
+        return trans.__(
+          'Ignore diagnostics with "%1" message',
+          diagnostic.message
+        );
       }
     });
 
@@ -208,7 +216,7 @@ class DiagnosticsPanel {
         const row = get_row();
         this.widget.content.jump_to(row);
       },
-      label: 'Jump to location',
+      label: trans.__('Jump to location'),
       icon: jumpToIcon
     });
 
@@ -223,7 +231,7 @@ class DiagnosticsPanel {
           .writeText(message)
           .then(() => {
             this.content.model.status_message.set(
-              `Successfully copied "${message}" to clipboard`
+              trans.__(`Successfully copied "%1" to clipboard`, message)
             );
           })
           .catch(() => {
@@ -231,12 +239,14 @@ class DiagnosticsPanel {
               'Could not copy with clipboard.writeText interface, falling back'
             );
             window.prompt(
-              'Your browser protects clipboard from write operations; please copy the message manually',
+              trans.__(
+                'Your browser protects clipboard from write operations; please copy the message manually'
+              ),
               message
             );
           });
       },
-      label: "Copy diagnostics' message",
+      label: trans.__("Copy diagnostics' message"),
       icon: copyIcon
     });
 
@@ -311,6 +321,7 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
   }
 
   switchDiagnosticsPanelSource = () => {
+    trans = this.adapter.trans;
     if (
       diagnostics_panel.content.model.virtual_editor === this.virtual_editor &&
       diagnostics_panel.content.model.diagnostics == this.diagnostics_db

--- a/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
@@ -3,6 +3,7 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 
 import { FeatureSettings, IFeatureCommand } from '../../feature';
 import { ILSPFeatureManager, PLUGIN_ID } from '../../tokens';
@@ -12,7 +13,6 @@ import {
   diagnosticsIcon,
   diagnostics_panel
 } from './diagnostics';
-import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 
 export const FEATURE_ID = PLUGIN_ID + ':diagnostics';
 

--- a/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
@@ -10,10 +10,11 @@ import {
   DiagnosticsCM,
   diagnosticsIcon
 } from './diagnostics';
+import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 
 export const FEATURE_ID = PLUGIN_ID + ':diagnostics';
 
-const COMMANDS: IFeatureCommand[] = [
+const COMMANDS = (trans: TranslationBundle): IFeatureCommand[] => [
   {
     id: 'show-diagnostics-panel',
     execute: ({ app, features, adapter }) => {
@@ -25,7 +26,6 @@ const COMMANDS: IFeatureCommand[] = [
       }
 
       const panel_widget = diagnostics_panel.widget;
-
       if (!panel_widget.isAttached) {
         app.shell.add(panel_widget, 'main', {
           ref: adapter.widget_id,
@@ -37,7 +37,7 @@ const COMMANDS: IFeatureCommand[] = [
     is_enabled: context => {
       return context.app.name != 'JupyterLab Classic';
     },
-    label: 'Show diagnostics panel',
+    label: trans.__('Show diagnostics panel'),
     rank: 3,
     icon: diagnosticsIcon
   }
@@ -45,14 +45,16 @@ const COMMANDS: IFeatureCommand[] = [
 
 export const DIAGNOSTICS_PLUGIN: JupyterFrontEndPlugin<void> = {
   id: FEATURE_ID,
-  requires: [ILSPFeatureManager, ISettingRegistry],
+  requires: [ILSPFeatureManager, ISettingRegistry, ITranslator],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     featureManager: ILSPFeatureManager,
-    settingRegistry: ISettingRegistry
+    settingRegistry: ISettingRegistry,
+    translator: ITranslator
   ) => {
     const settings = new FeatureSettings(settingRegistry, FEATURE_ID);
+    const trans = translator.load('jupyterlab-lsp');
 
     featureManager.register({
       feature: {
@@ -62,7 +64,7 @@ export const DIAGNOSTICS_PLUGIN: JupyterFrontEndPlugin<void> = {
         id: FEATURE_ID,
         name: 'LSP Diagnostics',
         settings: settings,
-        commands: COMMANDS
+        commands: COMMANDS(trans)
       }
     });
   }

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -169,7 +169,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       name: 'Severity',
       // TODO: use default diagnostic severity
       render_cell: row => (
-        <td key={3}>{DiagnosticSeverity[row.data.diagnostic.severity || 1]}</td>
+        <td key={3}>{trans.__(DiagnosticSeverity[row.data.diagnostic.severity || 1])}</td>
       ),
       sort: (a, b) =>
         a.data.diagnostic.severity > b.data.diagnostic.severity ? 1 : -1

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -16,6 +16,7 @@ import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { DocumentLocator, focus_on } from '../../components/utils';
 import { FeatureSettings } from '../../feature';
 import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
+import { TranslationBundle } from '@jupyterlab/translation';
 
 /**
  * Diagnostic which is localized at a specific editor (cell) within a notebook
@@ -111,7 +112,7 @@ function SortableTH(props: {
       className={is_sort_key ? 'lsp-sorted-header' : null}
     >
       <div>
-        <label>{props.name}</label>
+        <label>{trans.__(props.name)}</label>
         <sortIcon.react tag="span" className="lsp-sort-icon" />
       </div>
     </th>
@@ -223,7 +224,7 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
     const editor = this.model.virtual_editor;
     const adapter = this.model.adapter;
     if (!diagnostics_db || editor == null) {
-      return <div>No issues detected, great job!</div>;
+      return <div>{trans.__('No issues detected, great job!')}</div>;
     }
 
     let by_document = Array.from(diagnostics_db).map(
@@ -314,6 +315,8 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
   }
 }
 
+let trans: TranslationBundle;
+
 export namespace DiagnosticsListing {
   /**
    * A VDomModel for the LSP of current file editor/notebook.
@@ -325,8 +328,9 @@ export namespace DiagnosticsListing {
     settings: FeatureSettings<LSPDiagnosticsSettings>;
     status_message: StatusMessage;
 
-    constructor() {
+    constructor(translator_bundle: TranslationBundle) {
       super();
+      trans = translator_bundle;
     }
   }
 }

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -169,7 +169,9 @@ export class DiagnosticsListing extends VDomRenderer<DiagnosticsListing.Model> {
       name: 'Severity',
       // TODO: use default diagnostic severity
       render_cell: row => (
-        <td key={3}>{trans.__(DiagnosticSeverity[row.data.diagnostic.severity || 1])}</td>
+        <td key={3}>
+          {trans.__(DiagnosticSeverity[row.data.diagnostic.severity || 1])}
+        </td>
       ),
       sort: (a, b) =>
         a.data.diagnostic.severity > b.data.diagnostic.severity ? 1 : -1

--- a/packages/jupyterlab-lsp/src/features/highlights.ts
+++ b/packages/jupyterlab-lsp/src/features/highlights.ts
@@ -17,6 +17,7 @@ import highlightTypeSvg from '../../style/icons/highlight-type.svg';
 import { Debouncer } from '@lumino/polling';
 import { CodeHighlights as LSPHighlightsSettings } from '../_highlights';
 import { CodeEditor } from '@jupyterlab/codeeditor';
+import { ITranslator, TranslationBundle } from '@jupyterlab/translation';
 
 export const highlightIcon = new LabIcon({
   name: 'lsp:highlight',
@@ -28,13 +29,13 @@ export const highlightTypeIcon = new LabIcon({
   svgstr: highlightTypeSvg
 });
 
-const COMMANDS: IFeatureCommand[] = [
+const COMMANDS = (trans: TranslationBundle): IFeatureCommand[] => [
   {
     id: 'highlight-references',
     execute: ({ connection, virtual_position, document }) =>
       connection.getReferences(virtual_position, document.document_info),
     is_enabled: ({ connection }) => connection.isReferencesSupported(),
-    label: 'Highlight references',
+    label: trans.__('Highlight references'),
     icon: highlightIcon
   },
   {
@@ -42,7 +43,7 @@ const COMMANDS: IFeatureCommand[] = [
     execute: ({ connection, virtual_position, document }) =>
       connection.getTypeDefinition(virtual_position, document.document_info),
     is_enabled: ({ connection }) => connection.isTypeDefinitionSupported(),
-    label: 'Highlight type definition',
+    label: trans.__('Highlight type definition'),
     icon: highlightTypeIcon
   }
 ];
@@ -235,14 +236,16 @@ const FEATURE_ID = PLUGIN_ID + ':highlights';
 
 export const HIGHLIGHTS_PLUGIN: JupyterFrontEndPlugin<void> = {
   id: FEATURE_ID,
-  requires: [ILSPFeatureManager, ISettingRegistry],
+  requires: [ILSPFeatureManager, ISettingRegistry, ITranslator],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     featureManager: ILSPFeatureManager,
-    settingRegistry: ISettingRegistry
+    settingRegistry: ISettingRegistry,
+    translator: ITranslator
   ) => {
     const settings = new FeatureSettings(settingRegistry, FEATURE_ID);
+    const trans = translator.load('jupyterlab-lsp');
 
     featureManager.register({
       feature: {
@@ -250,7 +253,7 @@ export const HIGHLIGHTS_PLUGIN: JupyterFrontEndPlugin<void> = {
         id: FEATURE_ID,
         name: 'LSP Highlights',
         settings: settings,
-        commands: COMMANDS
+        commands: COMMANDS(trans)
       }
     });
   }

--- a/packages/jupyterlab-lsp/src/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.ts
@@ -104,8 +104,7 @@ const COMMANDS = (trans: TranslationBundle): IFeatureCommand[] => [
 ];
 
 export class RenameCM extends CodeMirrorIntegration {
-  
-  public setTrans(trans: TranslationBundle){
+  public setTrans(trans: TranslationBundle) {
     this.trans = trans;
   }
 

--- a/packages/jupyterlab-lsp/src/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.ts
@@ -40,7 +40,8 @@ const COMMANDS = (trans: TranslationBundle): IFeatureCommand[] => [
       features
     }) => {
       const rename_feature = features.get(FEATURE_ID) as RenameCM;
-      rename_feature.trans = trans;
+      rename_feature.setTrans(trans);
+
       let root_position = rename_feature.transform_virtual_position_to_root_position(
         virtual_position
       );
@@ -103,7 +104,11 @@ const COMMANDS = (trans: TranslationBundle): IFeatureCommand[] => [
 ];
 
 export class RenameCM extends CodeMirrorIntegration {
-  trans: TranslationBundle;
+  
+  public setTrans(trans: TranslationBundle){
+    this.trans = trans;
+  }
+
   public setStatus(message: string, timeout: number) {
     return this.status_message.set(message, timeout);
   }
@@ -124,7 +129,6 @@ export class RenameCM extends CodeMirrorIntegration {
 
     try {
       let status: string;
-      let is_plural: boolean;
       const change_text = this.trans.__('%1 to %2', old_value, new_value);
 
       if (outcome.appliedChanges === 0) {
@@ -133,16 +137,18 @@ export class RenameCM extends CodeMirrorIntegration {
           change_text
         );
       } else if (outcome.wasGranular) {
-        is_plural = outcome.appliedChanges > 1;
-        status = this.trans.__(
-          `Renamed %1 in %2 place${is_plural ? 's' : ''}`,
+        status = this.trans._n(
+          'Renamed %2 in %3 place',
+          'Renamed %2 in %3 places',
+          outcome.appliedChanges,
           change_text,
           outcome.appliedChanges
         );
       } else if (this.adapter.has_multiple_editors) {
-        is_plural = outcome.modifiedCells > 1;
-        status = this.trans.__(
-          `Renamed %1 in %2 cell${is_plural ? 's' : ''}`,
+        status = this.trans._n(
+          'Renamed %2 in %3 cell',
+          'Renamed %2 in %3 cells',
+          outcome.modifiedCells,
           change_text,
           outcome.modifiedCells
         );

--- a/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
+++ b/packages/jupyterlab-lsp/src/features/syntax_highlighting.ts
@@ -19,6 +19,7 @@ import { IEditorMimeTypeService } from '@jupyterlab/codeeditor';
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { CodeSyntax as LSPSyntaxHighlightingSettings } from '../_syntax_highlighting';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { ITranslator } from '@jupyterlab/translation';
 
 export const syntaxHighlightingIcon = new LabIcon({
   name: 'lsp:syntax-highlighting',
@@ -116,15 +117,22 @@ class SyntaxLabIntegration implements IFeatureLabIntegration {
 
 export const SYNTAX_HIGHLIGHTING_PLUGIN: JupyterFrontEndPlugin<void> = {
   id: FEATURE_ID,
-  requires: [ILSPFeatureManager, IEditorServices, ISettingRegistry],
+  requires: [
+    ILSPFeatureManager,
+    IEditorServices,
+    ISettingRegistry,
+    ITranslator
+  ],
   autoStart: true,
   activate: (
     app: JupyterFrontEnd,
     featureManager: ILSPFeatureManager,
     editorServices: IEditorServices,
-    settingRegistry: ISettingRegistry
+    settingRegistry: ISettingRegistry,
+    translator: ITranslator
   ) => {
     const settings = new FeatureSettings(settingRegistry, FEATURE_ID);
+    const trans = translator.load('jupyterlab-lsp');
 
     featureManager.register({
       feature: {
@@ -133,7 +141,7 @@ export const SYNTAX_HIGHLIGHTING_PLUGIN: JupyterFrontEndPlugin<void> = {
         ]),
         commands: [],
         id: FEATURE_ID,
-        name: 'Syntax highlighting',
+        name: trans.__('Syntax highlighting'),
         labIntegration: new SyntaxLabIntegration(
           editorServices.mimeTypeService
         ),

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -47,6 +47,7 @@ import { SYNTAX_HIGHLIGHTING_PLUGIN } from './features/syntax_highlighting';
 import { COMPLETION_THEME_MANAGER } from '@krassowski/completion-theme';
 import { plugin as THEME_VSCODE } from '@krassowski/theme-vscode';
 import { plugin as THEME_MATERIAL } from '@krassowski/theme-material';
+import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 import { CODE_OVERRIDES_MANAGER } from './overrides';
 import IPaths = JupyterFrontEnd.IPaths;
 import { LOG_CONSOLE } from './virtual/console';
@@ -113,6 +114,7 @@ export interface ILSPExtension {
   foreign_code_extractors: IForeignCodeExtractorsRegistry;
   code_overrides: ICodeOverridesRegistry;
   console: ILSPLogConsole;
+  translator: ITranslator;
 }
 
 export class LSPExtension implements ILSPExtension {
@@ -131,8 +133,10 @@ export class LSPExtension implements ILSPExtension {
     private code_extractors_manager: ILSPCodeExtractorsManager,
     private code_overrides_manager: ILSPCodeOverridesManager,
     public console: ILSPLogConsole,
+    public translator: ITranslator,
     status_bar: IStatusBar | null
   ) {
+    const trans = (translator || nullTranslator).load('jupyterlab-lsp');
     this.language_server_manager = new LanguageServerManager({});
     this.connection_manager = new DocumentConnectionManager({
       language_server_manager: this.language_server_manager,
@@ -142,7 +146,8 @@ export class LSPExtension implements ILSPExtension {
     const statusButtonExtension = new StatusButtonExtension({
       language_server_manager: this.language_server_manager,
       connection_manager: this.connection_manager,
-      adapter_manager: adapterManager
+      adapter_manager: adapterManager,
+      translator_bundle: trans
     });
 
     if (status_bar !== null) {
@@ -225,7 +230,8 @@ const plugin: JupyterFrontEndPlugin<ILSPFeatureManager> = {
     ILSPVirtualEditorManager,
     ILSPCodeExtractorsManager,
     ILSPCodeOverridesManager,
-    ILSPLogConsole
+    ILSPLogConsole,
+    ITranslator
   ],
   optional: [IStatusBar],
   activate: (app, ...args) => {
@@ -241,6 +247,7 @@ const plugin: JupyterFrontEndPlugin<ILSPFeatureManager> = {
         ILSPCodeExtractorsManager,
         ILSPCodeOverridesManager,
         ILSPLogConsole,
+        ITranslator,
         IStatusBar | null
       ])
     );


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
any text displayed on the UI is made localizable using the TranslationBundle and ITranslator from @jupyterlab/translation

## User-facing changes
User will be able to use jupyterlab-lsp extension in prefered language given that the language pack is installed.

Can also be viewed by using the language settings to enable string prefix for all localized strings:
![image](https://user-images.githubusercontent.com/71149531/111570506-65962d00-877b-11eb-973a-5161c2e94989.png)

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
