### PR TITLE
Fix regular-expression based extractors offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@
 
   - prevents throwing a highlights error when adding new cell with <kbd>Shift</kbd> + <kbd>Enter</kbd> ([#544])
   - fixes IPython `pinfo` and `pinfo2` (`?` and `??`) for identifiers containing `s` ([#547])
+  - fixes incorrect behaviour of LSP features in some IPython magics with single line of content ([#560])
 
 [#544]: https://github.com/krassowski/jupyterlab-lsp/pull/544
 [#547]: https://github.com/krassowski/jupyterlab-lsp/pull/547
 [#553]: https://github.com/krassowski/jupyterlab-lsp/pull/553
+[#560]: https://github.com/krassowski/jupyterlab-lsp/pull/560
 
 ### `jupyter-lsp 1.1.4` (2020-02-21)
 

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -296,6 +296,28 @@ Shows Documentation With CompletionItem Resolve
     Completer Should Include Documentation    the default method of the
     [Teardown]    Clean Up After Working With File    completion.R
 
+Shows Only Relevant Suggestions In Known Magics
+    # https://github.com/krassowski/jupyterlab-lsp/issues/559
+    # h<tab>
+    Enter Cell Editor    20    line=2
+    Trigger Completer
+    Completer Should Suggest    help
+    Completer Should Not Suggest  from
+    Completer Should Suggest    hash
+
+Completes In R Magics
+    # Proper completion in R magics needs to be tested as:
+    # - R magic extractor uses a tailor-made replacer function, not tested elsewhere
+    # - R lanugage server is very sensitive to off-by-one errors (see https://github.com/REditorSupport/languageserver/issues/395)
+    # '%%R\n librar<tab>'
+    Enter Cell Editor    22    line=2
+    Trigger Completer
+    Completer Should Suggest    library
+    # '%R lib<tab>'
+    Enter Cell Editor    24    line=1
+    Trigger Completer
+    Completer Should Suggest    library
+
 *** Keywords ***
 Setup Completion Test
     Setup Notebook    Python    Completion.ipynb

--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -302,7 +302,7 @@ Shows Only Relevant Suggestions In Known Magics
     Enter Cell Editor    20    line=2
     Trigger Completer
     Completer Should Suggest    help
-    Completer Should Not Suggest  from
+    Completer Should Not Suggest    from
     Completer Should Suggest    hash
 
 Completes In R Magics

--- a/atest/examples/Completion.ipynb
+++ b/atest/examples/Completion.ipynb
@@ -150,6 +150,56 @@
    "source": [
     "t"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cell magics show only relevant suggestions (triggering after `h` should return `hash`, `help`, etc, but not `from`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%python\n",
+    "h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test that the leading space does not cause issues in R cell magic:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%R\n",
+    " librar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And that R line magic works too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%R li"
+   ]
   }
  ],
  "metadata": {

--- a/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
-import { RegExpForeignCodeExtractor } from './regexp';
+import { getIndexOfCaptureGroup, RegExpForeignCodeExtractor } from './regexp';
 
 let R_CELL_MAGIC_EXISTS = `%%R
 some text
 `;
+
+let PYTHON_CELL_MAGIC_WITH_H = `%%python
+h`;
 
 let NO_CELL_MAGIC = `%R
 some text
@@ -23,11 +26,24 @@ x = """<a href="#">
 </a>""";
 print(x)`;
 
+
+describe('getIndexOfCaptureGroup', () => {
+  it('extracts index of a captured group', () => {
+    // tests for https://github.com/krassowski/jupyterlab-lsp/issues/559
+    let result = getIndexOfCaptureGroup(
+      new RegExp('^%%(python|python2|python3|pypy)( .*?)?\n([^]*)'),
+      '%%python\nh',
+      'h'
+    );
+    expect(result).to.be.equal(9);
+  });
+});
+
 describe('RegExpForeignCodeExtractor', () => {
   let r_cell_extractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '^%%R( .*?)?\n([^]*)',
-    extract_to_foreign: '$2',
+    foreign_capture_group: 2,
     keep_in_host: true,
     is_standalone: false,
     file_extension: 'R'
@@ -36,10 +52,19 @@ describe('RegExpForeignCodeExtractor', () => {
   let r_line_extractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '(^|\n)%R (.*)\n?',
-    extract_to_foreign: '$2',
+    foreign_capture_group: 2,
     keep_in_host: true,
     is_standalone: false,
     file_extension: 'R'
+  });
+
+  let python_cell_extractor = new RegExpForeignCodeExtractor({
+    language: 'python',
+    pattern: '^%%(python|python2|python3|pypy)( .*?)?\n([^]*)',
+    foreign_capture_group: 3,
+    keep_in_host: true,
+    is_standalone: true,
+    file_extension: 'py'
   });
 
   describe('#has_foreign_code()', () => {
@@ -75,16 +100,35 @@ describe('RegExpForeignCodeExtractor', () => {
   });
 
   describe('#extract_foreign_code()', () => {
+
+    it('should correctly return the range', () => {
+      let results = python_cell_extractor.extract_foreign_code(PYTHON_CELL_MAGIC_WITH_H);
+      expect(results.length).to.equal(1);
+
+      let result = results[0];
+
+      // test against https://github.com/krassowski/jupyterlab-lsp/issues/559
+      expect(result.host_code).to.equal(PYTHON_CELL_MAGIC_WITH_H);
+      expect(result.foreign_code).to.equal(
+        'h'
+      );
+
+      expect(result.range.start.line).to.equal(1);
+      expect(result.range.start.column).to.equal(0);
+      expect(result.range.end.line).to.equal(1);
+      expect(result.range.end.column).to.equal(1);
+    });
+
     it('should work with non-line magic and non-cell magic code snippets as well', () => {
       // Note: in the real application, one should NOT use regular expressions for HTML extraction
 
       let html_extractor = new RegExpForeignCodeExtractor({
         language: 'HTML',
-        pattern: '<(.*?)( .*?)?>([^]*?)</\\1>',
-        extract_to_foreign: '<$1$2>$3</$1>',
+        pattern: '(<(.*?)( .*?)?>([^]*?)</\\2>)',
+        foreign_capture_group: 1,
         keep_in_host: false,
         is_standalone: false,
-        file_extension: 'R'
+        file_extension: 'html'
       });
 
       let results = html_extractor.extract_foreign_code(HTML_IN_PYTHON);
@@ -118,7 +162,7 @@ describe('RegExpForeignCodeExtractor', () => {
       let extractor = new RegExpForeignCodeExtractor({
         language: 'R',
         pattern: '^%%R( .*?)?\n([^]*)',
-        extract_to_foreign: '$2',
+        foreign_capture_group: 2,
         keep_in_host: false,
         is_standalone: false,
         file_extension: 'R'
@@ -136,7 +180,7 @@ describe('RegExpForeignCodeExtractor', () => {
       let r_line_extractor = new RegExpForeignCodeExtractor({
         language: 'R',
         pattern: '(^|\n)%R (.*)\n?',
-        extract_to_foreign: '$2',
+        foreign_capture_group: 2,
         keep_in_host: false,
         is_standalone: false,
         file_extension: 'R'

--- a/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
@@ -42,7 +42,7 @@ describe('RegExpForeignCodeExtractor', () => {
   let r_cell_extractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '^%%R( .*?)?\n([^]*)',
-    foreign_capture_group: 2,
+    foreign_capture_groups: [2],
     keep_in_host: true,
     is_standalone: false,
     file_extension: 'R'
@@ -51,7 +51,7 @@ describe('RegExpForeignCodeExtractor', () => {
   let r_line_extractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '(^|\n)%R (.*)\n?',
-    foreign_capture_group: 2,
+    foreign_capture_groups: [2],
     keep_in_host: true,
     is_standalone: false,
     file_extension: 'R'
@@ -60,7 +60,7 @@ describe('RegExpForeignCodeExtractor', () => {
   let python_cell_extractor = new RegExpForeignCodeExtractor({
     language: 'python',
     pattern: '^%%(python|python2|python3|pypy)( .*?)?\n([^]*)',
-    foreign_capture_group: 3,
+    foreign_capture_groups: [3],
     keep_in_host: true,
     is_standalone: true,
     file_extension: 'py'
@@ -123,7 +123,7 @@ describe('RegExpForeignCodeExtractor', () => {
       let html_extractor = new RegExpForeignCodeExtractor({
         language: 'HTML',
         pattern: '(<(.*?)( .*?)?>([^]*?)</\\2>)',
-        foreign_capture_group: 1,
+        foreign_capture_groups: [1],
         keep_in_host: false,
         is_standalone: false,
         file_extension: 'html'
@@ -160,7 +160,7 @@ describe('RegExpForeignCodeExtractor', () => {
       let extractor = new RegExpForeignCodeExtractor({
         language: 'R',
         pattern: '^%%R( .*?)?\n([^]*)',
-        foreign_capture_group: 2,
+        foreign_capture_groups: [2],
         keep_in_host: false,
         is_standalone: false,
         file_extension: 'R'
@@ -178,7 +178,7 @@ describe('RegExpForeignCodeExtractor', () => {
       let r_line_extractor = new RegExpForeignCodeExtractor({
         language: 'R',
         pattern: '(^|\n)%R (.*)\n?',
-        foreign_capture_group: 2,
+        foreign_capture_groups: [2],
         keep_in_host: false,
         is_standalone: false,
         file_extension: 'R'

--- a/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
@@ -26,7 +26,6 @@ x = """<a href="#">
 </a>""";
 print(x)`;
 
-
 describe('getIndexOfCaptureGroup', () => {
   it('extracts index of a captured group', () => {
     // tests for https://github.com/krassowski/jupyterlab-lsp/issues/559
@@ -100,18 +99,17 @@ describe('RegExpForeignCodeExtractor', () => {
   });
 
   describe('#extract_foreign_code()', () => {
-
     it('should correctly return the range', () => {
-      let results = python_cell_extractor.extract_foreign_code(PYTHON_CELL_MAGIC_WITH_H);
+      let results = python_cell_extractor.extract_foreign_code(
+        PYTHON_CELL_MAGIC_WITH_H
+      );
       expect(results.length).to.equal(1);
 
       let result = results[0];
 
       // test against https://github.com/krassowski/jupyterlab-lsp/issues/559
       expect(result.host_code).to.equal(PYTHON_CELL_MAGIC_WITH_H);
-      expect(result.foreign_code).to.equal(
-        'h'
-      );
+      expect(result.foreign_code).to.equal('h');
 
       expect(result.range.start.line).to.equal(1);
       expect(result.range.start.column).to.equal(0);

--- a/packages/jupyterlab-lsp/src/extractors/regexp.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.ts
@@ -3,8 +3,11 @@ import { position_at_offset } from '../positioning';
 import { replacer } from '../overrides/tokens';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
-
-export function getIndexOfCaptureGroup(expression: RegExp, matched_string: string, value_of_captured_group: string): number {
+export function getIndexOfCaptureGroup(
+  expression: RegExp,
+  matched_string: string,
+  value_of_captured_group: string
+): number {
   // TODO: use https://github.com/tc39/proposal-regexp-match-indices once supported in >95% of browsers
   //  (probably around 2025)
 
@@ -16,7 +19,6 @@ export function getIndexOfCaptureGroup(expression: RegExp, matched_string: strin
   let full_matched = captured_groups[0];
 
   for (let group of captured_groups.slice(1)) {
-
     if (typeof group === 'undefined') {
       continue;
     }
@@ -69,8 +71,14 @@ export class RegExpForeignCodeExtractor implements IForeignCodeExtractor {
     let match: RegExpExecArray = this.global_expression.exec(code);
     let host_code_fragment: string;
 
-    let new_api_replacer = typeof this.options.foreign_replacer !== 'undefined' ? this.options.foreign_replacer : ('$' + this.options.foreign_capture_group);
-    const replacer = typeof this.options.extract_to_foreign !== 'undefined' ? this.options.extract_to_foreign : new_api_replacer;
+    let new_api_replacer =
+      typeof this.options.foreign_replacer !== 'undefined'
+        ? this.options.foreign_replacer
+        : '$' + this.options.foreign_capture_group;
+    const replacer =
+      typeof this.options.extract_to_foreign !== 'undefined'
+        ? this.options.extract_to_foreign
+        : new_api_replacer;
 
     while (match != null) {
       let matched_string = match[0];
@@ -118,11 +126,12 @@ export class RegExpForeignCodeExtractor implements IForeignCodeExtractor {
       }
 
       const foreign_group_index_in_match = getIndexOfCaptureGroup(
-          this.expression, matched_string, foreign_code_group_value
+        this.expression,
+        matched_string,
+        foreign_code_group_value
       );
 
-      let start_offset =
-        match.index + foreign_group_index_in_match;
+      let start_offset = match.index + foreign_group_index_in_match;
 
       let start = position_at_offset(start_offset, lines);
       let end = position_at_offset(

--- a/packages/jupyterlab-lsp/src/extractors/testutils.ts
+++ b/packages/jupyterlab-lsp/src/extractors/testutils.ts
@@ -12,9 +12,14 @@ export function extract_code(document: VirtualDocument, code: string) {
   );
 }
 
+interface IDocumentWithRange {
+  range: CodeEditor.IRange;
+  virtual_document: VirtualDocument;
+}
+
 export function get_the_only_pair(
   foreign_document_map: Map<CodeEditor.IRange, IVirtualDocumentBlock>
-) {
+): IDocumentWithRange {
   expect(foreign_document_map.size).to.equal(1);
 
   let range = foreign_document_map.keys().next().value;

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
@@ -26,8 +26,8 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
   python: [
     new RegExpForeignCodeExtractor({
       language: 'sql',
-      pattern: `^%%bigquery(?: (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(?:\\w+ << )|(?:\\w+@\\w+)))?\n?(.+\n)?([^]*)`,
-      extract_to_foreign: '$1$2',
+      pattern: `^%%bigquery(?: (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(?:\\w+ << )|(?:\\w+@\\w+)))?\n?((?:.+\n)?(?:[^]*))`,
+      foreign_capture_group: 1,
       is_standalone: true,
       file_extension: 'sql'
     })

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
@@ -27,7 +27,7 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'sql',
       pattern: `^%%bigquery(?: (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(?:\\w+ << )|(?:\\w+@\\w+)))?\n?((?:.+\n)?(?:[^]*))`,
-      foreign_capture_group: 1,
+      foreign_capture_groups: [1],
       is_standalone: true,
       file_extension: 'sql'
     })

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
@@ -126,7 +126,6 @@ describe('IPython rpy2 extractors', () => {
     let { foreign_document_map } = extract(code);
     let { range } = get_the_only_pair(foreign_document_map);
     expect(range.start.line).to.be.equal(1);
-    // note: the space before ggplot() is included in the range
     expect(range.start.column).to.be.equal(0);
 
     expect(range.end.line).to.be.equal(1);

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
@@ -32,6 +32,29 @@ describe('IPython rpy2 extractors', () => {
   });
 
   describe('%R line magic', () => {
+    it('correctly gives ranges in source', () => {
+      let code = '%R ggplot()';
+      let { foreign_document_map } = extract(code);
+      let { range } = get_the_only_pair(foreign_document_map);
+      expect(range.start.line).to.be.equal(0);
+      // note: the space before ggplot() should NOT be included in the range
+      expect(range.start.column).to.be.equal(3);
+
+      expect(range.end.line).to.be.equal(0);
+      expect(range.end.column).to.be.equal(3 + 8);
+    });
+
+    it('correctly gives ranges in source when wrapped in lines', () => {
+      let code = wrap_in_python_lines('%R ggplot()');
+      let { foreign_document_map } = extract(code);
+      let { range } = get_the_only_pair(foreign_document_map);
+      expect(range.start.line).to.be.equal(1);
+      expect(range.start.column).to.be.equal(3);
+
+      expect(range.end.line).to.be.equal(1);
+      expect(range.end.column).to.be.equal(3 + 8);
+    });
+
     it('extracts simple commands', () => {
       let code = wrap_in_python_lines('%R ggplot()');
       let { cell_code_kept, foreign_document_map } = extract(code);
@@ -96,5 +119,17 @@ describe('IPython rpy2 extractors', () => {
     let r_document = get_the_only_virtual(foreign_document_map);
     expect(r_document.language).to.equal('r');
     expect(r_document.value).to.equal('df <- data.frame(); ggplot(df)\n');
+  });
+
+  it('correctly gives ranges in source', () => {
+    let code = '%%R\nggplot()';
+    let { foreign_document_map } = extract(code);
+    let { range } = get_the_only_pair(foreign_document_map);
+    expect(range.start.line).to.be.equal(1);
+    // note: the space before ggplot() is included in the range
+    expect(range.start.column).to.be.equal(0);
+
+    expect(range.end.line).to.be.equal(1);
+    expect(range.end.column).to.be.equal(8);
   });
 });

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
@@ -3,7 +3,6 @@ import { RegExpForeignCodeExtractor } from '../../extractors/regexp';
 import { extract_r_args, rpy2_args_pattern, RPY2_MAX_ARGS } from './rpy2';
 
 function create_rpy_code_extractor(strip_leading_space: boolean) {
-
   function rpy2_code_extractor(match: string, ...args: string[]) {
     let r = extract_r_args(args, -3);
     let code: string;
@@ -17,7 +16,7 @@ function create_rpy_code_extractor(strip_leading_space: boolean) {
     return code;
   }
 
-  return rpy2_code_extractor
+  return rpy2_code_extractor;
 }
 
 let rpy2_code_extractor_non_stripping = create_rpy_code_extractor(false);

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
@@ -2,22 +2,31 @@ import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 import { RegExpForeignCodeExtractor } from '../../extractors/regexp';
 import { extract_r_args, rpy2_args_pattern, RPY2_MAX_ARGS } from './rpy2';
 
-function rpy2_code_extractor(match: string, ...args: string[]) {
-  let r = extract_r_args(args, -3);
-  let code: string;
-  if (r.rest == null) {
-    code = '';
-  } else {
-    code = r.rest.startsWith(' ') ? r.rest.slice(1) : r.rest;
+function create_rpy_code_extractor(strip_leading_space: boolean) {
+
+  function rpy2_code_extractor(match: string, ...args: string[]) {
+    let r = extract_r_args(args, -3);
+    let code: string;
+    if (r.rest == null) {
+      code = '';
+    } else if (strip_leading_space) {
+      code = r.rest.startsWith(' ') ? r.rest.slice(1) : r.rest;
+    } else {
+      code = r.rest;
+    }
+    return code;
   }
-  return code;
+
+  return rpy2_code_extractor
 }
+
+let rpy2_code_extractor_non_stripping = create_rpy_code_extractor(false);
 
 function rpy2_args(match: string, ...args: string[]) {
   let r = extract_r_args(args, -3);
   // define dummy input variables using empty data frames
   let inputs = r.inputs.map(i => i + ' <- data.frame();').join(' ');
-  let code = rpy2_code_extractor(match, ...args);
+  let code = rpy2_code_extractor_non_stripping(match, ...args);
   if (inputs !== '' && code) {
     inputs += ' ';
   }
@@ -33,15 +42,20 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'r',
       pattern: '^%%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '\n([^]*)',
-      extract_to_foreign: rpy2_code_extractor,
+      foreign_capture_group: RPY2_MAX_ARGS * 2 + 1,
+      // it is important to not strip any leading spaces
+      foreign_replacer: rpy2_code_extractor_non_stripping,
       extract_arguments: rpy2_args,
       is_standalone: false,
       file_extension: 'R'
     }),
     new RegExpForeignCodeExtractor({
       language: 'r',
-      pattern: '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '( .*)?\n?',
-      extract_to_foreign: rpy2_code_extractor,
+      // it is very important to not include the space which will be trimmed in the capture group,
+      // otherwise the offset will be off by one and the R language server will crash
+      pattern: '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + ' ?(.*)?\n?',
+      foreign_capture_group: RPY2_MAX_ARGS * 2 + 1,
+      foreign_replacer: create_rpy_code_extractor(true),
       extract_arguments: rpy2_args,
       is_standalone: false,
       file_extension: 'R'

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
@@ -41,7 +41,7 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'r',
       pattern: '^%%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '\n([^]*)',
-      foreign_capture_group: RPY2_MAX_ARGS * 2 + 1,
+      foreign_capture_groups: [RPY2_MAX_ARGS * 2 + 1],
       // it is important to not strip any leading spaces
       foreign_replacer: rpy2_code_extractor_non_stripping,
       extract_arguments: rpy2_args,
@@ -53,7 +53,7 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
       // it is very important to not include the space which will be trimmed in the capture group,
       // otherwise the offset will be off by one and the R language server will crash
       pattern: '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + ' ?(.*)?\n?',
-      foreign_capture_group: RPY2_MAX_ARGS * 2 + 1,
+      foreign_capture_groups: [RPY2_MAX_ARGS * 2 + 1],
       foreign_replacer: create_rpy_code_extractor(true),
       extract_arguments: rpy2_args,
       is_standalone: false,

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
@@ -27,14 +27,14 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'sql',
       pattern: `^%%sql(?: (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(?:\\w+ << )|(?:\\w+@\\w+)))?\n?((?:.+\n)?(?:[^]*))`,
-      foreign_capture_group: 1,
+      foreign_capture_groups: [1],
       is_standalone: true,
       file_extension: 'sql'
     }),
     new RegExpForeignCodeExtractor({
       language: 'sql',
       pattern: `(?:^|\n)%sql (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(.*))\n?`,
-      foreign_capture_group: 1,
+      foreign_capture_groups: [1],
       is_standalone: false,
       file_extension: 'sql'
     })

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
@@ -26,15 +26,15 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
   python: [
     new RegExpForeignCodeExtractor({
       language: 'sql',
-      pattern: `^%%sql(?: (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(?:\\w+ << )|(?:\\w+@\\w+)))?\n?(.+\n)?([^]*)`,
-      extract_to_foreign: '$1$2',
+      pattern: `^%%sql(?: (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(?:\\w+ << )|(?:\\w+@\\w+)))?\n?((?:.+\n)?(?:[^]*))`,
+      foreign_capture_group: 1,
       is_standalone: true,
       file_extension: 'sql'
     }),
     new RegExpForeignCodeExtractor({
       language: 'sql',
       pattern: `(?:^|\n)%sql (?:${SQL_URL_PATTERN}|${COMMAND_PATTERN}|(.*))\n?`,
-      extract_to_foreign: '$1',
+      foreign_capture_group: 1,
       is_standalone: false,
       file_extension: 'sql'
     })

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.ts
@@ -11,35 +11,35 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'python',
       pattern: '^%%(python|python2|python3|pypy)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: true,
       file_extension: 'py'
     }),
     new RegExpForeignCodeExtractor({
       language: 'perl',
       pattern: '^%%(perl)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: true,
       file_extension: 'pl'
     }),
     new RegExpForeignCodeExtractor({
       language: 'ruby',
       pattern: '^%%(ruby)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: true,
       file_extension: 'rb'
     }),
     new RegExpForeignCodeExtractor({
       language: 'sh',
       pattern: '^%%(sh|bash)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: true,
       file_extension: 'sh'
     }),
     new RegExpForeignCodeExtractor({
       language: 'html',
       pattern: '^%%(html --isolated)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: true,
       file_extension: 'html'
     }),
@@ -49,28 +49,28 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'javascript',
       pattern: '^%%(js|javascript)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: false,
       file_extension: 'js'
     }),
     new RegExpForeignCodeExtractor({
       language: 'html',
       pattern: '^%%(?!html --isolated)(html)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: false,
       file_extension: 'html'
     }),
     new RegExpForeignCodeExtractor({
       language: 'latex',
       pattern: '^%%(latex)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: false,
       file_extension: 'tex'
     }),
     new RegExpForeignCodeExtractor({
       language: 'markdown',
       pattern: '^%%(markdown)( .*?)?\n([^]*)',
-      foreign_capture_group: 3,
+      foreign_capture_groups: [3],
       is_standalone: false,
       file_extension: 'md'
     })

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.ts
@@ -11,35 +11,35 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'python',
       pattern: '^%%(python|python2|python3|pypy)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: true,
       file_extension: 'py'
     }),
     new RegExpForeignCodeExtractor({
       language: 'perl',
       pattern: '^%%(perl)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: true,
       file_extension: 'pl'
     }),
     new RegExpForeignCodeExtractor({
       language: 'ruby',
       pattern: '^%%(ruby)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: true,
       file_extension: 'rb'
     }),
     new RegExpForeignCodeExtractor({
       language: 'sh',
       pattern: '^%%(sh|bash)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: true,
       file_extension: 'sh'
     }),
     new RegExpForeignCodeExtractor({
       language: 'html',
       pattern: '^%%(html --isolated)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: true,
       file_extension: 'html'
     }),
@@ -49,28 +49,28 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
     new RegExpForeignCodeExtractor({
       language: 'javascript',
       pattern: '^%%(js|javascript)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: false,
       file_extension: 'js'
     }),
     new RegExpForeignCodeExtractor({
       language: 'html',
       pattern: '^%%(?!html --isolated)(html)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: false,
       file_extension: 'html'
     }),
     new RegExpForeignCodeExtractor({
       language: 'latex',
       pattern: '^%%(latex)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: false,
       file_extension: 'tex'
     }),
     new RegExpForeignCodeExtractor({
       language: 'markdown',
       pattern: '^%%(markdown)( .*?)?\n([^]*)',
-      extract_to_foreign: '$3',
+      foreign_capture_group: 3,
       is_standalone: false,
       file_extension: 'md'
     })

--- a/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
@@ -17,7 +17,7 @@ describe('VirtualEditor', () => {
   let r_line_extractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '(^|\n)%R (.*)\n?',
-    foreign_capture_group: 2,
+    foreign_capture_groups: [2],
     is_standalone: false,
     file_extension: 'R'
   });

--- a/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
@@ -17,7 +17,7 @@ describe('VirtualEditor', () => {
   let r_line_extractor = new RegExpForeignCodeExtractor({
     language: 'R',
     pattern: '(^|\n)%R (.*)\n?',
-    extract_to_foreign: '$2',
+    foreign_capture_group: 2,
     is_standalone: false,
     file_extension: 'R'
   });


### PR DESCRIPTION
## References

Fixes #559

## Code changes

- splits `RegExpForeignCodeExtractor`'s `extract_to_foreign` into `foreign_capture_groups` and `foreign_replacer` (in a backward compatible way, with a deprecation notice for 4.0)
- corrects computation of offset (and thus ranges) for extracted documents by relying on `foreign_capture_groups` to determine start index; the old way was ok-ish for some extractors, but not a good general solution

## User-facing changes

Completion and other features will work more consistently in cell magics and line magics (and other extractors).

## Backwards-incompatible changes

None, but deprecation notices added for `RegExpForeignCodeExtractor.extract_to_foreign` and `RegExpForeignCodeExtractor.keep_in_host`.

## Chores

- [x] linted
- [x] tested
- [x] documented
- [x] changelog entry
