### PR TITLE
Allow to disable LSP or Kernel completions independently.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### (unreleased)
+
+- Add ability to deactivate Kernel completions or LSP completion through the settings.
+
 ### `jupyter-lsp 1.2.0` (2021-04-26)
 
 - features:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ from the Language Server (in notebook).
 If the kernel is too slow to respond promptly only the Language Server suggestions will be shown (default threshold: 0.6s).
 You can configure the completer to not attempt to fetch the kernel completions if the kernel is busy (skipping the 0.6s timeout).
 
-You can deactivate the kernel suggestions by adding `"kenel"` to the `disableCompletionsFrom` in the `completion` section
-of _Advanced Settings_. Alternatively if you _only_ want kernel completions you can add `"languageServer"` to the same
+You can deactivate the kernel suggestions by adding `"Kernel"` to the `disableCompletionsFrom` in the `completion` section
+of _Advanced Settings_. Alternatively if you _only_ want kernel completions you can add `"LSP"` to the same
 setting; Or add both if you like to code in hardcore mode and get no completions, or if another provider has been added.
 
 ### Rename

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ from the Language Server (in notebook).
 If the kernel is too slow to respond promptly only the Language Server suggestions will be shown (default threshold: 0.6s).
 You can configure the completer to not attempt to fetch the kernel completions if the kernel is busy (skipping the 0.6s timeout).
 
+You can deactivate the kernel suggestions by setting the `useKernelCompletions` to `false` in the `completion` section
+of advanced settings. Alternatively if you _only_ want kernel completions you can set `useLspCompletions` to `false`.
+Or both if you like to code in hardcore mode and get no completions.
+
 ### Rename
 
 Rename variables, functions and more, in both: notebooks and the file editor.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ from the Language Server (in notebook).
 If the kernel is too slow to respond promptly only the Language Server suggestions will be shown (default threshold: 0.6s).
 You can configure the completer to not attempt to fetch the kernel completions if the kernel is busy (skipping the 0.6s timeout).
 
-You can deactivate the kernel suggestions by setting the `useKernelCompletions` to `false` in the `completion` section
-of advanced settings. Alternatively if you _only_ want kernel completions you can set `useLspCompletions` to `false`.
-Or both if you like to code in hardcore mode and get no completions.
+You can deactivate the kernel suggestions by adding `"kenel"` to the `disableCompletionsFrom` in the `completion` section
+of _Advanced Settings_. Alternatively if you _only_ want kernel completions you can add `"languageServer"` to the same
+setting; Or add both if you like to code in hardcore mode and get no completions, or if another provider has been added.
 
 ### Rename
 

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -42,7 +42,7 @@
       "description": "The time to wait for the kernel completions suggestions in milliseconds. Set to 0 to disable kernel completions, or to -1 to wait indefinitely (not recommended)."
     },
     "disableCompletionsFrom": {
-      "description": "The sources from which to exclude completion from. Possible values include 'kernel', 'languageServer'.",
+      "description": "The sources from which to exclude completion from. Possible values include 'Kernel', 'LSP'.",
       "type": "array",
       "default": [],
       "uniqueItems": true

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -41,17 +41,11 @@
       "type": "number",
       "description": "The time to wait for the kernel completions suggestions in milliseconds. Set to 0 to disable kernel completions, or to -1 to wait indefinitely (not recommended)."
     },
-    "useKernelCompletions": {
-      "title": "Request Kernel Completion",
-      "type": "boolean",
-      "default": true,
-      "description": "Whether to send completions request to the kernel."
-    },
-    "useLspCompletions": {
-      "title": "Request LSP Completion",
-      "type": "boolean",
-      "default": true,
-      "description": "Whether to send completions request to the lsp server."
+    "disableCompletionsFrom": {
+      "description": "The sources from which to exclude completion from. Possible values include 'kernel', 'languageServer'.",
+      "type": "array",
+      "default": [],
+      "uniqueItems": true
     },
     "waitForBusyKernel": {
       "title": "Wait for kernel if busy",

--- a/packages/jupyterlab-lsp/schema/completion.json
+++ b/packages/jupyterlab-lsp/schema/completion.json
@@ -41,6 +41,18 @@
       "type": "number",
       "description": "The time to wait for the kernel completions suggestions in milliseconds. Set to 0 to disable kernel completions, or to -1 to wait indefinitely (not recommended)."
     },
+    "useKernelCompletions": {
+      "title": "Request Kernel Completion",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to send completions request to the kernel."
+    },
+    "useLspCompletions": {
+      "title": "Request LSP Completion",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to send completions request to the lsp server."
+    },
     "waitForBusyKernel": {
       "title": "Wait for kernel if busy",
       "default": true,

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -80,9 +80,8 @@ export class LSPConnector
 
   protected get use_lsp_completions(): boolean {
     return (
-      this.options.settings.composite.disableCompletionsFrom.indexOf(
-        'LSP'
-      ) == -1
+      this.options.settings.composite.disableCompletionsFrom.indexOf('LSP') ==
+      -1
     );
   }
 

--- a/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
+++ b/packages/jupyterlab-lsp/src/features/completion/completion_handler.ts
@@ -81,7 +81,7 @@ export class LSPConnector
   protected get use_lsp_completions(): boolean {
     return (
       this.options.settings.composite.disableCompletionsFrom.indexOf(
-        'languageServer'
+        'LSP'
       ) == -1
     );
   }
@@ -89,7 +89,7 @@ export class LSPConnector
   protected get use_kernel_completions(): boolean {
     return (
       this.options.settings.composite.disableCompletionsFrom.indexOf(
-        'kernel'
+        'Kernel'
       ) == -1
     );
   }


### PR DESCRIPTION
Some user love LSP for many of its features, but prefer to keep
completions via the kernel.

This adds two boolean flags in the configuration to not send completions
request to LSP and not send completions requests to the kernel.


## References

#440  - I'm not sure how to toggle it on a per-notebook basis; I can likely add local state to LSPConnector which I guess is persisted on a per notebook basis but would welcome guidance on the best place to store that.

## Code changes

- Add 2 boolean to the setting. 
- turns those two booleans into properties on the LSPConnector, 
- when false skip requesting completions for the corresponding source.

## User-facing changes

None by default. User may disable one or two completer sources.

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested - manually for now I can try to add an automatic test. <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [x] documented  <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->


Note: I haven't touched typescript and frontend in years,  so I'm likely doing some things wrong; 