### PR TITLE
Fix a test failing on CI as R got more methods

### DIFF
--- a/atest/05_Features/Completion.robot
+++ b/atest/05_Features/Completion.robot
@@ -267,7 +267,7 @@ Completes Correctly With R Double And Triple Colon
     Completer Should Suggest    .print.via.format
     Select Completer Suggestion    .print.via.format
     Wait Until Keyword Succeeds    40x    0.5s    File Editor Line Should Equal    1    tools::.print.via.format
-    # tripple colon
+    # triple colon
     Place Cursor In File Editor At    4    11
     Trigger Completer
     Completer Should Suggest    .packageName
@@ -289,6 +289,8 @@ Shows Documentation With CompletionItem Resolve
     Wait Until Fully Initialized
     Trigger Completer
     Completer Should Suggest    print.data.frame
+    # if data.frame is not active, activate it (it should be in top 10 on any platform)
+    Activate Completer Suggestion    print.data.frame    max_steps_down=10
     Completer Should Include Documentation    Print a data frame.
     # should remain visible after typing:
     Press Keys    None    efa
@@ -341,6 +343,21 @@ File Editor Line Should Equal
     ${content} =    Get File Editor Content
     ${line} =    Get Line    ${content}    ${line}
     Should Be Equal    ${line}    ${value}
+
+Activate Completer Suggestion
+    [Arguments]    ${text}    ${max_steps_down}=100
+    ${suggestion} =    Set Variable    css:.jp-Completer-item[data-value="${text}"]
+    Wait Until Page Contains Element    ${suggestion}
+    ${active_suggestion} =    Set Variable    css:.jp-mod-active.jp-Completer-item[data-value="${text}"]
+    FOR    ${i}    IN RANGE    ${max_steps_down}
+        Capture Page Screenshot    ${i}-completions.png
+        ${matching_active_elements} =    Get Element Count    ${active_suggestion}
+        LOG    ${matching_active_elements}
+        Exit For Loop If    ${matching_active_elements} == 1
+        Press Keys    None    DOWN
+        Sleep    0.1s
+    END
+    Wait Until Page Contains Element    ${active_suggestion}
 
 Select Completer Suggestion
     [Arguments]    ${text}

--- a/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/virtual_documents_shadow.py
@@ -41,7 +41,7 @@ class EditableFile:
         lines = [""]
         try:
             # TODO: what to do about bad encoding reads?
-            lines = self.path.read_text(encoding='utf-8').splitlines()
+            lines = self.path.read_text(encoding="utf-8").splitlines()
         except FileNotFoundError:
             pass
         return lines
@@ -49,7 +49,7 @@ class EditableFile:
     @run_on_executor
     def write_lines(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text("\n".join(self.lines), encoding='utf-8')
+        self.path.write_text("\n".join(self.lines), encoding="utf-8")
 
     @staticmethod
     def trim(lines: list, character: int, side: int):


### PR DESCRIPTION
R got more methods starting with `data.frame.p`, trying to fix CI.

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above).
Use "fixes" and "closes" linking phrases as appropriate. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
