### PR TITLE
patch jupyter_lsp-1.1.4 for 'native' Windows users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@
 
   - fixed name of jupyterlab-lsp package displayed in JupyterLab UI ([#570], thanks @marimeireles)
   - removed vendored CodeMirror from distribution ([#576])
+  - fix encoding on Windows for non-conda installs ([#580], thanks @stonebig)
 
 [#557]: https://github.com/krassowski/jupyterlab-lsp/pull/557
 [#570]: https://github.com/krassowski/jupyterlab-lsp/pull/570
 [#576]: https://github.com/krassowski/jupyterlab-lsp/pull/576
+[#580]: https://github.com/krassowski/jupyterlab-lsp/pull/580
 
 ### `@krassowski/jupyterlab-lsp 3.5.0` (2020-03-22)
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
@@ -41,7 +41,7 @@ class EditableFile:
         lines = [""]
         try:
             # TODO: what to do about bad encoding reads?
-            lines = self.path.read_text().splitlines()
+            lines = self.path.read_text(encoding='utf-8').splitlines()
         except FileNotFoundError:
             pass
         return lines
@@ -49,7 +49,7 @@ class EditableFile:
     @run_on_executor
     def write_lines(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text("\n".join(self.lines))
+        self.path.write_text("\n".join(self.lines), encoding='utf-8')
 
     @staticmethod
     def trim(lines: list, character: int, side: int):


### PR DESCRIPTION
on Windows, even if cp1252, a Notebook must be written in utf-8.
Anaconda on Windows is not 'native', so doesn't have the problem.

shall solve https://github.com/krassowski/jupyterlab-lsp/issues/579

<!--
Thanks for contributing to jupyterlab-lsp!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlab/jupyterlab/blob/master/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above).
Use "fixes" and "closes" linking phrases as appropriate. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
