### PR TITLE
Use ICodeMirror, more type imports, order plugin for fixer

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -59,9 +59,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ matrix.os }}-lint-
 
       - name: Set up Python and mamba
-        uses: conda-incubator/setup-miniconda@master
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          condarc-file: .github/.condarc
           environment-file: requirements/github-actions.yml
           miniforge-variant: Mambaforge
           use-mamba: true
@@ -138,9 +137,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ matrix.os }}-build-
 
       - name: Set up Python and mamba
-        uses: conda-incubator/setup-miniconda@master
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          condarc-file: .github/.condarc
           miniforge-variant: Mambaforge
 
       - name: Install minimal build deps
@@ -253,9 +251,8 @@ jobs:
             ${{ env.CACHE_EPOCH }}-${{ matrix.os }}-${{ matrix.python }}-atest-
 
       - name: Set up Python and mamba
-        uses: conda-incubator/setup-miniconda@master
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          condarc-file: .github/.condarc
           environment-file: requirements/github-actions.yml
           miniforge-variant: Mambaforge
           use-mamba: true

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Lint frontend
         run: jlpm lint:check
 
+      - name: Check distributions
+        run: python scripts/distcheck.py
+
   build:
     name: build
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - bug fixes:
 
   - fixes name of jupyterlab-lsp package displayed in JupyterLab UI ([#570])
+  - remove vendored CodeMirror from distribution ([#576])
 
 [#570]: https://github.com/krassowski/jupyterlab-lsp/pull/570
+[#576]: https://github.com/krassowski/jupyterlab-lsp/pull/576
 
 ### `@krassowski/jupyterlab-lsp 3.5.0` (2020-03-22)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,12 @@ To run tests matching specific phrase, forward `-t` argument over yarn and lerna
 jlpm test -- -- -t match_phrase
 ```
 
+To verify the webpack build wouldn't include problematic vendored dependencies:
+
+```bash
+python scripts/distcheck.py
+```
+
 ### Server Development
 
 #### Testing `jupyter-lsp`

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "vscode-css-languageserver-bin": "^1.4.0",
     "vscode-html-languageserver-bin": "^1.4.0",
     "vscode-json-languageserver-bin": "^1.0.1",
-    "yaml-language-server": "^0.12.0",
-    "vscode-json-languageservice": "^3.9.1 <3.10.0"
+    "vscode-json-languageservice": "^3.9.1 <3.10.0",
+    "yaml-language-server": "^0.12.0"
   },
   "husky": {
     "hooks": {}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "private": true,
   "scripts": {
-    "bootstrap": "jlpm --no-optional --prefer-offline && lerna bootstrap && jlpm lint && jlpm clean && jlpm build",
+    "bootstrap": "jlpm --no-optional --prefer-offline && lerna bootstrap && jlpm clean && jlpm build && jlpm lint",
     "build": "jlpm build:schema && jlpm build:meta && jlpm build:ws && jlpm build:labextension",
     "build:schema": "lerna run build:schema --stream",
     "build:meta": "lerna run build --stream --scope @krassowski/jupyterlab-lsp-metapackage",

--- a/packages/.eslintrc.js
+++ b/packages/.eslintrc.js
@@ -10,6 +10,9 @@ module.exports = {
   root: true,
   extends: [
     'eslint:recommended',
+    'plugin:import/errors',
+    'plugin:import/warnings',
+    'plugin:import/typescript',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'prettier/@typescript-eslint',
@@ -55,12 +58,32 @@ module.exports = {
     'no-undef': 'warn',
     'no-useless-escape': 'off',
     'prefer-const': 'off',
-    // deviations from jupyterlab, should not be changed
-    // a pitfall of enums is that they do not work correctly
-    // when circular dependencies are present
-    // (see https://stackoverflow.com/a/59665223/)
-    'import/no-cycle': 'error',
+    // the default, but for reference...
+    'import/order': [
+      'warn',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'parent',
+          'sibling',
+          'index',
+          'object',
+          'unknown'
+        ],
+        pathGroups: [
+          { pattern: 'react/**', group: 'builtin', order: 'after' },
+          { pattern: 'codemirror/**', group: 'external', order: 'before' },
+          { pattern: '@lumino/**', group: 'external', order: 'before' },
+          { pattern: '@jupyterlab/**', group: 'external', order: 'after' }
+        ],
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc' }
+      }
+    ],
     // deviations from jupyterlab, should probably be fixed
+    'import/no-cycle': 'off', // somehow we lapsed here... ~200 cycles now
+    'import/export': 'off', // we do class/interface + NS pun exports _all over_
     '@typescript-eslint/triple-slash-reference': 'off',
     'jest/no-test-callback': 'off',
     'jest/valid-expect': 'off',

--- a/packages/_example-extractor/src/api.spec.ts
+++ b/packages/_example-extractor/src/api.spec.ts
@@ -1,8 +1,7 @@
+import { IExtractedCode } from '@krassowski/jupyterlab-lsp';
 import { expect } from 'chai';
 
 import { extractor } from '.';
-
-import { IExtractedCode } from '@krassowski/jupyterlab-lsp';
 
 const EXAMPLE = `%%foo
 bar

--- a/packages/_example-extractor/src/index.ts
+++ b/packages/_example-extractor/src/index.ts
@@ -2,7 +2,6 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-
 import {
   ILSPCodeExtractorsManager,
   RegExpForeignCodeExtractor

--- a/packages/code-jumpers/src/history.ts
+++ b/packages/code-jumpers/src/history.ts
@@ -1,6 +1,7 @@
-import { IGlobalPosition } from './positions';
 import { IModelDB, IObservableUndoableList } from '@jupyterlab/observables';
 import { JSONValue } from '@lumino/coreutils';
+
+import { IGlobalPosition } from './positions';
 
 const DB_ENTRY = 'jumpy_history';
 

--- a/packages/code-jumpers/src/index.ts
+++ b/packages/code-jumpers/src/index.ts
@@ -1,5 +1,5 @@
+import { FileEditorJumper } from './jumpers/fileeditor';
 import { CodeJumper } from './jumpers/jumper';
 import { NotebookJumper } from './jumpers/notebook';
-import { FileEditorJumper } from './jumpers/fileeditor';
 
 export { CodeJumper, NotebookJumper, FileEditorJumper };

--- a/packages/code-jumpers/src/jumpers/fileeditor.ts
+++ b/packages/code-jumpers/src/jumpers/fileeditor.ts
@@ -1,10 +1,12 @@
-import { FileEditor } from '@jupyterlab/fileeditor';
-import { IGlobalPosition, ILocalPosition } from '../positions';
-import { CodeJumper, jumpers } from './jumper';
-import { JumpHistory } from '../history';
+import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { CodeEditor } from '@jupyterlab/codeeditor';
+import { FileEditor } from '@jupyterlab/fileeditor';
+
+import { JumpHistory } from '../history';
+import { IGlobalPosition, ILocalPosition } from '../positions';
+
+import { CodeJumper, jumpers } from './jumper';
 
 export class FileEditorJumper extends CodeJumper {
   editor: FileEditor;

--- a/packages/code-jumpers/src/jumpers/jumper.ts
+++ b/packages/code-jumpers/src/jumpers/jumper.ts
@@ -1,12 +1,13 @@
+import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-
-import { IGlobalPosition, ILocalPosition } from '../positions';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { JumpHistory } from '../history';
 import { FileEditor } from '@jupyterlab/fileeditor';
+
+import { JumpHistory } from '../history';
+import { IGlobalPosition, ILocalPosition } from '../positions';
+
 import IEditor = CodeEditor.IEditor;
-import { Dialog, showDialog } from '@jupyterlab/apputils';
 
 const movement_keys = [
   'ArrowRight',

--- a/packages/code-jumpers/src/jumpers/notebook.ts
+++ b/packages/code-jumpers/src/jumpers/notebook.ts
@@ -1,11 +1,12 @@
-import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
+import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IDocumentManager } from '@jupyterlab/docmanager';
+import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
+
+import { JumpHistory } from '../history';
+import { _ensureFocus } from '../notebook_private';
+import { IGlobalPosition, ILocalPosition } from '../positions';
 
 import { CodeJumper, jumpers } from './jumper';
-import { IGlobalPosition, ILocalPosition } from '../positions';
-import { _ensureFocus } from '../notebook_private';
-import { JumpHistory } from '../history';
-import { CodeEditor } from '@jupyterlab/codeeditor';
 
 export class NotebookJumper extends CodeJumper {
   notebook: Notebook;

--- a/packages/completion-theme/src/about.tsx
+++ b/packages/completion-theme/src/about.tsx
@@ -1,10 +1,11 @@
-import React, { ReactElement } from 'react';
-import {
-  ICompletionTheme,
-  ILicenseInfo,
-  COMPLETER_THEME_PREFIX
-} from './types';
 import { LabIcon } from '@jupyterlab/ui-components';
+import React, { ReactElement } from 'react';
+
+import {
+  COMPLETER_THEME_PREFIX,
+  ICompletionTheme,
+  ILicenseInfo
+} from './types';
 
 function render_licence(licence: ILicenseInfo): ReactElement {
   return (

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -1,22 +1,23 @@
-import { kernelIcon, LabIcon } from '@jupyterlab/ui-components';
+import '../style/index.css';
+import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import {
   Dialog,
   ICommandPalette,
   IThemeManager,
   showDialog
 } from '@jupyterlab/apputils';
-import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { LabIcon, kernelIcon } from '@jupyterlab/ui-components';
+
+import { render_themes_list } from './about';
 import {
+  COMPLETER_THEME_PREFIX,
+  CompletionItemKindStrings,
   ICompletionIconSet,
   ICompletionTheme,
   ILSPCompletionThemeManager,
-  PLUGIN_ID,
-  COMPLETER_THEME_PREFIX,
   KernelKind,
-  CompletionItemKindStrings
+  PLUGIN_ID
 } from './types';
-import { render_themes_list } from './about';
-import '../style/index.css';
 
 export class CompletionThemeManager implements ILSPCompletionThemeManager {
   protected current_icons: Map<string, LabIcon>;

--- a/packages/completion-theme/src/types.ts
+++ b/packages/completion-theme/src/types.ts
@@ -1,5 +1,5 @@
-import { Token } from '@lumino/coreutils';
 import { LabIcon } from '@jupyterlab/ui-components';
+import { Token } from '@lumino/coreutils';
 
 export const COMPLETER_THEME_PREFIX = 'lsp-completer-theme-';
 

--- a/packages/jupyterlab-lsp/src/adapter_manager.ts
+++ b/packages/jupyterlab-lsp/src/adapter_manager.ts
@@ -1,15 +1,17 @@
+import type { IClassicShell } from '@jupyterlab-classic/application';
+import { ILabShell, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { Signal } from '@lumino/signaling';
+
+import { WidgetAdapter } from './adapters/adapter';
 import {
   IAdapterRegistration,
   IAdapterTypeOptions,
   ILSPAdapterManager,
   PLUGIN_ID
 } from './tokens';
-import { Signal } from '@lumino/signaling';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { WidgetAdapter } from './adapters/adapter';
-import { ILabShell, JupyterFrontEndPlugin } from '@jupyterlab/application';
+
 import { LSPExtension } from './index';
-import type { IClassicShell } from '@jupyterlab-classic/application';
 
 export class WidgetAdapterManager implements ILSPAdapterManager {
   adapterTypeAdded: Signal<

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -1,23 +1,25 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
-import { IVirtualEditor } from '../virtual/editor';
-import { IForeignContext, VirtualDocument } from '../virtual/document';
-import { Signal } from '@lumino/signaling';
-import { IRootPosition, IVirtualPosition } from '../positioning';
-import { LSPConnection } from '../connection';
-import { ICommandContext } from '../command_manager';
 import { JSONObject } from '@lumino/coreutils';
+import { Signal } from '@lumino/signaling';
+
+import { ICommandContext } from '../command_manager';
+import { LSPConnection } from '../connection';
 import {
   DocumentConnectionManager,
   IDocumentConnectionData,
   ISocketConnectionOptions
 } from '../connection_manager';
-import { ILSPExtension, ILSPLogConsole } from '../index';
-import { IFeatureEditorIntegration, IFeature } from '../feature';
 import { EditorAdapter } from '../editor_integration/editor_adapter';
-import IEditor = CodeEditor.IEditor;
+import { IFeature, IFeatureEditorIntegration } from '../feature';
+import { ILSPExtension, ILSPLogConsole } from '../index';
 import { LanguageIdentifier } from '../lsp';
+import { IRootPosition, IVirtualPosition } from '../positioning';
+import { IForeignContext, VirtualDocument } from '../virtual/document';
+import { IVirtualEditor } from '../virtual/editor';
+
+import IEditor = CodeEditor.IEditor;
 
 export class StatusMessage {
   /**

--- a/packages/jupyterlab-lsp/src/adapters/file_editor/file_editor.ts
+++ b/packages/jupyterlab-lsp/src/adapters/file_editor/file_editor.ts
@@ -1,15 +1,17 @@
-import { WidgetAdapter } from '../adapter';
-import { FileEditor } from '@jupyterlab/fileeditor';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { LSPExtension } from '../../index';
-import { PositionConverter } from '../../converter';
-import { IRootPosition, IVirtualPosition } from '../../positioning';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { FileEditor } from '@jupyterlab/fileeditor';
+
 import { ICommandContext } from '../../command_manager';
-import { IVirtualEditor } from '../../virtual/editor';
-import IEditor = CodeEditor.IEditor;
+import { PositionConverter } from '../../converter';
+import { LSPExtension } from '../../index';
+import { IRootPosition, IVirtualPosition } from '../../positioning';
 import { VirtualDocument } from '../../virtual/document';
+import { IVirtualEditor } from '../../virtual/editor';
+import { WidgetAdapter } from '../adapter';
+
+import IEditor = CodeEditor.IEditor;
 
 export class FileEditorAdapter extends WidgetAdapter<
   IDocumentWidget<FileEditor>

--- a/packages/jupyterlab-lsp/src/adapters/file_editor/index.ts
+++ b/packages/jupyterlab-lsp/src/adapters/file_editor/index.ts
@@ -1,9 +1,11 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { ILSPAdapterManager, PLUGIN_ID } from '../../tokens';
-import { IEditorTracker } from '@jupyterlab/fileeditor';
-import { FileEditorAdapter } from './file_editor';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { IEditorTracker } from '@jupyterlab/fileeditor';
+
 import { CommandEntryPoint } from '../../command_manager';
+import { ILSPAdapterManager, PLUGIN_ID } from '../../tokens';
+
+import { FileEditorAdapter } from './file_editor';
 
 export const FileEditorContextMenuEntryPoint: CommandEntryPoint =
   'file-editor-context-menu';

--- a/packages/jupyterlab-lsp/src/adapters/notebook/index.ts
+++ b/packages/jupyterlab-lsp/src/adapters/notebook/index.ts
@@ -1,13 +1,15 @@
-import { CommandEntryPoint } from '../../command_manager';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { INotebookTracker } from '@jupyterlab/notebook';
+
+import { CommandEntryPoint } from '../../command_manager';
 import {
   IAdapterTypeOptions,
   ILSPAdapterManager,
   PLUGIN_ID
 } from '../../tokens';
-import { INotebookTracker } from '@jupyterlab/notebook';
+
 import { NotebookAdapter } from './notebook';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
 
 export const CellContextMenuEntryPoint: CommandEntryPoint =
   'notebook-cell-context-menu';

--- a/packages/jupyterlab-lsp/src/adapters/notebook/notebook.ts
+++ b/packages/jupyterlab-lsp/src/adapters/notebook/notebook.ts
@@ -1,22 +1,24 @@
-import { WidgetAdapter } from '../adapter';
-import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
-import { until_ready } from '../../utils';
-import { Cell, ICellModel } from '@jupyterlab/cells';
-import * as nbformat from '@jupyterlab/nbformat';
-import ILanguageInfoMetadata = nbformat.ILanguageInfoMetadata;
-import { Session } from '@jupyterlab/services';
 import { SessionContext } from '@jupyterlab/apputils';
-import { LSPExtension } from '../../index';
-import { PositionConverter } from '../../converter';
-import { IEditorPosition, IVirtualPosition } from '../../positioning';
-import { ICommandContext } from '../../command_manager';
+import { Cell, ICellModel } from '@jupyterlab/cells';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import IEditor = CodeEditor.IEditor;
-import { VirtualDocument } from '../../virtual/document';
+import * as nbformat from '@jupyterlab/nbformat';
+import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
 import {
-  IObservableUndoableList,
-  IObservableList
+  IObservableList,
+  IObservableUndoableList
 } from '@jupyterlab/observables';
+import { Session } from '@jupyterlab/services';
+
+import { ICommandContext } from '../../command_manager';
+import { PositionConverter } from '../../converter';
+import { LSPExtension } from '../../index';
+import { IEditorPosition, IVirtualPosition } from '../../positioning';
+import { until_ready } from '../../utils';
+import { VirtualDocument } from '../../virtual/document';
+import { WidgetAdapter } from '../adapter';
+
+import IEditor = CodeEditor.IEditor;
+import ILanguageInfoMetadata = nbformat.ILanguageInfoMetadata;
 
 export class NotebookAdapter extends WidgetAdapter<NotebookPanel> {
   editor: Notebook;

--- a/packages/jupyterlab-lsp/src/command_manager.spec.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.spec.ts
@@ -1,12 +1,13 @@
+import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { expect } from 'chai';
+
+import { WidgetAdapter } from './adapters/adapter';
 import {
   CommandEntryPoint,
   ContextCommandManager,
   IContextMenuOptions
 } from './command_manager';
-import { WidgetAdapter } from './adapters/adapter';
 import { IFeatureCommand } from './feature';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { BrowserConsole } from './virtual/console';
 
 describe('ContextMenuCommandManager', () => {

--- a/packages/jupyterlab-lsp/src/command_manager.ts
+++ b/packages/jupyterlab-lsp/src/command_manager.ts
@@ -1,14 +1,15 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { ICommandPalette, IWidgetTracker } from '@jupyterlab/apputils';
-import { WidgetAdapter } from './adapters/adapter';
-import { IFeatureEditorIntegration, IFeatureCommand } from './feature';
-import { VirtualDocument } from './virtual/document';
-import { LSPConnection } from './connection';
-import { IRootPosition, IVirtualPosition } from './positioning';
-import { IVirtualEditor } from './virtual/editor';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+
+import { WidgetAdapter } from './adapters/adapter';
+import { LSPConnection } from './connection';
+import { IFeatureCommand, IFeatureEditorIntegration } from './feature';
+import { IRootPosition, IVirtualPosition } from './positioning';
 import { ILSPAdapterManager, ILSPLogConsole } from './tokens';
+import { VirtualDocument } from './virtual/document';
+import { IVirtualEditor } from './virtual/editor';
 
 function is_context_menu_over_token(adapter: WidgetAdapter<IDocumentWidget>) {
   let position = adapter.get_position_from_context_menu();

--- a/packages/jupyterlab-lsp/src/components/free_tooltip.ts
+++ b/packages/jupyterlab-lsp/src/components/free_tooltip.ts
@@ -1,16 +1,17 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 // (Parts of the FreeTooltip code are copy-paste from Tooltip, ideally this would be PRed be merged)
-import { Tooltip } from '@jupyterlab/tooltip';
-import { CodeEditor } from '@jupyterlab/codeeditor';
 import { HoverBox } from '@jupyterlab/apputils';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import { IEditorPosition } from '../positioning';
-import { PositionConverter } from '../converter';
-import { Widget } from '@lumino/widgets';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { WidgetAdapter } from '../adapters/adapter';
+import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { Tooltip } from '@jupyterlab/tooltip';
+import { Widget } from '@lumino/widgets';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+
+import { WidgetAdapter } from '../adapters/adapter';
+import { PositionConverter } from '../converter';
+import { IEditorPosition } from '../positioning';
 
 const MIN_HEIGHT = 20;
 const MAX_HEIGHT = 250;

--- a/packages/jupyterlab-lsp/src/components/icons.ts
+++ b/packages/jupyterlab-lsp/src/components/icons.ts
@@ -1,7 +1,8 @@
 import { LabIcon } from '@jupyterlab/ui-components';
+
+import codeCheckSvg from '../../style/icons/code-check.svg';
 import codeClock from '../../style/icons/code-clock.svg';
 import codeWarning from '../../style/icons/code-warning.svg';
-import codeCheckSvg from '../../style/icons/code-check.svg';
 
 export const codeWarningIcon = new LabIcon({
   name: 'lsp:codeWarning',

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -2,41 +2,44 @@
 // Distributed under the terms of the Modified BSD License.
 // Based on the @jupyterlab/codemirror-extension statusbar
 
-import React from 'react';
-
-import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
-import '../../style/statusbar.css';
-
-import * as SCHEMA from '../_schema';
-
+import {
+  VDomModel,
+  VDomRenderer,
+  Dialog,
+  showDialog
+} from '@jupyterlab/apputils';
+import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
+import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
 import {
   GroupItem,
-  interactiveItem,
   Popup,
-  showPopup,
-  TextItem
+  TextItem,
+  interactiveItem,
+  showPopup
 } from '@jupyterlab/statusbar';
-
 import {
+  LabIcon,
   caretDownIcon,
   caretUpIcon,
   circleEmptyIcon,
   circleIcon,
-  LabIcon,
   stopIcon
 } from '@jupyterlab/ui-components';
+import React from 'react';
+
+import '../../style/statusbar.css';
+import * as SCHEMA from '../_schema';
 import { WidgetAdapter } from '../adapters/adapter';
-import { collect_documents, VirtualDocument } from '../virtual/document';
 import { LSPConnection } from '../connection';
 import { DocumentConnectionManager } from '../connection_manager';
-import { ILanguageServerManager, ILSPAdapterManager } from '../tokens';
-import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
-import { DocumentLocator } from './utils';
-import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
-import { LanguageServerManager } from '../manager';
-import { codeCheckIcon, codeClockIcon, codeWarningIcon } from './icons';
-import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { SERVER_EXTENSION_404 } from '../errors';
+import { LanguageServerManager } from '../manager';
+import { ILSPAdapterManager, ILanguageServerManager } from '../tokens';
+import { VirtualDocument, collect_documents } from '../virtual/document';
+
+import { codeCheckIcon, codeClockIcon, codeWarningIcon } from './icons';
+import { DocumentLocator } from './utils';
+
 import okButton = Dialog.okButton;
 
 interface IServerStatusProps {

--- a/packages/jupyterlab-lsp/src/components/utils.spec.ts
+++ b/packages/jupyterlab-lsp/src/components/utils.spec.ts
@@ -1,7 +1,9 @@
-import { get_breadcrumbs } from './utils';
-import { VirtualDocument } from '../virtual/document';
-import { WidgetAdapter } from '../adapters/adapter';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+
+import { WidgetAdapter } from '../adapters/adapter';
+import { VirtualDocument } from '../virtual/document';
+
+import { get_breadcrumbs } from './utils';
 
 function create_dummy_document(options: Partial<VirtualDocument.IOptions>) {
   return new VirtualDocument({

--- a/packages/jupyterlab-lsp/src/components/utils.tsx
+++ b/packages/jupyterlab-lsp/src/components/utils.tsx
@@ -1,7 +1,8 @@
-import { VirtualDocument } from '../virtual/document';
-import { WidgetAdapter } from '../adapters/adapter';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 import React from 'react';
+
+import { WidgetAdapter } from '../adapters/adapter';
+import { VirtualDocument } from '../virtual/document';
 
 export function get_breadcrumbs(
   document: VirtualDocument,

--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -2,13 +2,14 @@
 // ISC licence is, quote, "functionally equivalent to the simplified BSD and MIT licenses,
 // but without language deemed unnecessary following the Berne Convention." (Wikipedia).
 // Introduced modifications are BSD licenced, copyright JupyterLab development team.
-import * as lsProtocol from 'vscode-languageserver-protocol';
 import {
   IDocumentInfo,
   ILspOptions,
   IPosition,
   LspWsConnection
 } from 'lsp-ws-connection';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+
 import { until_ready } from './utils';
 
 interface ILSPOptions extends ILspOptions {}

--- a/packages/jupyterlab-lsp/src/converter.ts
+++ b/packages/jupyterlab-lsp/src/converter.ts
@@ -1,6 +1,6 @@
-import * as lsProtocol from 'vscode-languageserver-protocol';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import * as CodeMirror from 'codemirror';
+import type * as CodeMirror from 'codemirror';
+import type * as lsProtocol from 'vscode-languageserver-protocol';
 
 export class PositionConverter {
   static lsp_to_cm(position: lsProtocol.Position): CodeMirror.Position {

--- a/packages/jupyterlab-lsp/src/editor_integration/cm_adapter.spec.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/cm_adapter.spec.ts
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
+import type * as CodeMirror from 'codemirror';
+
 import { IRootPosition } from '../positioning';
-import * as CodeMirror from 'codemirror';
-import { FileEditorFeatureTestEnvironment } from './testutils';
-import { CodeMirrorIntegration } from './codemirror';
 import { IEditorChange } from '../virtual/editor';
+
+import { CodeMirrorIntegration } from './codemirror';
+import { FileEditorFeatureTestEnvironment } from './testutils';
 
 describe('CodeMirrorAdapter', () => {
   let env: FileEditorFeatureTestEnvironment;

--- a/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/codemirror.ts
@@ -1,30 +1,31 @@
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+import type * as CodeMirror from 'codemirror';
+import type * as lsProtocol from 'vscode-languageserver-protocol';
+
+import { StatusMessage, WidgetAdapter } from '../adapters/adapter';
+import { LSPConnection } from '../connection';
+import { PositionConverter } from '../converter';
 import {
-  IFeatureEditorIntegration,
   IEditorIntegrationOptions,
   IFeature,
+  IFeatureEditorIntegration,
   IFeatureSettings
 } from '../feature';
-import { VirtualDocument } from '../virtual/document';
-import { LSPConnection } from '../connection';
-import * as CodeMirror from 'codemirror';
 import {
   IEditorPosition,
   IRootPosition,
   IVirtualPosition,
   offset_at_position
 } from '../positioning';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import { PositionConverter } from '../converter';
+import { ILSPLogConsole } from '../tokens';
 import { DefaultMap, uris_equal } from '../utils';
-import { CodeEditor } from '@jupyterlab/codeeditor';
 import {
   CodeMirrorHandler,
   CodeMirrorVirtualEditor
 } from '../virtual/codemirror_editor';
-import { StatusMessage, WidgetAdapter } from '../adapters/adapter';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { VirtualDocument } from '../virtual/document';
 import { IEditorChange } from '../virtual/editor';
-import { ILSPLogConsole } from '../tokens';
 
 function toDocumentChanges(changes: {
   [uri: string]: lsProtocol.TextEdit[];

--- a/packages/jupyterlab-lsp/src/editor_integration/editor_adapter.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/editor_adapter.ts
@@ -1,11 +1,13 @@
-import IEditor = CodeEditor.IEditor;
-import { IEditorChange, IVirtualEditor } from '../virtual/editor';
-import { IFeatureEditorIntegration } from '../feature';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { VirtualDocument } from '../virtual/document';
-import { until_ready } from '../utils';
+
+import { IFeatureEditorIntegration } from '../feature';
 import { IRootPosition } from '../positioning';
 import { ILSPLogConsole } from '../tokens';
+import { until_ready } from '../utils';
+import { VirtualDocument } from '../virtual/document';
+import { IEditorChange, IVirtualEditor } from '../virtual/editor';
+
+import IEditor = CodeEditor.IEditor;
 
 export class EditorAdapter<T extends IVirtualEditor<IEditor>> {
   features: Map<string, IFeatureEditorIntegration<T>>;

--- a/packages/jupyterlab-lsp/src/editor_integration/feature.spec.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/feature.spec.ts
@@ -1,19 +1,21 @@
+import { PageConfig } from '@jupyterlab/coreutils';
+import * as nbformat from '@jupyterlab/nbformat';
+import { NotebookModel } from '@jupyterlab/notebook';
 import { expect } from 'chai';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+
+import { foreign_code_extractors } from '../transclusions/ipython/extractors';
+import { overrides } from '../transclusions/ipython/overrides';
+
+import { CodeMirrorIntegration } from './codemirror';
 import {
-  code_cell,
   FileEditorFeatureTestEnvironment,
-  getCellsJSON,
   NotebookFeatureTestEnvironment,
+  code_cell,
+  getCellsJSON,
   python_notebook_metadata,
   showAllCells
 } from './testutils';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import * as nbformat from '@jupyterlab/nbformat';
-import { overrides } from '../transclusions/ipython/overrides';
-import { foreign_code_extractors } from '../transclusions/ipython/extractors';
-import { NotebookModel } from '@jupyterlab/notebook';
-import { PageConfig } from '@jupyterlab/coreutils';
-import { CodeMirrorIntegration } from './codemirror';
 
 const js_fib_code = `function fib(n) {
   return n<2?n:fib(n-1)+fib(n-2);

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -1,54 +1,57 @@
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { ICellModel } from '@jupyterlab/cells';
+import { CodeEditor } from '@jupyterlab/codeeditor';
 import {
   CodeMirrorEditor,
   CodeMirrorEditorFactory,
   CodeMirrorMimeTypeService
 } from '@jupyterlab/codemirror';
-import { IVirtualEditor, VirtualEditorManager } from '../virtual/editor';
-import { LSPConnection } from '../connection';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { WidgetAdapter } from '../adapters/adapter';
+import {
+  Context,
+  IDocumentWidget,
+  TextModelFactory
+} from '@jupyterlab/docregistry';
+import { FileEditor, FileEditorFactory } from '@jupyterlab/fileeditor';
+import * as nbformat from '@jupyterlab/nbformat';
 import {
   Notebook,
   NotebookModel,
   NotebookModelFactory,
   NotebookPanel
 } from '@jupyterlab/notebook';
+import { ServiceManager } from '@jupyterlab/services';
 import { NBTestUtils } from '@jupyterlab/testutils';
-import * as nbformat from '@jupyterlab/nbformat';
-import { ICellModel } from '@jupyterlab/cells';
-import { VirtualDocument } from '../virtual/document';
-import { LanguageServerManager } from '../manager';
+import { Signal } from '@lumino/signaling';
+
+import { WidgetAdapter } from '../adapters/adapter';
+import { FileEditorAdapter } from '../adapters/file_editor/file_editor';
+import { NotebookAdapter } from '../adapters/notebook/notebook';
+import { LSPConnection } from '../connection';
 import { DocumentConnectionManager } from '../connection_manager';
-import {
-  CodeMirrorIntegration,
-  CodeMirrorIntegrationConstructor
-} from './codemirror';
-import { EditorAdapter } from './editor_adapter';
-import IEditor = CodeEditor.IEditor;
-import { CodeMirrorVirtualEditor } from '../virtual/codemirror_editor';
+import { IForeignCodeExtractorsRegistry } from '../extractors/types';
+import { IFeatureSettings } from '../feature';
+import { FeatureManager, ILSPExtension } from '../index';
+import { LanguageServerManager } from '../manager';
+import { ICodeOverridesRegistry } from '../overrides/tokens';
 import {
   ILSPFeatureManager,
   ILSPLogConsole,
   ILSPVirtualEditorManager,
   WidgetAdapterConstructor
 } from '../tokens';
-import { FileEditorAdapter } from '../adapters/file_editor/file_editor';
-import { NotebookAdapter } from '../adapters/notebook/notebook';
-import {
-  Context,
-  IDocumentWidget,
-  TextModelFactory
-} from '@jupyterlab/docregistry';
-import createNotebookPanel = NBTestUtils.createNotebookPanel;
-import { FileEditor, FileEditorFactory } from '@jupyterlab/fileeditor';
-import { ServiceManager } from '@jupyterlab/services';
-import { FeatureManager, ILSPExtension } from '../index';
-import { JupyterFrontEnd } from '@jupyterlab/application';
-import { IFeatureSettings } from '../feature';
-import { IForeignCodeExtractorsRegistry } from '../extractors/types';
-import { ICodeOverridesRegistry } from '../overrides/tokens';
-import { Signal } from '@lumino/signaling';
+import { CodeMirrorVirtualEditor } from '../virtual/codemirror_editor';
 import { BrowserConsole } from '../virtual/console';
+import { VirtualDocument } from '../virtual/document';
+import { IVirtualEditor, VirtualEditorManager } from '../virtual/editor';
+
+import {
+  CodeMirrorIntegration,
+  CodeMirrorIntegrationConstructor
+} from './codemirror';
+import { EditorAdapter } from './editor_adapter';
+
+import createNotebookPanel = NBTestUtils.createNotebookPanel;
+import IEditor = CodeEditor.IEditor;
 
 export interface ITestEnvironment {
   document_options: VirtualDocument.IOptions;

--- a/packages/jupyterlab-lsp/src/extractors/manager.ts
+++ b/packages/jupyterlab-lsp/src/extractors/manager.ts
@@ -1,5 +1,7 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+
 import { ILSPCodeExtractorsManager } from '../tokens';
+
 import { IForeignCodeExtractor, IForeignCodeExtractorsRegistry } from './types';
 
 export class CodeExtractorsManager implements ILSPCodeExtractorsManager {

--- a/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { getIndexOfCaptureGroup, RegExpForeignCodeExtractor } from './regexp';
+
+import { RegExpForeignCodeExtractor, getIndexOfCaptureGroup } from './regexp';
 
 let R_CELL_MAGIC_EXISTS = `%%R
 some text

--- a/packages/jupyterlab-lsp/src/extractors/regexp.ts
+++ b/packages/jupyterlab-lsp/src/extractors/regexp.ts
@@ -1,7 +1,9 @@
-import { IExtractedCode, IForeignCodeExtractor } from './types';
-import { position_at_offset } from '../positioning';
-import { replacer } from '../overrides/tokens';
 import { CodeEditor } from '@jupyterlab/codeeditor';
+
+import { replacer } from '../overrides/tokens';
+import { position_at_offset } from '../positioning';
+
+import { IExtractedCode, IForeignCodeExtractor } from './types';
 
 export function getIndexOfCaptureGroup(
   expression: RegExp,

--- a/packages/jupyterlab-lsp/src/extractors/testutils.ts
+++ b/packages/jupyterlab-lsp/src/extractors/testutils.ts
@@ -1,6 +1,7 @@
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { IVirtualDocumentBlock, VirtualDocument } from '../virtual/document';
 import { expect } from 'chai';
+
+import { IVirtualDocumentBlock, VirtualDocument } from '../virtual/document';
 
 export function extract_code(document: VirtualDocument, code: string) {
   return document.extract_foreign_code(

--- a/packages/jupyterlab-lsp/src/extractors/types.ts
+++ b/packages/jupyterlab-lsp/src/extractors/types.ts
@@ -1,4 +1,5 @@
 import { CodeEditor } from '@jupyterlab/codeeditor';
+
 import { LanguageIdentifier } from '../lsp';
 
 export interface IExtractedCode {

--- a/packages/jupyterlab-lsp/src/feature.ts
+++ b/packages/jupyterlab-lsp/src/feature.ts
@@ -1,15 +1,17 @@
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { CommandEntryPoint, ICommandContext } from './command_manager';
-import { IEditorChange, IVirtualEditor } from './virtual/editor';
-import { VirtualDocument } from './virtual/document';
-import { LSPConnection } from './connection';
-import { IRootPosition } from './positioning';
-import { StatusMessage, WidgetAdapter } from './adapters/adapter';
-import IEditor = CodeEditor.IEditor;
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { Signal } from '@lumino/signaling';
+
+import { StatusMessage, WidgetAdapter } from './adapters/adapter';
+import { CommandEntryPoint, ICommandContext } from './command_manager';
+import { LSPConnection } from './connection';
+import { IRootPosition } from './positioning';
+import { VirtualDocument } from './virtual/document';
+import { IEditorChange, IVirtualEditor } from './virtual/editor';
+
+import IEditor = CodeEditor.IEditor;
 
 export interface IFeatureCommand {
   /**

--- a/packages/jupyterlab-lsp/src/features/completion/completion.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion.ts
@@ -1,28 +1,29 @@
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { CompletionHandler, ICompletionManager } from '@jupyterlab/completer';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { NotebookPanel } from '@jupyterlab/notebook';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ILSPCompletionThemeManager } from '@krassowski/completion-theme/lib/types';
+import type * as CodeMirror from 'codemirror';
+
+import { CodeCompletion as LSPCompletionSettings } from '../../_completion';
+import { IEditorChangedData, WidgetAdapter } from '../../adapters/adapter';
+import { NotebookAdapter } from '../../adapters/notebook/notebook';
+import { IDocumentConnectionData } from '../../connection_manager';
+import { CodeMirrorIntegration } from '../../editor_integration/codemirror';
+import { FeatureSettings, IFeatureLabIntegration } from '../../feature';
 import {
   AdditionalCompletionTriggerKinds,
   CompletionTriggerKind,
   ExtendedCompletionTriggerKind
 } from '../../lsp';
-import * as CodeMirror from 'codemirror';
-import { CodeMirrorIntegration } from '../../editor_integration/codemirror';
-import { JupyterFrontEnd } from '@jupyterlab/application';
-import { IEditorChangedData, WidgetAdapter } from '../../adapters/adapter';
-import { LSPConnector } from './completion_handler';
-import { CompletionHandler, ICompletionManager } from '@jupyterlab/completer';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { NotebookPanel } from '@jupyterlab/notebook';
-import { FeatureSettings, IFeatureLabIntegration } from '../../feature';
-
-import { CodeCompletion as LSPCompletionSettings } from '../../_completion';
-import { IDocumentConnectionData } from '../../connection_manager';
 import { ILSPAdapterManager, ILSPLogConsole } from '../../tokens';
-import { NotebookAdapter } from '../../adapters/notebook/notebook';
-import { ILSPCompletionThemeManager } from '@krassowski/completion-theme/lib/types';
-import { ICompletionData, LSPCompletionRenderer } from './renderer';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
-import { LSPCompleterModel } from './model';
+
+import { LSPConnector } from './completion_handler';
 import { LazyCompletionItem } from './item';
+import { LSPCompleterModel } from './model';
+import { ICompletionData, LSPCompletionRenderer } from './renderer';
 
 const DOC_PANEL_SELECTOR = '.jp-Completer-docpanel';
 const DOC_PANEL_PLACEHOLDER_CLASS = 'lsp-completer-placeholder';

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -1,43 +1,45 @@
+import { CodeEditor } from '@jupyterlab/codeeditor';
 import {
   CompletionConnector,
   CompletionHandler,
   ContextConnector,
   KernelConnector
 } from '@jupyterlab/completer';
-import { CodeEditor } from '@jupyterlab/codeeditor';
+import { Session } from '@jupyterlab/services';
+import { LabIcon } from '@jupyterlab/ui-components';
+import {
+  ILSPCompletionThemeManager,
+  KernelKind
+} from '@krassowski/completion-theme/lib/types';
 import { JSONArray, JSONObject } from '@lumino/coreutils';
+import * as lsProtocol from 'vscode-languageserver-types';
+
+import { CodeCompletion as LSPCompletionSettings } from '../../_completion';
+import { LSPConnection } from '../../connection';
+import { PositionConverter } from '../../converter';
+import { FeatureSettings } from '../../feature';
 import {
   AdditionalCompletionTriggerKinds,
   CompletionItemKind,
   CompletionTriggerKind,
   ExtendedCompletionTriggerKind
 } from '../../lsp';
-import * as lsProtocol from 'vscode-languageserver-types';
-import { VirtualDocument } from '../../virtual/document';
-import { IVirtualEditor } from '../../virtual/editor';
 import {
   IEditorPosition,
   IRootPosition,
   IVirtualPosition
 } from '../../positioning';
-import { LSPConnection } from '../../connection';
-import { Session } from '@jupyterlab/services';
-
-import { CodeCompletion as LSPCompletionSettings } from '../../_completion';
-import { FeatureSettings } from '../../feature';
-import { PositionConverter } from '../../converter';
-import {
-  ILSPCompletionThemeManager,
-  KernelKind
-} from '@krassowski/completion-theme/lib/types';
-import { LabIcon } from '@jupyterlab/ui-components';
 import { ILSPLogConsole } from '../../tokens';
+import { VirtualDocument } from '../../virtual/document';
+import { IVirtualEditor } from '../../virtual/editor';
+
 import { CompletionLabIntegration } from './completion';
 import {
   ICompletionsSource,
   IExtendedCompletionItem,
   LazyCompletionItem
 } from './item';
+
 import ICompletionItemsResponseType = CompletionHandler.ICompletionItemsResponseType;
 
 /**

--- a/packages/jupyterlab-lsp/src/features/completion/index.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/index.ts
@@ -1,21 +1,23 @@
 import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import { ICompletionManager } from '@jupyterlab/completer';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { LabIcon } from '@jupyterlab/ui-components';
+import { ILSPCompletionThemeManager } from '@krassowski/completion-theme/lib/types';
+
+import completionSvg from '../../../style/icons/completion.svg';
+import { FeatureSettings } from '../../feature';
+import {
   ILSPAdapterManager,
   ILSPFeatureManager,
   ILSPLogConsole,
   PLUGIN_ID
 } from '../../tokens';
-import {
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin
-} from '@jupyterlab/application';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { ICompletionManager } from '@jupyterlab/completer';
-import { FeatureSettings } from '../../feature';
+
 import { CompletionCM, CompletionLabIntegration } from './completion';
-import { LabIcon } from '@jupyterlab/ui-components';
-import completionSvg from '../../../style/icons/completion.svg';
-import { ILSPCompletionThemeManager } from '@krassowski/completion-theme/lib/types';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
 export const completionIcon = new LabIcon({
   name: 'lsp:completion',

--- a/packages/jupyterlab-lsp/src/features/completion/item.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/item.ts
@@ -1,8 +1,10 @@
 import { CompletionHandler } from '@jupyterlab/completer';
 import { LabIcon } from '@jupyterlab/ui-components';
 import * as lsProtocol from 'vscode-languageserver-types';
-import { LSPConnector } from './completion_handler';
+
 import { until_ready } from '../../utils';
+
+import { LSPConnector } from './completion_handler';
 
 /**
  * To be upstreamed

--- a/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.spec.ts
@@ -1,7 +1,8 @@
-import { LSPCompleterModel } from './model';
 import { expect } from 'chai';
-import { LazyCompletionItem } from './item';
 import * as lsProtocol from 'vscode-languageserver-types';
+
+import { LazyCompletionItem } from './item';
+import { LSPCompleterModel } from './model';
 
 describe('LSPCompleterModel', () => {
   let model: LSPCompleterModel;

--- a/packages/jupyterlab-lsp/src/features/completion/model.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/model.ts
@@ -3,6 +3,7 @@
 
 import { CompleterModel, CompletionHandler } from '@jupyterlab/completer';
 import { StringExt } from '@lumino/algorithm';
+
 import { LazyCompletionItem } from './item';
 
 interface ICompletionMatch<T extends CompletionHandler.ICompletionItem> {

--- a/packages/jupyterlab-lsp/src/features/completion/renderer.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/renderer.ts
@@ -2,10 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Completer } from '@jupyterlab/completer';
-import { CompletionLabIntegration } from './completion';
-import { Signal } from '@lumino/signaling';
 import { IRenderMime } from '@jupyterlab/rendermime';
+import { Signal } from '@lumino/signaling';
+
 import { ILSPLogConsole } from '../../tokens';
+
+import { CompletionLabIntegration } from './completion';
 import { LazyCompletionItem } from './item';
 
 export interface ICompletionData {

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
@@ -1,19 +1,21 @@
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { expect } from 'chai';
-import { TextMarker, TextMarkerOptions } from 'codemirror';
-import { DiagnosticsCM, diagnostics_panel } from './diagnostics';
+import type { TextMarker, TextMarkerOptions } from 'codemirror';
+import type * as lsProtocol from 'vscode-languageserver-protocol';
+
+import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
 import {
-  code_cell,
   FileEditorFeatureTestEnvironment,
   MockSettings,
   NotebookFeatureTestEnvironment,
+  code_cell,
   set_notebook_content,
   showAllCells
 } from '../../editor_integration/testutils';
-import { CodeMirrorEditor } from '@jupyterlab/codemirror';
 import { is_equal } from '../../positioning';
 import { foreign_code_extractors } from '../../transclusions/ipython/extractors';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
+
+import { DiagnosticsCM, diagnostics_panel } from './diagnostics';
 import { message_without_code } from './listing';
 
 describe('Diagnostics', () => {

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -1,10 +1,22 @@
-import * as CodeMirror from 'codemirror';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import { PositionConverter } from '../../converter';
-import { IEditorPosition, IVirtualPosition } from '../../positioning';
-import { DiagnosticSeverity } from '../../lsp';
-import { DefaultMap, uris_equal } from '../../utils';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 import { MainAreaWidget } from '@jupyterlab/apputils';
+import { LabIcon, copyIcon } from '@jupyterlab/ui-components';
+import { Menu } from '@lumino/widgets';
+import type * as CodeMirror from 'codemirror';
+import type * as lsProtocol from 'vscode-languageserver-protocol';
+
+import diagnosticsSvg from '../../../style/icons/diagnostics.svg';
+import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
+import { PositionConverter } from '../../converter';
+import { CodeMirrorIntegration } from '../../editor_integration/codemirror';
+import { FeatureSettings } from '../../feature';
+import { DiagnosticSeverity } from '../../lsp';
+import { IEditorPosition, IVirtualPosition } from '../../positioning';
+import { DefaultMap, uris_equal } from '../../utils';
+import { CodeMirrorVirtualEditor } from '../../virtual/codemirror_editor';
+import { VirtualDocument } from '../../virtual/document';
+import { jumpToIcon } from '../jump_to';
+
 import {
   DIAGNOSTICS_LISTING_CLASS,
   DiagnosticsDatabase,
@@ -12,16 +24,6 @@ import {
   IDiagnosticsRow,
   IEditorDiagnostic
 } from './listing';
-import { VirtualDocument } from '../../virtual/document';
-import { FeatureSettings } from '../../feature';
-import { CodeMirrorIntegration } from '../../editor_integration/codemirror';
-import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
-import { CodeMirrorVirtualEditor } from '../../virtual/codemirror_editor';
-import { copyIcon, LabIcon } from '@jupyterlab/ui-components';
-import diagnosticsSvg from '../../../style/icons/diagnostics.svg';
-import { Menu } from '@lumino/widgets';
-import { JupyterFrontEnd } from '@jupyterlab/application';
-import { jumpToIcon } from '../jump_to';
 
 export const diagnosticsIcon = new LabIcon({
   name: 'lsp:diagnostics',

--- a/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/index.ts
@@ -1,14 +1,16 @@
-import { ILSPFeatureManager, PLUGIN_ID } from '../../tokens';
-import { FeatureSettings, IFeatureCommand } from '../../feature';
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+import { FeatureSettings, IFeatureCommand } from '../../feature';
+import { ILSPFeatureManager, PLUGIN_ID } from '../../tokens';
+
 import {
-  diagnostics_panel,
   DiagnosticsCM,
-  diagnosticsIcon
+  diagnosticsIcon,
+  diagnostics_panel
 } from './diagnostics';
 
 export const FEATURE_ID = PLUGIN_ID + ':diagnostics';

--- a/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/listing.tsx
@@ -1,21 +1,22 @@
-import React, { ReactElement } from 'react';
 import { VDomModel, VDomRenderer } from '@jupyterlab/apputils';
-import { caretDownIcon, caretUpIcon } from '@jupyterlab/ui-components';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import * as CodeMirror from 'codemirror';
-import { IEditorPosition } from '../../positioning';
-import { VirtualDocument } from '../../virtual/document';
-
-import '../../../style/diagnostics_listing.css';
-import { DiagnosticSeverity } from '../../lsp';
-import { CodeMirrorVirtualEditor } from '../../virtual/codemirror_editor';
-import { StatusMessage, WidgetAdapter } from '../../adapters/adapter';
-import { IVirtualEditor } from '../../virtual/editor';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { caretDownIcon, caretUpIcon } from '@jupyterlab/ui-components';
+import type * as CodeMirror from 'codemirror';
+import React, { ReactElement } from 'react';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+
+import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
+import { StatusMessage, WidgetAdapter } from '../../adapters/adapter';
 import { DocumentLocator, focus_on } from '../../components/utils';
 import { FeatureSettings } from '../../feature';
-import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
+import { DiagnosticSeverity } from '../../lsp';
+import { IEditorPosition } from '../../positioning';
+import { CodeMirrorVirtualEditor } from '../../virtual/codemirror_editor';
+import { VirtualDocument } from '../../virtual/document';
+import { IVirtualEditor } from '../../virtual/editor';
+
+import '../../../style/diagnostics_listing.css';
 
 /**
  * Diagnostic which is localized at a specific editor (cell) within a notebook

--- a/packages/jupyterlab-lsp/src/features/highlights.ts
+++ b/packages/jupyterlab-lsp/src/features/highlights.ts
@@ -1,22 +1,23 @@
-import * as CodeMirror from 'codemirror';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import { DocumentHighlightKind } from '../lsp';
-import { VirtualDocument } from '../virtual/document';
-import { IRootPosition, IVirtualPosition } from '../positioning';
-import { FeatureSettings, IFeatureCommand } from '../feature';
-import { CodeMirrorIntegration } from '../editor_integration/codemirror';
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
+import { CodeEditor } from '@jupyterlab/codeeditor';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { LabIcon } from '@jupyterlab/ui-components';
-import highlightSvg from '../../style/icons/highlight.svg';
-import highlightTypeSvg from '../../style/icons/highlight-type.svg';
 import { Debouncer } from '@lumino/polling';
+import type * as CodeMirror from 'codemirror';
+import type * as lsProtocol from 'vscode-languageserver-protocol';
+
+import highlightTypeSvg from '../../style/icons/highlight-type.svg';
+import highlightSvg from '../../style/icons/highlight.svg';
 import { CodeHighlights as LSPHighlightsSettings } from '../_highlights';
-import { CodeEditor } from '@jupyterlab/codeeditor';
+import { CodeMirrorIntegration } from '../editor_integration/codemirror';
+import { FeatureSettings, IFeatureCommand } from '../feature';
+import { DocumentHighlightKind } from '../lsp';
+import { IRootPosition, IVirtualPosition } from '../positioning';
+import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
+import { VirtualDocument } from '../virtual/document';
 
 export const highlightIcon = new LabIcon({
   name: 'lsp:highlight',

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -1,29 +1,29 @@
-import { getModifierState } from '../utils';
-import { IRootPosition, is_equal, IVirtualPosition } from '../positioning';
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import * as CodeMirror from 'codemirror';
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { LabIcon } from '@jupyterlab/ui-components';
 import { Throttler } from '@lumino/polling';
+import type * as CodeMirror from 'codemirror';
+import type * as lsProtocol from 'vscode-languageserver-protocol';
+
+import hoverSvg from '../../style/icons/hover.svg';
+import { CodeHover as LSPHoverSettings, ModifierKey } from '../_hover';
+import { EditorTooltipManager, FreeTooltip } from '../components/free_tooltip';
+import { PositionConverter } from '../converter';
 import {
   CodeMirrorIntegration,
   IEditorRange
 } from '../editor_integration/codemirror';
 import { FeatureSettings, IFeatureLabIntegration } from '../feature';
-import { EditorTooltipManager, FreeTooltip } from '../components/free_tooltip';
-import {
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin
-} from '@jupyterlab/application';
-import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { IRootPosition, IVirtualPosition, is_equal } from '../positioning';
 import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { CodeHover as LSPHoverSettings, ModifierKey } from '../_hover';
-import { LabIcon } from '@jupyterlab/ui-components';
-
-import hoverSvg from '../../style/icons/hover.svg';
-import { IEditorChange } from '../virtual/editor';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { PositionConverter } from '../converter';
+import { getModifierState } from '../utils';
 import { VirtualDocument } from '../virtual/document';
+import { IEditorChange } from '../virtual/editor';
 
 export const hoverIcon = new LabIcon({
   name: 'lsp:hover',

--- a/packages/jupyterlab-lsp/src/features/jump_to.ts
+++ b/packages/jupyterlab-lsp/src/features/jump_to.ts
@@ -1,33 +1,34 @@
 import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+import { URLExt } from '@jupyterlab/coreutils';
+import { IDocumentManager } from '@jupyterlab/docmanager';
+import { IEditorTracker } from '@jupyterlab/fileeditor';
+import { INotebookTracker } from '@jupyterlab/notebook';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { LabIcon } from '@jupyterlab/ui-components';
+import {
   CodeJumper,
-  NotebookJumper,
-  FileEditorJumper
+  FileEditorJumper,
+  NotebookJumper
 } from '@krassowski/code-jumpers';
-import { PositionConverter } from '../converter';
-import { IVirtualPosition } from '../positioning';
-import { getModifierState, uri_to_contents_path, uris_equal } from '../utils';
 import { AnyLocation } from 'lsp-ws-connection/lib/types';
+
+import jumpToSvg from '../../style/icons/jump-to.svg';
+import { CodeJump as LSPJumpSettings, ModifierKey } from '../_jump_to';
+import { CommandEntryPoint } from '../command_manager';
+import { PositionConverter } from '../converter';
+import { CodeMirrorIntegration } from '../editor_integration/codemirror';
 import {
   FeatureSettings,
   IFeatureCommand,
   IFeatureLabIntegration
 } from '../feature';
-import { CodeMirrorIntegration } from '../editor_integration/codemirror';
-import {
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin
-} from '@jupyterlab/application';
-import { IEditorTracker } from '@jupyterlab/fileeditor';
-import { CodeMirrorEditor } from '@jupyterlab/codemirror';
-import { INotebookTracker } from '@jupyterlab/notebook';
-import { IDocumentManager } from '@jupyterlab/docmanager';
+import { IVirtualPosition } from '../positioning';
 import { ILSPAdapterManager, ILSPFeatureManager, PLUGIN_ID } from '../tokens';
-import { LabIcon } from '@jupyterlab/ui-components';
-import jumpToSvg from '../../style/icons/jump-to.svg';
-import { URLExt } from '@jupyterlab/coreutils';
-import { CodeJump as LSPJumpSettings, ModifierKey } from '../_jump_to';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { CommandEntryPoint } from '../command_manager';
+import { getModifierState, uri_to_contents_path, uris_equal } from '../utils';
 
 export const jumpToIcon = new LabIcon({
   name: 'lsp:jump-to',

--- a/packages/jupyterlab-lsp/src/features/rename.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.spec.ts
@@ -1,8 +1,10 @@
-import { expect } from 'chai';
-import { RenameCM } from './rename';
-import { FileEditorFeatureTestEnvironment } from '../editor_integration/testutils';
-import * as lsProtocol from 'vscode-languageserver-protocol';
 import { PageConfig } from '@jupyterlab/coreutils';
+import { expect } from 'chai';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+
+import { FileEditorFeatureTestEnvironment } from '../editor_integration/testutils';
+
+import { RenameCM } from './rename';
 
 describe('Rename', () => {
   let env: FileEditorFeatureTestEnvironment;

--- a/packages/jupyterlab-lsp/src/features/rename.ts
+++ b/packages/jupyterlab-lsp/src/features/rename.ts
@@ -1,21 +1,23 @@
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import { InputDialog } from '@jupyterlab/apputils';
-import { DiagnosticsCM } from './diagnostics/diagnostics';
-import { FeatureSettings, IFeatureCommand } from '../feature';
-import {
-  CodeMirrorIntegration,
-  IEditOutcome
-} from '../editor_integration/codemirror';
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
+import { InputDialog } from '@jupyterlab/apputils';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { CodeMirrorVirtualEditor } from '../virtual/codemirror_editor';
 import { LabIcon } from '@jupyterlab/ui-components';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+
 import renameSvg from '../../style/icons/rename.svg';
+import {
+  CodeMirrorIntegration,
+  IEditOutcome
+} from '../editor_integration/codemirror';
+import { FeatureSettings, IFeatureCommand } from '../feature';
+import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
+import { CodeMirrorVirtualEditor } from '../virtual/codemirror_editor';
+
 import { FEATURE_ID as DIAGNOSTICS_PLUGIN_ID } from './diagnostics';
+import { DiagnosticsCM } from './diagnostics/diagnostics';
 
 export const renameIcon = new LabIcon({
   name: 'lsp:rename',

--- a/packages/jupyterlab-lsp/src/features/signature.ts
+++ b/packages/jupyterlab-lsp/src/features/signature.ts
@@ -1,15 +1,16 @@
-import * as lsProtocol from 'vscode-languageserver-protocol';
-import { IRootPosition } from '../positioning';
-import { CodeMirrorIntegration } from '../editor_integration/codemirror';
-import { FeatureSettings, IFeatureLabIntegration } from '../feature';
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
-import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import * as lsProtocol from 'vscode-languageserver-protocol';
+
 import { EditorTooltipManager } from '../components/free_tooltip';
+import { CodeMirrorIntegration } from '../editor_integration/codemirror';
+import { FeatureSettings, IFeatureLabIntegration } from '../feature';
+import { IRootPosition } from '../positioning';
+import { ILSPFeatureManager, PLUGIN_ID } from '../tokens';
 import { IEditorChange } from '../virtual/editor';
 
 export class SignatureCM extends CodeMirrorIntegration {

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -11,16 +11,40 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { ICommandPalette } from '@jupyterlab/apputils';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { Signal } from '@lumino/signaling';
-import { LanguageServerManager } from './manager';
-import '../style/index.css';
-import { ContextCommandManager } from './command_manager';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { IStatusBar } from '@jupyterlab/statusbar';
+import { COMPLETION_THEME_MANAGER } from '@krassowski/completion-theme';
+import { plugin as THEME_MATERIAL } from '@krassowski/theme-material';
+import { plugin as THEME_VSCODE } from '@krassowski/theme-vscode';
+import { Signal } from '@lumino/signaling';
+
+import '../style/index.css';
+
+import { WIDGET_ADAPTER_MANAGER } from './adapter_manager';
+import { FILE_EDITOR_ADAPTER } from './adapters/file_editor';
+import { NOTEBOOK_ADAPTER } from './adapters/notebook';
+import { ContextCommandManager } from './command_manager';
 import { StatusButtonExtension } from './components/statusbar';
 import { DocumentConnectionManager } from './connection_manager';
+import { CODE_EXTRACTORS_MANAGER } from './extractors/manager';
+import { IForeignCodeExtractorsRegistry } from './extractors/types';
+import { IFeature } from './feature';
+import { COMPLETION_PLUGIN } from './features/completion';
+import { DIAGNOSTICS_PLUGIN } from './features/diagnostics';
+import { HIGHLIGHTS_PLUGIN } from './features/highlights';
+import { HOVER_PLUGIN } from './features/hover';
+import { JUMP_PLUGIN } from './features/jump_to';
+import { RENAME_PLUGIN } from './features/rename';
+import { SIGNATURE_PLUGIN } from './features/signature';
+import { SYNTAX_HIGHLIGHTING_PLUGIN } from './features/syntax_highlighting';
+import { LanguageServerManager } from './manager';
+import { CODE_OVERRIDES_MANAGER } from './overrides';
+import {
+  ICodeOverridesRegistry,
+  ILSPCodeOverridesManager
+} from './overrides/tokens';
 import {
   IAdapterTypeOptions,
   ILSPAdapterManager,
@@ -31,33 +55,12 @@ import {
   PLUGIN_ID,
   TLanguageServerConfigurations
 } from './tokens';
-import { IFeature } from './feature';
-import { JUMP_PLUGIN } from './features/jump_to';
-import { SIGNATURE_PLUGIN } from './features/signature';
-import { HOVER_PLUGIN } from './features/hover';
-import { RENAME_PLUGIN } from './features/rename';
-import { HIGHLIGHTS_PLUGIN } from './features/highlights';
-import { WIDGET_ADAPTER_MANAGER } from './adapter_manager';
-import { FILE_EDITOR_ADAPTER } from './adapters/file_editor';
-import { NOTEBOOK_ADAPTER } from './adapters/notebook';
-import { VIRTUAL_EDITOR_MANAGER } from './virtual/editor';
-import { CODEMIRROR_VIRTUAL_EDITOR } from './virtual/codemirror_editor';
-import { DIAGNOSTICS_PLUGIN } from './features/diagnostics';
-import { COMPLETION_PLUGIN } from './features/completion';
-import { CODE_EXTRACTORS_MANAGER } from './extractors/manager';
-import { IForeignCodeExtractorsRegistry } from './extractors/types';
-import {
-  ICodeOverridesRegistry,
-  ILSPCodeOverridesManager
-} from './overrides/tokens';
 import { DEFAULT_TRANSCLUSIONS } from './transclusions/defaults';
-import { SYNTAX_HIGHLIGHTING_PLUGIN } from './features/syntax_highlighting';
-import { COMPLETION_THEME_MANAGER } from '@krassowski/completion-theme';
-import { plugin as THEME_VSCODE } from '@krassowski/theme-vscode';
-import { plugin as THEME_MATERIAL } from '@krassowski/theme-material';
-import { CODE_OVERRIDES_MANAGER } from './overrides';
-import IPaths = JupyterFrontEnd.IPaths;
+import { CODEMIRROR_VIRTUAL_EDITOR } from './virtual/codemirror_editor';
 import { LOG_CONSOLE } from './virtual/console';
+import { VIRTUAL_EDITOR_MANAGER } from './virtual/editor';
+
+import IPaths = JupyterFrontEnd.IPaths;
 
 export interface IFeatureOptions {
   /**

--- a/packages/jupyterlab-lsp/src/manager.ts
+++ b/packages/jupyterlab-lsp/src/manager.ts
@@ -1,10 +1,9 @@
-import { Signal } from '@lumino/signaling';
-
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
+import { Signal } from '@lumino/signaling';
 
-import { ILanguageServerManager, TSessionMap } from './tokens';
 import * as SCHEMA from './_schema';
+import { ILanguageServerManager, TSessionMap } from './tokens';
 
 export class LanguageServerManager implements ILanguageServerManager {
   protected _sessionsChanged: Signal<ILanguageServerManager, void> = new Signal<

--- a/packages/jupyterlab-lsp/src/overrides/index.ts
+++ b/packages/jupyterlab-lsp/src/overrides/index.ts
@@ -1,4 +1,5 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+
 import {
   ICodeOverridesRegistry,
   ILSPCodeOverridesManager,

--- a/packages/jupyterlab-lsp/src/overrides/tokens.ts
+++ b/packages/jupyterlab-lsp/src/overrides/tokens.ts
@@ -1,6 +1,7 @@
-import { PLUGIN_ID } from '../tokens';
 import { Token } from '@lumino/coreutils';
+
 import { LanguageIdentifier } from '../lsp';
+import { PLUGIN_ID } from '../tokens';
 
 export type replacer = (...args: string[]) => string;
 

--- a/packages/jupyterlab-lsp/src/positioning.spec.ts
+++ b/packages/jupyterlab-lsp/src/positioning.spec.ts
@@ -1,5 +1,6 @@
-import { position_at_offset, offset_at_position } from './positioning';
 import { expect } from 'chai';
+
+import { offset_at_position, position_at_offset } from './positioning';
 
 describe('positionAtOffset', () => {
   it('works with single line', () => {

--- a/packages/jupyterlab-lsp/src/positioning.ts
+++ b/packages/jupyterlab-lsp/src/positioning.ts
@@ -1,5 +1,5 @@
-import * as CodeMirror from 'codemirror';
 import { CodeEditor } from '@jupyterlab/codeeditor';
+import type * as CodeMirror from 'codemirror';
 
 /**
  * is_* attributes are there only to enforce strict interface type checking

--- a/packages/jupyterlab-lsp/src/tokens.ts
+++ b/packages/jupyterlab-lsp/src/tokens.ts
@@ -1,27 +1,28 @@
-import { ISignal, Signal } from '@lumino/signaling';
+import { IWidgetTracker } from '@jupyterlab/apputils';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { ServerConnection } from '@jupyterlab/services';
+import { Token } from '@lumino/coreutils';
+import { ISignal, Signal } from '@lumino/signaling';
 
 import * as SCHEMA from './_schema';
 import { WidgetAdapter } from './adapters/adapter';
-import { Token } from '@lumino/coreutils';
-import { IFeatureOptions, ILSPExtension, LSPExtension } from './index';
-import { WidgetAdapterManager } from './adapter_manager';
-import { IEditorName, IFeature } from './feature';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { IVirtualEditor } from './virtual/editor';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { IWidgetTracker } from '@jupyterlab/apputils';
 import {
   CommandEntryPoint,
   ContextCommandManager,
   IContextMenuOptions
 } from './command_manager';
-import IEditor = CodeEditor.IEditor;
 import {
   IForeignCodeExtractor,
   IForeignCodeExtractorsRegistry
 } from './extractors/types';
+import { IEditorName, IFeature } from './feature';
 import { LanguageIdentifier } from './lsp';
+import { IVirtualEditor } from './virtual/editor';
+
+import { IFeatureOptions, ILSPExtension, LSPExtension } from './index';
+
+import IEditor = CodeEditor.IEditor;
 
 export type TLanguageServerId = string;
 export type TLanguageId = string;
@@ -130,11 +131,11 @@ export interface IAdapterTypeOptions<T extends IDocumentWidget> {
 
 export interface ILSPAdapterManager {
   adapterTypeAdded: Signal<
-    WidgetAdapterManager,
+    ILSPAdapterManager,
     IAdapterTypeOptions<IDocumentWidget>
   >;
-  adapterChanged: Signal<WidgetAdapterManager, WidgetAdapter<IDocumentWidget>>;
-  adapterDisposed: Signal<WidgetAdapterManager, WidgetAdapter<IDocumentWidget>>;
+  adapterChanged: Signal<ILSPAdapterManager, WidgetAdapter<IDocumentWidget>>;
+  adapterDisposed: Signal<ILSPAdapterManager, WidgetAdapter<IDocumentWidget>>;
   currentAdapter: WidgetAdapter<IDocumentWidget>;
   isAnyActive: () => boolean;
   registerExtension(extension: LSPExtension): void;

--- a/packages/jupyterlab-lsp/src/transclusions/defaults.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/defaults.ts
@@ -1,8 +1,9 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+
+import { IPYTHON_TRANSCLUSIONS } from './ipython';
+import { IPYTHON_BIGQUERY_TRANSCLUSIONS } from './ipython-bigquery';
 import { IPYTHON_RPY2_TRANSCLUSIONS } from './ipython-rpy2';
 import { IPYTHON_SQL_TRANSCLUSIONS } from './ipython-sql';
-import { IPYTHON_BIGQUERY_TRANSCLUSIONS } from './ipython-bigquery';
-import { IPYTHON_TRANSCLUSIONS } from './ipython';
 
 export const DEFAULT_TRANSCLUSIONS: JupyterFrontEndPlugin<void>[] = [
   IPYTHON_RPY2_TRANSCLUSIONS,

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.spec.ts
@@ -1,7 +1,9 @@
-import { VirtualDocument } from '../../virtual/document';
 import { expect } from 'chai';
-import { foreign_code_extractors } from './extractors';
+
 import { extract_code, get_the_only_virtual } from '../../extractors/testutils';
+import { VirtualDocument } from '../../virtual/document';
+
+import { foreign_code_extractors } from './extractors';
 
 describe('Bigquery SQL extractors', () => {
   let document: VirtualDocument;

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.ts
@@ -1,5 +1,5 @@
-import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 import { RegExpForeignCodeExtractor } from '../../extractors/regexp';
+import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 
 export const SQL_URL_PATTERN = '(?:(?:.*?)://(?:.*))';
 // note: -a/--connection_arguments and -f/--file are not supported yet

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/index.ts
@@ -1,5 +1,7 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+
 import { ILSPCodeExtractorsManager, PLUGIN_ID } from '../../tokens';
+
 import { foreign_code_extractors } from './extractors';
 
 /**

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
@@ -1,12 +1,14 @@
-import { VirtualDocument } from '../../virtual/document';
 import { expect } from 'chai';
-import { foreign_code_extractors } from './extractors';
+
 import {
   extract_code,
   get_the_only_pair,
   get_the_only_virtual,
   wrap_in_python_lines
 } from '../../extractors/testutils';
+import { VirtualDocument } from '../../virtual/document';
+
+import { foreign_code_extractors } from './extractors';
 
 describe('IPython rpy2 extractors', () => {
   let document: VirtualDocument;

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
@@ -1,6 +1,7 @@
-import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 import { RegExpForeignCodeExtractor } from '../../extractors/regexp';
-import { extract_r_args, rpy2_args_pattern, RPY2_MAX_ARGS } from './rpy2';
+import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
+
+import { RPY2_MAX_ARGS, extract_r_args, rpy2_args_pattern } from './rpy2';
 
 function create_rpy_code_extractor(strip_leading_space: boolean) {
   function rpy2_code_extractor(match: string, ...args: string[]) {

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/index.ts
@@ -1,6 +1,8 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { ILSPCodeExtractorsManager, PLUGIN_ID } from '../../tokens';
+
 import { ILSPCodeOverridesManager } from '../../overrides/tokens';
+import { ILSPCodeExtractorsManager, PLUGIN_ID } from '../../tokens';
+
 import { foreign_code_extractors } from './extractors';
 import { overrides } from './overrides';
 

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
@@ -1,6 +1,8 @@
-import { ReversibleOverridesMap } from '../../overrides/maps';
-import { overrides } from './overrides';
 import { expect } from 'chai';
+
+import { ReversibleOverridesMap } from '../../overrides/maps';
+
+import { overrides } from './overrides';
 
 let R_CELL_MAGIC = `%%R
 print(1)

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.ts
@@ -1,12 +1,13 @@
 import { IScopedCodeOverride } from '../../overrides/tokens';
+import { LINE_MAGIC_PREFIX } from '../ipython/overrides';
+
 import {
+  RPY2_MAX_ARGS,
   parse_r_args,
   rpy2_args_pattern,
-  RPY2_MAX_ARGS,
   rpy2_reverse_pattern,
   rpy2_reverse_replacement
 } from './rpy2';
-import { LINE_MAGIC_PREFIX } from '../ipython/overrides';
 
 export let overrides: IScopedCodeOverride[] = [
   {

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.spec.ts
@@ -1,11 +1,13 @@
-import { VirtualDocument } from '../../virtual/document';
 import { expect } from 'chai';
-import { foreign_code_extractors, SQL_URL_PATTERN } from './extractors';
+
 import {
   extract_code,
   get_the_only_virtual,
   wrap_in_python_lines
 } from '../../extractors/testutils';
+import { VirtualDocument } from '../../virtual/document';
+
+import { SQL_URL_PATTERN, foreign_code_extractors } from './extractors';
 
 describe('IPython SQL extractors', () => {
   let document: VirtualDocument;

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.ts
@@ -1,5 +1,5 @@
-import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 import { RegExpForeignCodeExtractor } from '../../extractors/regexp';
+import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 
 export const SQL_URL_PATTERN = '(?:(?:.*?)://(?:.*))';
 // note: -a/--connection_arguments and -f/--file are not supported yet

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/index.ts
@@ -1,5 +1,7 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+
 import { ILSPCodeExtractorsManager, PLUGIN_ID } from '../../tokens';
+
 import { foreign_code_extractors } from './extractors';
 
 /**

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.spec.ts
@@ -1,7 +1,9 @@
-import { VirtualDocument } from '../../virtual/document';
 import { expect } from 'chai';
-import { foreign_code_extractors } from './extractors';
+
 import { extract_code, get_the_only_virtual } from '../../extractors/testutils';
+import { VirtualDocument } from '../../virtual/document';
+
+import { foreign_code_extractors } from './extractors';
 
 describe('IPython extractors', () => {
   let document: VirtualDocument;

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.ts
@@ -1,5 +1,5 @@
-import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 import { RegExpForeignCodeExtractor } from '../../extractors/regexp';
+import { IForeignCodeExtractorsRegistry } from '../../extractors/types';
 
 export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
   // general note: to match new lines use [^] instead of dot, unless the target is ES2018, then use /s

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/index.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/index.ts
@@ -1,7 +1,9 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { ILSPCodeExtractorsManager, PLUGIN_ID } from '../../tokens';
-import { foreign_code_extractors } from './extractors';
+
 import { ILSPCodeOverridesManager } from '../../overrides/tokens';
+import { ILSPCodeExtractorsManager, PLUGIN_ID } from '../../tokens';
+
+import { foreign_code_extractors } from './extractors';
 import { overrides } from './overrides';
 
 export const IPYTHON_TRANSCLUSIONS: JupyterFrontEndPlugin<void> = {

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/overrides.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+
 import { ReversibleOverridesMap } from '../../overrides/maps';
+
 import { overrides } from './overrides';
 
 const CELL_MAGIC_EXISTS = `%%MAGIC

--- a/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/codemirror_editor.ts
@@ -1,26 +1,28 @@
-import * as CodeMirror from 'codemirror';
-import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { CodeEditor } from '@jupyterlab/codeeditor';
-import { IEditorName } from '../feature';
-import {
-  IBlockAddedInfo,
-  ICodeBlockOptions,
-  UpdateManager,
-  VirtualDocument
-} from './document';
-import { IForeignCodeExtractorsRegistry } from '../extractors/types';
+import { CodeMirrorEditor } from '@jupyterlab/codemirror';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
 import { Signal } from '@lumino/signaling';
+import type * as CodeMirror from 'codemirror';
+
+import { IEditorChangedData, WidgetAdapter } from '../adapters/adapter';
+import { IForeignCodeExtractorsRegistry } from '../extractors/types';
+import { IEditorName } from '../feature';
 import {
   IEditorPosition,
   IRootPosition,
   ISourcePosition,
   IVirtualPosition
 } from '../positioning';
-import { IEditorChange, IVirtualEditor, IWindowCoordinates } from './editor';
-import { IEditorChangedData, WidgetAdapter } from '../adapters/adapter';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
-import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { ILSPLogConsole, ILSPVirtualEditorManager, PLUGIN_ID } from '../tokens';
+
+import {
+  IBlockAddedInfo,
+  ICodeBlockOptions,
+  UpdateManager,
+  VirtualDocument
+} from './document';
+import { IEditorChange, IVirtualEditor, IWindowCoordinates } from './editor';
 
 export type CodeMirrorHandler = (
   instance: CodeMirrorVirtualEditor,

--- a/packages/jupyterlab-lsp/src/virtual/console.ts
+++ b/packages/jupyterlab-lsp/src/virtual/console.ts
@@ -1,12 +1,13 @@
 import '../../style/console.css';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { ILogConsoleCore, ILSPLogConsole, PLUGIN_ID } from '../tokens';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
+import { Signal } from '@lumino/signaling';
+
 import {
   LanguageServer as LSPSettings,
   LoggingConsoleVerbosityLevel
 } from '../_plugin';
-import { Signal } from '@lumino/signaling';
+import { ILSPLogConsole, ILogConsoleCore, PLUGIN_ID } from '../tokens';
 
 interface ILogConsoleImplementation extends ILogConsoleCore {
   dispose(): void;

--- a/packages/jupyterlab-lsp/src/virtual/document.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.spec.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai';
-import { is_within_range, VirtualDocument } from './document';
-import { ISourcePosition, IVirtualPosition } from '../positioning';
 import { CodeEditor } from '@jupyterlab/codeeditor';
+import { expect } from 'chai';
+
+import { ISourcePosition, IVirtualPosition } from '../positioning';
 import { foreign_code_extractors } from '../transclusions/ipython-rpy2/extractors';
+
+import { VirtualDocument, is_within_range } from './document';
+
 import Mock = jest.Mock;
 
 let R_LINE_MAGICS = `%R df = data.frame()

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -1,24 +1,26 @@
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { Signal } from '@lumino/signaling';
+import { IDocumentInfo } from 'lsp-ws-connection/src';
+
+import { DocumentConnectionManager } from '../connection_manager';
 import {
   IForeignCodeExtractor,
   IForeignCodeExtractorsRegistry
 } from '../extractors/types';
+import { LanguageIdentifier } from '../lsp';
+import { ReversibleOverridesMap } from '../overrides/maps';
 import { ICodeOverridesRegistry } from '../overrides/tokens';
-import { DefaultMap, until_ready } from '../utils';
-import { Signal } from '@lumino/signaling';
-import { CodeEditor } from '@jupyterlab/codeeditor';
 import {
   IEditorPosition,
   ISourcePosition,
   IVirtualPosition
 } from '../positioning';
-import { IDocumentInfo } from 'lsp-ws-connection/src';
-
-import { DocumentConnectionManager } from '../connection_manager';
-import IRange = CodeEditor.IRange;
-import { ReversibleOverridesMap } from '../overrides/maps';
-import { LanguageIdentifier } from '../lsp';
 import { ILSPLogConsole } from '../tokens';
+import { DefaultMap, until_ready } from '../utils';
+
 import { BrowserConsole } from './console';
+
+import IRange = CodeEditor.IRange;
 
 type language = string;
 

--- a/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editor.spec.ts
@@ -1,17 +1,19 @@
-import { expect } from 'chai';
-import { RegExpForeignCodeExtractor } from '../extractors/regexp';
-import { IRootPosition } from '../positioning';
+import { CodeEditor } from '@jupyterlab/codeeditor';
 import { PageConfig } from '@jupyterlab/coreutils';
+import { expect } from 'chai';
+
 import { DocumentConnectionManager } from '../connection_manager';
 import {
   FileEditorTestEnvironment,
   MockLanguageServerManager,
   NotebookTestEnvironment
 } from '../editor_integration/testutils';
-import { CodeEditor } from '@jupyterlab/codeeditor';
+import { RegExpForeignCodeExtractor } from '../extractors/regexp';
 import { IForeignCodeExtractorsRegistry } from '../extractors/types';
-import { VirtualDocument } from './document';
+import { IRootPosition } from '../positioning';
+
 import { BrowserConsole } from './console';
+import { VirtualDocument } from './document';
 
 describe('VirtualEditor', () => {
   let r_line_extractor = new RegExpForeignCodeExtractor({

--- a/packages/jupyterlab-lsp/src/virtual/editor.ts
+++ b/packages/jupyterlab-lsp/src/virtual/editor.ts
@@ -1,22 +1,25 @@
-import { VirtualDocument } from './document';
+import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { IDocumentWidget } from '@jupyterlab/docregistry';
+import { Signal } from '@lumino/signaling';
+
+import { WidgetAdapter } from '../adapters/adapter';
+import { IEditorName } from '../feature';
 import {
   IEditorPosition,
   IRootPosition,
   ISourcePosition,
   IVirtualPosition
 } from '../positioning';
-import { Signal } from '@lumino/signaling';
-import { CodeEditor } from '@jupyterlab/codeeditor';
-import { IEditorName } from '../feature';
-import IEditor = CodeEditor.IEditor;
-import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import {
-  IVirtualEditorType,
   ILSPVirtualEditorManager,
+  IVirtualEditorType,
   PLUGIN_ID
 } from '../tokens';
-import { WidgetAdapter } from '../adapters/adapter';
-import { IDocumentWidget } from '@jupyterlab/docregistry';
+
+import { VirtualDocument } from './document';
+
+import IEditor = CodeEditor.IEditor;
 
 export interface IWindowCoordinates {
   /**

--- a/packages/lsp-ws-connection/src/test/connection.test.ts
+++ b/packages/lsp-ws-connection/src/test/connection.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as lsProtocol from 'vscode-languageserver-protocol';
+
 import { LspWsConnection } from '..';
 
 const serverUri = 'ws://localhost:8080';

--- a/packages/lsp-ws-connection/src/test/mock-connection.ts
+++ b/packages/lsp-ws-connection/src/test/mock-connection.ts
@@ -1,4 +1,5 @@
 import * as sinon from 'sinon';
+
 import { ILspConnection } from '..';
 
 interface IListeners {

--- a/packages/lsp-ws-connection/src/test/server-capability-registration.test.ts
+++ b/packages/lsp-ws-connection/src/test/server-capability-registration.test.ts
@@ -4,6 +4,7 @@ import {
   ServerCapabilities,
   Unregistration
 } from 'vscode-languageserver-protocol';
+
 import {
   registerServerCapability,
   unregisterServerCapability

--- a/packages/lsp-ws-connection/src/ws-connection.ts
+++ b/packages/lsp-ws-connection/src/ws-connection.ts
@@ -1,22 +1,24 @@
 import * as events from 'events';
+
+import * as protocol from 'vscode-languageserver-protocol';
 import {
   CompletionItemTag,
   LocationLink
 } from 'vscode-languageserver-protocol';
-import * as protocol from 'vscode-languageserver-protocol';
-import { ConsoleLogger, listen, MessageConnection } from 'vscode-ws-jsonrpc';
+import { ConsoleLogger, MessageConnection, listen } from 'vscode-ws-jsonrpc';
+
 import {
   registerServerCapability,
   unregisterServerCapability
 } from './server-capability-registration';
 import {
+  AnyCompletion,
+  AnyLocation,
+  IDocumentInfo,
   ILspConnection,
   ILspOptions,
   IPosition,
-  ITokenInfo,
-  IDocumentInfo,
-  AnyLocation,
-  AnyCompletion
+  ITokenInfo
 } from './types';
 
 /**

--- a/packages/metapackage/src/index.ts
+++ b/packages/metapackage/src/index.ts
@@ -1,7 +1,7 @@
 import '@krassowski/code-jumpers';
 import '@krassowski/completion-theme';
-import '@krassowski/jupyterlab-lsp-example-extractor';
 import '@krassowski/jupyterlab-lsp';
+import '@krassowski/jupyterlab-lsp-example-extractor';
 import '@krassowski/theme-material';
 import '@krassowski/theme-vscode';
 import 'lsp-ws-connection';

--- a/packages/theme-material/src/index.ts
+++ b/packages/theme-material/src/index.ts
@@ -1,36 +1,36 @@
+import '../style/completer.css';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import {
   ICompletionIconSet,
   ICompletionTheme,
   ILSPCompletionThemeManager
 } from '@krassowski/completion-theme/lib/types';
-import '../style/completer.css';
 
+import alpha_t_over_code from '../style/icons/alpha-t-and-code.svg';
 import alphabetical from '../style/icons/alphabetical.svg';
-import sitemap from '../style/icons/sitemap.svg';
-import palette from '../style/icons/palette-outline.svg';
-import plus_minus from '../style/icons/plus-minus-variant.svg';
 import beaker from '../style/icons/beaker-outline.svg';
-import module from '../style/icons/package-variant-closed.svg';
-import func from '../style/icons/function.svg';
-import func_variant from '../style/icons/function-variant.svg';
-import connection from '../style/icons/transit-connection-horizontal.svg';
-import value from '../style/icons/text.svg';
-import list_numbered from '../style/icons/format-list-numbered-rtl.svg';
-import variable from '../style/icons/checkbox-blank-outline.svg';
+import snippet from '../style/icons/border-none-variant.svg';
 import field from '../style/icons/checkbox-blank-circle-outline.svg';
-import hammer_wrench from '../style/icons/hammer-wrench.svg';
-import wrench from '../style/icons/wrench.svg';
+import variable from '../style/icons/checkbox-blank-outline.svg';
 import file from '../style/icons/file-outline.svg';
 import file_replace from '../style/icons/file-replace-outline.svg';
-import folder from '../style/icons/folder-outline.svg';
-import number from '../style/icons/numeric.svg';
-import shield from '../style/icons/shield-outline.svg';
 import structure from '../style/icons/file-tree.svg';
 import lightning from '../style/icons/flash-outline.svg';
+import folder from '../style/icons/folder-outline.svg';
+import list_numbered from '../style/icons/format-list-numbered-rtl.svg';
+import func_variant from '../style/icons/function-variant.svg';
+import func from '../style/icons/function.svg';
+import hammer_wrench from '../style/icons/hammer-wrench.svg';
 import key from '../style/icons/key.svg';
-import snippet from '../style/icons/border-none-variant.svg';
-import alpha_t_over_code from '../style/icons/alpha-t-and-code.svg';
+import number from '../style/icons/numeric.svg';
+import module from '../style/icons/package-variant-closed.svg';
+import palette from '../style/icons/palette-outline.svg';
+import plus_minus from '../style/icons/plus-minus-variant.svg';
+import shield from '../style/icons/shield-outline.svg';
+import sitemap from '../style/icons/sitemap.svg';
+import value from '../style/icons/text.svg';
+import connection from '../style/icons/transit-connection-horizontal.svg';
+import wrench from '../style/icons/wrench.svg';
 
 const default_set: ICompletionIconSet = {
   Text: alphabetical,

--- a/packages/theme-vscode/src/index.ts
+++ b/packages/theme-vscode/src/index.ts
@@ -1,64 +1,61 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
-import '../style/completer.css';
-
-/**
- * Light theme variants
- */
-import symbol_string from '../style/icons/light/symbol-string.svg';
-import symbol_method from '../style/icons/light/symbol-method.svg';
-import symbol_field from '../style/icons/light/symbol-field.svg';
-import symbol_variable from '../style/icons/light/symbol-variable.svg';
-import symbol_class from '../style/icons/light/symbol-class.svg';
-import symbol_interface from '../style/icons/light/symbol-interface.svg';
-import json from '../style/icons/light/json.svg';
-import symbol_property from '../style/icons/light/symbol-property.svg';
-import symbol_ruler from '../style/icons/light/symbol-ruler.svg';
-import value from '../style/icons/light/note.svg';
-import symbol_enumerator from '../style/icons/light/symbol-enumerator.svg';
-import symbol_keyword from '../style/icons/light/symbol-keyword.svg';
-import symbol_snippet from '../style/icons/light/symbol-snippet.svg';
-import symbol_color from '../style/icons/light/symbol-color.svg';
-import file from '../style/icons/light/file.svg';
-import references from '../style/icons/light/references.svg';
-import folder from '../style/icons/light/folder.svg';
-import symbol_enumerator_member from '../style/icons/light/symbol-enumerator-member.svg';
-import symbol_constant from '../style/icons/light/symbol-constant.svg';
-import symbol_structure from '../style/icons/light/symbol-structure.svg';
-import symbol_event from '../style/icons/light/symbol-event.svg';
-import symbol_operator from '../style/icons/light/symbol-operator.svg';
-import symbol_parameter from '../style/icons/light/symbol-parameter.svg';
-
-/**
- * Dark theme variants
- */
-import dark_symbol_string from '../style/icons/dark/symbol-string.svg';
-import dark_symbol_method from '../style/icons/dark/symbol-method.svg';
-import dark_symbol_field from '../style/icons/dark/symbol-field.svg';
-import dark_symbol_variable from '../style/icons/dark/symbol-variable.svg';
-import dark_symbol_class from '../style/icons/dark/symbol-class.svg';
-import dark_symbol_interface from '../style/icons/dark/symbol-interface.svg';
-import dark_json from '../style/icons/dark/json.svg';
-import dark_symbol_property from '../style/icons/dark/symbol-property.svg';
-import dark_symbol_ruler from '../style/icons/dark/symbol-ruler.svg';
-import dark_value from '../style/icons/dark/note.svg';
-import dark_symbol_enumerator from '../style/icons/dark/symbol-enumerator.svg';
-import dark_symbol_keyword from '../style/icons/dark/symbol-keyword.svg';
-import dark_symbol_snippet from '../style/icons/dark/symbol-snippet.svg';
-import dark_symbol_color from '../style/icons/dark/symbol-color.svg';
-import dark_file from '../style/icons/dark/file.svg';
-import dark_references from '../style/icons/dark/references.svg';
-import dark_folder from '../style/icons/dark/folder.svg';
-import dark_symbol_enumerator_member from '../style/icons/dark/symbol-enumerator-member.svg';
-import dark_symbol_constant from '../style/icons/dark/symbol-constant.svg';
-import dark_symbol_structure from '../style/icons/dark/symbol-structure.svg';
-import dark_symbol_event from '../style/icons/dark/symbol-event.svg';
-import dark_symbol_operator from '../style/icons/dark/symbol-operator.svg';
-import dark_symbol_parameter from '../style/icons/dark/symbol-parameter.svg';
 import {
   ICompletionIconSet,
   ICompletionTheme,
   ILSPCompletionThemeManager
 } from '@krassowski/completion-theme/lib/types';
+
+import '../style/completer.css';
+import dark_file from '../style/icons/dark/file.svg';
+import dark_folder from '../style/icons/dark/folder.svg';
+import dark_json from '../style/icons/dark/json.svg';
+import dark_value from '../style/icons/dark/note.svg';
+import dark_references from '../style/icons/dark/references.svg';
+import dark_symbol_class from '../style/icons/dark/symbol-class.svg';
+import dark_symbol_color from '../style/icons/dark/symbol-color.svg';
+import dark_symbol_constant from '../style/icons/dark/symbol-constant.svg';
+import dark_symbol_enumerator_member from '../style/icons/dark/symbol-enumerator-member.svg';
+import dark_symbol_enumerator from '../style/icons/dark/symbol-enumerator.svg';
+import dark_symbol_event from '../style/icons/dark/symbol-event.svg';
+import dark_symbol_field from '../style/icons/dark/symbol-field.svg';
+import dark_symbol_interface from '../style/icons/dark/symbol-interface.svg';
+import dark_symbol_keyword from '../style/icons/dark/symbol-keyword.svg';
+import dark_symbol_method from '../style/icons/dark/symbol-method.svg';
+import dark_symbol_operator from '../style/icons/dark/symbol-operator.svg';
+import dark_symbol_parameter from '../style/icons/dark/symbol-parameter.svg';
+import dark_symbol_property from '../style/icons/dark/symbol-property.svg';
+import dark_symbol_ruler from '../style/icons/dark/symbol-ruler.svg';
+import dark_symbol_snippet from '../style/icons/dark/symbol-snippet.svg';
+import dark_symbol_string from '../style/icons/dark/symbol-string.svg';
+import dark_symbol_structure from '../style/icons/dark/symbol-structure.svg';
+import dark_symbol_variable from '../style/icons/dark/symbol-variable.svg';
+import file from '../style/icons/light/file.svg';
+import folder from '../style/icons/light/folder.svg';
+import json from '../style/icons/light/json.svg';
+import value from '../style/icons/light/note.svg';
+import references from '../style/icons/light/references.svg';
+import symbol_class from '../style/icons/light/symbol-class.svg';
+import symbol_color from '../style/icons/light/symbol-color.svg';
+import symbol_constant from '../style/icons/light/symbol-constant.svg';
+import symbol_enumerator_member from '../style/icons/light/symbol-enumerator-member.svg';
+import symbol_enumerator from '../style/icons/light/symbol-enumerator.svg';
+import symbol_event from '../style/icons/light/symbol-event.svg';
+import symbol_field from '../style/icons/light/symbol-field.svg';
+import symbol_interface from '../style/icons/light/symbol-interface.svg';
+import symbol_keyword from '../style/icons/light/symbol-keyword.svg';
+import symbol_method from '../style/icons/light/symbol-method.svg';
+import symbol_operator from '../style/icons/light/symbol-operator.svg';
+import symbol_parameter from '../style/icons/light/symbol-parameter.svg';
+import symbol_property from '../style/icons/light/symbol-property.svg';
+import symbol_ruler from '../style/icons/light/symbol-ruler.svg';
+import symbol_snippet from '../style/icons/light/symbol-snippet.svg';
+import symbol_string from '../style/icons/light/symbol-string.svg';
+import symbol_structure from '../style/icons/light/symbol-structure.svg';
+import symbol_variable from '../style/icons/light/symbol-variable.svg';
+
+/**
+ * Dark theme variants
+ */
 
 const light_set: ICompletionIconSet = {
   Text: symbol_string,

--- a/requirements/atest.txt
+++ b/requirements/atest.txt
@@ -1,5 +1,5 @@
 # acceptance test dependencies for jupyter_lsp
 -r ./lab.txt
 bs4
-robotframework >=3.2
+robotframework >=4
 robotframework-seleniumlibrary

--- a/requirements/atest.yml
+++ b/requirements/atest.yml
@@ -6,6 +6,6 @@ channels:
 
 dependencies:
   - robotframework-seleniumlibrary
-  - robotframework >=3.2
+  - robotframework >=4
   - firefox
   - geckodriver

--- a/requirements/github-actions.yml
+++ b/requirements/github-actions.yml
@@ -33,7 +33,7 @@ dependencies:
   - bs4
   - firefox
   - geckodriver
-  - robotframework >=3.2
+  - robotframework >=4
   - robotframework-seleniumlibrary
   # TODO: remove when jedi vs IPython vs python-language-server is resolved
   - jedi <0.18

--- a/requirements/lint.yml
+++ b/requirements/lint.yml
@@ -9,5 +9,5 @@ dependencies:
   - isort
   - mypy
   - robotframework-lint >=1.1
-  - robotframework >=3.2
+  - robotframework >=4
   - pytest-tornasync

--- a/scripts/distcheck.py
+++ b/scripts/distcheck.py
@@ -1,0 +1,73 @@
+"""sanity checks for webpack vs python packaging"""
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+# known packages that cause problems if vendored in webpack
+BAD_CHUNK_PATTERNS = {
+    (
+        "codemirror_codemirror",
+        "codemirror_lib",
+    ): """
+    Please ensure is CodeMirror is imported by type, e.g.
+
+        import type * as CodeMirror from 'codemirror'
+
+    see https://github.com/krassowski/jupyterlab-lsp/issues/575
+    """
+}
+
+# canary file created by a debug build
+BUILD_LOG = "build_log.json"
+
+# where the packages are
+PY_PACKAGES = ROOT / "python_packages"
+
+# just one, for now
+LABEXTENSION_PATHS = [
+    "jupyterlab_lsp/jupyterlab_lsp/labextensions/@krassowski/jupyterlab-lsp"
+]
+
+
+def check_webpack():
+    """verify certain packages would not be bundled
+
+    this it to avoid distributing private copies of modules
+    """
+    for path in LABEXTENSION_PATHS:
+        build_log = PY_PACKAGES / path / BUILD_LOG
+        print("checking for", build_log)
+        if not build_log.exists():
+            print(build_log, "missing, doing verbose debug build")
+            subprocess.check_call(["jlpm", "lerna", "run", "build:labextension:dev"])
+            break
+
+    bad = []
+    good = 0
+
+    for path in LABEXTENSION_PATHS:
+        for asset in (PY_PACKAGES / path / "static").rglob("*.js"):
+            for patterns, msg in BAD_CHUNK_PATTERNS.items():
+                for pattern in patterns:
+                    if pattern in str(asset):
+                        print(">>> Found", pattern, "in", asset, "\n", msg)
+                        bad += [asset]
+            if asset not in bad:
+                good += 1
+
+    if not good:
+        print("didn't find any js assets, probably broken")
+        return 1
+
+    print(f"{good} assets looked good vs", sum(BAD_CHUNK_PATTERNS.keys(), tuple()))
+
+    if bad:
+        print(f"{bad} assets appear to be on the bad list", BAD_CHUNK_PATTERNS)
+
+    return len(bad)
+
+
+if __name__ == "__main__":
+    sys.exit(check_webpack())

--- a/scripts/distcheck.py
+++ b/scripts/distcheck.py
@@ -10,10 +10,9 @@ BAD_CHUNK_PATTERNS = {
     (
         "codemirror_codemirror",
         "codemirror_lib",
-    ): """
-    Please ensure is CodeMirror is imported by type, e.g.
+    ): """Please ensure CodeMirror is imported by type _only_, e.g.
 
-        import type * as CodeMirror from 'codemirror'
+        import type * as CodeMirror from 'codemirror';
 
     see https://github.com/krassowski/jupyterlab-lsp/issues/575
     """

--- a/yarn.lock
+++ b/yarn.lock
@@ -1755,10 +1755,10 @@
 "@krassowski/jupyterlab-lsp-example-extractor@file:packages/_example-extractor":
   version "0.0.0"
   dependencies:
-    "@krassowski/jupyterlab-lsp" "^3.4"
+    "@krassowski/jupyterlab-lsp" "^3.5"
 
 "@krassowski/jupyterlab-lsp@file:packages/jupyterlab-lsp":
-  version "3.4.1"
+  version "3.5.0"
   dependencies:
     "@krassowski/code-jumpers" "~1.0.0"
     "@krassowski/completion-theme" "~2.0.0"


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/jupyterlab-lsp/gh-575-avoid-private-cm?urlpath=lab)

## References

- fixes #575

## Code changes

- [x] uses `import type` for most/all `import 'codemirror'`
  - _should_ help the compiler/webpack know we don't want another codemirror
- [x] uses `ICodeMirror.CodeMirror` for the `CMSyntaxHighlighting.get_mode`
  - this looked like the only case of actually calling a "dirty" static method
  - however, we may want to hoist `codeMirror` to the baseline `lab_integration`...
- [x] add the `import-plugin`  plugin for eslint to see if everything's good
  - this is _way_ more aggresssive than the default, but at least _can_ fix most of the issues (let it run a few times with tweaks)
  - we lot some comments to sorting
  - collapsed some duplicated imports
  - doesn't like our `export class` and `export namespace` pun: i never did much, either, but here we are
  - apparently we _have_ been making lots of cyclical imports... maybe they're just types, but yeah. ~200 errors
    - had to disable for now
  - would like some way to say, _only allow importing `codemirror` with `import type`_, haven't found yet
  - does require building with `tsc` (and all the schema stuff) _before_ linting... 
    - [x] updated `jlpm bootstrap` as such
- [x] add a test to verify we aren't shipping codemirror
  - i am not exactly sure how to do this... when it does a `dev` build, the `node_modules__codemirror__codemirror_js` shows up... but perhaps there's a way to look at a production `remoteEntry` and find magic strings...

## User-facing changes

- n/a

## Backwards-incompatible changes

- n/a

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [x] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
