### PR TITLE
Change jupyterlab_lsp > jupyterlab-lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+### `@krassowski/jupyterlab-lsp 3.5.1` (unreleased)
+
+- bug fixes:
+
+  - fixes name of jupyterlab-lsp package displayed in JupyterLab UI ([#570])
+
+[#570]: https://github.com/krassowski/jupyterlab-lsp/pull/570
+
 ### `@krassowski/jupyterlab-lsp 3.5.0` (2020-03-22)
 
 - features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - prevents throwing a highlights error when adding new cell with <kbd>Shift</kbd> + <kbd>Enter</kbd> ([#544])
   - fixes IPython `pinfo` and `pinfo2` (`?` and `??`) for identifiers containing `s` ([#547])
   - fixes incorrect behaviour of LSP features in some IPython magics with single line of content ([#560])
+  - fixes name of jupyterlab-lsp package in JupyterLab
 
 - for extension authors:
 

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -131,7 +131,7 @@
     "discovery": {
       "server": {
         "base": {
-          "name": "jupyterlab_lsp"
+          "name": "jupyterlab-lsp"
         },
         "managers": [
           "pip",

--- a/python_packages/jupyterlab_lsp/jupyterlab_lsp/install.json
+++ b/python_packages/jupyterlab_lsp/jupyterlab_lsp/install.json
@@ -1,5 +1,5 @@
 {
   "packageManager": "python",
-  "packageName": "jupyterlab_lsp",
-  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab_lsp"
+  "packageName": "jupyterlab-lsp",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab-lsp"
 }


### PR DESCRIPTION
<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

#568

## Code changes

Fixed the name of the package and the instructions on how to download it on the jupyterlab-lsp interface.

## Backwards-incompatible changes

No backwards-incompatible changes.

## Chores

- [ ] linted
- [ ] tested
- [ ] documented
- [ ] changelog entry
