### PR TITLE
Implement console log window messages, update lsp-ws-connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - add ability to deactivate Kernel completions or LSP completion through the settings ([#586], thanks @Carreau)
   - allow to set a priority for LSP server, allowing to choose which server to use when multiple servers are installed ([#588])
   - add auto-detection of pyright server ([#587], thanks @yuntan)
+  - log server messages in user-accessible console ([#606])
+  - old emit-based API of lsp-ws-connection is new deprecated and will be removed in the next major version; please use `serverNotifications`, `clientNotifications`, `clientRequests` and `serverRequests` instead ([#606])
 
 - bug fixes:
 
@@ -14,11 +16,13 @@
 
 - other changes:
   - drop Node 10 (EOL 2 weeks ago) testing on CI, add Node 15 ([#587])
+  - update lsp-ws-connection dependencies ([#606])
 
 [#586]: https://github.com/krassowski/jupyterlab-lsp/pull/586
 [#587]: https://github.com/krassowski/jupyterlab-lsp/pull/587
 [#588]: https://github.com/krassowski/jupyterlab-lsp/pull/588
 [#599]: https://github.com/krassowski/jupyterlab-lsp/pull/599
+[#606]: https://github.com/krassowski/jupyterlab-lsp/pull/606
 
 ### `jupyter-lsp 1.2.0` (2021-04-26)
 

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -62,7 +62,7 @@
     "@krassowski/theme-material": "~2.1.0",
     "@krassowski/theme-vscode": "~2.1.0",
     "lodash.mergewith": "^4.6.1",
-    "lsp-ws-connection": "~0.5.1"
+    "lsp-ws-connection": "~0.6.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.3",
@@ -78,6 +78,7 @@
     "@jupyterlab/docmanager": "^3.0.0",
     "@jupyterlab/docregistry": "^3.0.0",
     "@jupyterlab/fileeditor": "^3.0.0",
+    "@jupyterlab/logconsole": "^3.0.0",
     "@jupyterlab/notebook": "^3.0.0",
     "@jupyterlab/rendermime": "^3.0.0",
     "@jupyterlab/services": "^6.0.0",
@@ -102,7 +103,8 @@
     "react": "^17.0.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.3",
-    "typescript": "~4.1.3"
+    "typescript": "~4.1.3",
+    "vscode-languageserver-protocol": "^3.16.0"
   },
   "peerDependencies": {
     "@jupyterlab/application": "^3.0.0",

--- a/packages/jupyterlab-lsp/schema/plugin.json
+++ b/packages/jupyterlab-lsp/schema/plugin.json
@@ -60,6 +60,19 @@
       "enum": ["debug", "log", "warn", "error"],
       "default": "warn",
       "description": "The verbosity of the console for debugging problems with this extension. Allowed values are: debug, log, warn, error."
+    },
+    "logAllCommunication": {
+      "title": "Log all LSP communication with the LSP servers",
+      "type": "boolean",
+      "default": false,
+      "description": "Whether all messages sent to and received from LSP servers should be logged into the console. To see these messages, set loggingLevel to debug or log. Note: Only messages handled by the new API will be shown."
+    },
+    "setTrace": {
+      "title": "Ask servers to send trace notifications",
+      "type": ["string", "null"],
+      "enum": ["off", "messages", "verbose", null],
+      "default": null,
+      "description": "Whether to ask server to send logs with execution trace (for debugging). To see these messages, set loggingLevel to debug or log. Accepted values are: \"off\", \"messages\", \"verbose\". Servers are allowed to ignore this request."
     }
   },
   "jupyter.lab.shortcuts": []

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -357,7 +357,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
         );
         logger.log({
           type: 'text',
-          data: message.message
+          data: connection.serverIdentifier + ': ' + message.message
         } as ILogPayload);
       }
     );
@@ -371,7 +371,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
         );
         logger.log({
           type: 'text',
-          data: message.message
+          data: connection.serverIdentifier + ': ' + message.message
         } as ILogPayload);
         this.extension.app.commands
           .execute('logconsole:open', {

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -1,4 +1,5 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { CodeEditor } from '@jupyterlab/codeeditor';
 import { DocumentRegistry, IDocumentWidget } from '@jupyterlab/docregistry';
 import { ILogPayload } from '@jupyterlab/logconsole';
@@ -22,9 +23,6 @@ import { IForeignContext, VirtualDocument } from '../virtual/document';
 import { IVirtualEditor } from '../virtual/editor';
 
 import IEditor = CodeEditor.IEditor;
-
-import { Dialog, showDialog } from '@jupyterlab/apputils';
-
 import IButton = Dialog.IButton;
 import createButton = Dialog.createButton;
 
@@ -352,6 +350,17 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     // as it changes the source to the active file afterwards anyways
     const loggerSourceName = virtual_document.uri;
     const logger = this.extension.user_console.getLogger(loggerSourceName);
+
+    data.connection.serverNotifications['$/logTrace'].connect(
+      (connection, message) => {
+        this.console.log(
+          data.connection.serverIdentifier,
+          'trace',
+          virtual_document.uri,
+          message
+        );
+      }
+    );
 
     data.connection.serverNotifications['window/logMessage'].connect(
       (connection, message) => {

--- a/packages/jupyterlab-lsp/src/connection.ts
+++ b/packages/jupyterlab-lsp/src/connection.ts
@@ -2,15 +2,18 @@
 // ISC licence is, quote, "functionally equivalent to the simplified BSD and MIT licenses,
 // but without language deemed unnecessary following the Berne Convention." (Wikipedia).
 // Introduced modifications are BSD licenced, copyright JupyterLab development team.
-import { Signal } from '@lumino/signaling';
+import { ISignal, Signal } from '@lumino/signaling';
 import {
+  AnyCompletion,
+  AnyLocation,
   IDocumentInfo,
   ILspOptions,
   IPosition,
   LspWsConnection
 } from 'lsp-ws-connection';
 import type * as rpc from 'vscode-jsonrpc';
-import type * as lsProtocol from 'vscode-languageserver-protocol';
+import type * as lsp from 'vscode-languageserver-protocol';
+import type { MessageConnection } from 'vscode-ws-jsonrpc';
 
 import { until_ready } from './utils';
 
@@ -18,47 +21,282 @@ interface ILSPOptions extends ILspOptions {
   serverIdentifier?: string;
 }
 
-interface ConnectionSignal<T> extends Signal<LSPConnection, T> {
-  // empty
+/**
+ * Method strings are reproduced here because a non-typing import of
+ * `vscode-languageserver-protocol` is ridiculously expensive.
+ */
+export namespace Method {
+  /** Server notifications */
+  export enum ServerNotification {
+    PUBLISH_DIAGNOSTICS = 'textDocument/publishDiagnostics',
+    SHOW_MESSAGE = 'window/showMessage',
+    LOG_TRACE = '$/logTrace',
+    LOG_MESSAGE = 'window/logMessage'
+  }
+
+  /** Client notifications */
+  export enum ClientNotification {
+    DID_CHANGE = 'textDocument/didChange',
+    DID_CHANGE_CONFIGURATION = 'workspace/didChangeConfiguration',
+    DID_OPEN = 'textDocument/didOpen',
+    DID_SAVE = 'textDocument/didSave',
+    INITIALIZED = 'initialized',
+    SET_TRACE = '$/setTrace'
+  }
+
+  /** Server requests */
+  export enum ServerRequests {
+    REGISTER_CAPABILITY = 'client/registerCapability',
+    SHOW_MESSAGE_REQUEST = 'window/showMessageRequest',
+    UNREGISTER_CAPABILITY = 'client/unregisterCapability'
+  }
+
+  /** Client requests */
+  export enum ClientRequest {
+    COMPLETION = 'textDocument/completion',
+    COMPLETION_ITEM_RESOLVE = 'completionItem/resolve',
+    DEFINITION = 'textDocument/definition',
+    DOCUMENT_HIGHLIGHT = 'textDocument/documentHighlight',
+    DOCUMENT_SYMBOL = 'textDocument/documentSymbol',
+    HOVER = 'textDocument/hover',
+    IMPLEMENTATION = 'textDocument/implementation',
+    INITIALIZE = 'initialize',
+    REFERENCES = 'textDocument/references',
+    RENAME = 'textDocument/rename',
+    SIGNATURE_HELP = 'textDocument/signatureHelp',
+    TYPE_DEFINITION = 'textDocument/typeDefinition'
+  }
 }
 
-interface INamespace {
-  [index: string]: ConnectionSignal<any> | ((params: any) => void);
+export interface IServerNotifyParams {
+  [Method.ServerNotification.LOG_MESSAGE]: lsp.LogMessageParams;
+  [Method.ServerNotification.LOG_TRACE]: rpc.LogTraceParams;
+  [Method.ServerNotification.PUBLISH_DIAGNOSTICS]: lsp.PublishDiagnosticsParams;
+  [Method.ServerNotification.SHOW_MESSAGE]: lsp.ShowMessageParams;
 }
 
-interface ILSPNotifications {
-  $: {
-    logTrace: ConnectionSignal<rpc.LogTraceParams>;
-    setTrace: (params: rpc.SetTraceParams) => void;
-  };
-  window: {
-    showMessage: ConnectionSignal<lsProtocol.ShowMessageParams>;
-    logMessage: ConnectionSignal<lsProtocol.LogMessageParams>;
-  };
-  [index: string]: INamespace;
+export interface IClientNotifyParams {
+  [Method.ClientNotification
+    .DID_CHANGE_CONFIGURATION]: lsp.DidChangeConfigurationParams;
+  [Method.ClientNotification.DID_CHANGE]: lsp.DidChangeTextDocumentParams;
+  [Method.ClientNotification.DID_OPEN]: lsp.DidOpenTextDocumentParams;
+  [Method.ClientNotification.DID_SAVE]: lsp.DidSaveTextDocumentParams;
+  [Method.ClientNotification.INITIALIZED]: lsp.InitializedParams;
+  [Method.ClientNotification.SET_TRACE]: rpc.SetTraceParams;
 }
+
+export interface IServerRequestParams {
+  [Method.ServerRequests.REGISTER_CAPABILITY]: lsp.RegistrationParams;
+  [Method.ServerRequests.SHOW_MESSAGE_REQUEST]: lsp.ShowMessageRequestParams;
+  [Method.ServerRequests.UNREGISTER_CAPABILITY]: lsp.UnregistrationParams;
+}
+
+export interface IServerResult {
+  [Method.ServerRequests.REGISTER_CAPABILITY]: void;
+  [Method.ServerRequests.SHOW_MESSAGE_REQUEST]: lsp.MessageActionItem | null;
+  [Method.ServerRequests.UNREGISTER_CAPABILITY]: void;
+}
+
+export interface IClientRequestParams {
+  [Method.ClientRequest.COMPLETION_ITEM_RESOLVE]: lsp.CompletionItem;
+  [Method.ClientRequest.COMPLETION]: lsp.CompletionParams;
+  [Method.ClientRequest.DEFINITION]: lsp.TextDocumentPositionParams;
+  [Method.ClientRequest.DOCUMENT_HIGHLIGHT]: lsp.TextDocumentPositionParams;
+  [Method.ClientRequest.DOCUMENT_SYMBOL]: lsp.DocumentSymbolParams;
+  [Method.ClientRequest.HOVER]: lsp.TextDocumentPositionParams;
+  [Method.ClientRequest.IMPLEMENTATION]: lsp.TextDocumentPositionParams;
+  [Method.ClientRequest.INITIALIZE]: lsp.InitializeParams;
+  [Method.ClientRequest.REFERENCES]: lsp.ReferenceParams;
+  [Method.ClientRequest.RENAME]: lsp.RenameParams;
+  [Method.ClientRequest.SIGNATURE_HELP]: lsp.TextDocumentPositionParams;
+  [Method.ClientRequest.TYPE_DEFINITION]: lsp.TextDocumentPositionParams;
+}
+
+export interface IClientResult {
+  [Method.ClientRequest.COMPLETION_ITEM_RESOLVE]: lsp.CompletionItem;
+  [Method.ClientRequest.COMPLETION]: AnyCompletion;
+  [Method.ClientRequest.DEFINITION]: AnyLocation;
+  [Method.ClientRequest.DOCUMENT_HIGHLIGHT]: lsp.DocumentHighlight[];
+  [Method.ClientRequest.DOCUMENT_SYMBOL]: lsp.DocumentSymbol[];
+  [Method.ClientRequest.HOVER]: lsp.Hover;
+  [Method.ClientRequest.IMPLEMENTATION]: AnyLocation;
+  [Method.ClientRequest.INITIALIZE]: lsp.InitializeResult;
+  [Method.ClientRequest.REFERENCES]: Location[];
+  [Method.ClientRequest.RENAME]: lsp.WorkspaceEdit;
+  [Method.ClientRequest.SIGNATURE_HELP]: lsp.SignatureHelp;
+  [Method.ClientRequest.TYPE_DEFINITION]: AnyLocation;
+}
+
+export type ServerNotifications<
+  T extends keyof IServerNotifyParams = keyof IServerNotifyParams
+> = {
+  // ISignal does not have emit, which is intended - client cannot emit server notifications.
+  [key in T]: ISignal<LSPConnection, IServerNotifyParams[key]>;
+};
+
+export type ClientNotifications<
+  T extends keyof IClientNotifyParams = keyof IClientNotifyParams
+> = {
+  // Signal has emit.
+  [key in T]: Signal<LSPConnection, IClientNotifyParams[key]>;
+};
+
+export interface IClientRequestHandler<
+  T extends keyof IClientRequestParams = keyof IClientRequestParams
+> {
+  request(params: IClientRequestParams[T]): Promise<IClientResult[T]>;
+}
+
+export interface IServerRequestHandler<
+  T extends keyof IServerRequestParams = keyof IServerRequestParams
+> {
+  setHandler(
+    handler: (params: IServerRequestParams[T]) => Promise<IServerResult[T]>
+  ): void;
+  clearHandler(): void;
+}
+
+export type ClientRequests<
+  T extends keyof IClientRequestParams = keyof IClientRequestParams
+> = {
+  // has async request(params) returning a promise with result.
+  [key in T]: IClientRequestHandler<key>;
+};
+
+export type ServerRequests<
+  T extends keyof IServerRequestParams = keyof IServerRequestParams
+> = {
+  // has async request(params) returning a promise with result.
+  [key in T]: IServerRequestHandler<key>;
+};
+
+class ClientRequestHandler<
+  T extends keyof IClientRequestParams = keyof IClientRequestParams
+> implements IClientRequestHandler {
+  constructor(protected connection: MessageConnection, protected method: T) {}
+  request(params: IClientRequestParams[T]): Promise<IClientResult[T]> {
+    return this.connection.sendRequest(this.method, params);
+  }
+}
+
+class ServerRequestHandler<
+  T extends keyof IServerRequestParams = keyof IServerRequestParams
+> implements IServerRequestHandler {
+  private _handler: (
+    params: IServerRequestParams[T]
+  ) => Promise<IServerResult[T]>;
+
+  constructor(protected connection: MessageConnection, protected method: T) {
+    // on request accepts "thenable"
+    this.connection.onRequest(method, this.handle);
+    this._handler = null;
+  }
+
+  private handle(request: IServerRequestParams[T]): Promise<IServerResult[T]> {
+    if (!this._handler) {
+      return;
+    }
+    return this._handler(request);
+  }
+
+  setHandler(
+    handler: (params: IServerRequestParams[T]) => Promise<IServerResult[T]>
+  ) {
+    this._handler = handler;
+  }
+
+  clearHandler() {
+    this._handler = null;
+  }
+}
+
+export const Provider: { [key: string]: keyof lsp.ServerCapabilities } = {
+  TEXT_DOCUMENT_SYNC: 'textDocumentSync',
+  COMPLETION: 'completionProvider',
+  HOVER: 'hoverProvider',
+  SIGNATURE_HELP: 'signatureHelpProvider',
+  DECLARATION: 'declarationProvider',
+  DEFINITION: 'definitionProvider',
+  TYPE_DEFINITION: 'typeDefinitionProvider',
+  IMPLEMENTATION: 'implementationProvider',
+  REFERENCES: 'referencesProvider',
+  DOCUMENT_HIGHLIGHT: 'documentHighlightProvider',
+  DOCUMENT_SYMBOL: 'documentSymbolProvider',
+  CODE_ACTION: 'codeActionProvider',
+  CODE_LENS: 'codeLensProvider',
+  DOCUMENT_LINK: 'documentLinkProvider',
+  COLOR: 'colorProvider',
+  DOCUMENT_FORMATTING: 'documentFormattingProvider',
+  DOCUMENT_RANGE_FORMATTING: 'documentRangeFormattingProvider',
+  DOCUMENT_ON_TYPE_FORMATTING: 'documentOnTypeFormattingProvider',
+  RENAME: 'renameProvider',
+  FOLDING_RANGE: 'foldingRangeProvider',
+  EXECUTE_COMMAND: 'executeCommandProvider',
+  SELECTION_RANGE: 'selectionRangeProvider',
+  WORKSPACE_SYMBOL: 'workspaceSymbolProvider',
+  WORKSPACE: 'workspace'
+};
 
 export class LSPConnection extends LspWsConnection {
   protected documentsToOpen: IDocumentInfo[];
   public serverIdentifier: string;
-  public notifications: ILSPNotifications;
+
+  public serverNotifications: ServerNotifications;
+  public clientNotifications: ClientNotifications;
+  public clientRequests: ClientRequests;
+  public serverRequests: ServerRequests;
+
+  protected constructNotificationHandlers<
+    T extends ServerNotifications | ClientNotifications,
+    U extends keyof T = keyof T
+  >(
+    methods: typeof Method.ServerNotification | typeof Method.ClientNotification
+  ) {
+    const result: { [key in U]?: Signal<any, any> } = {};
+    for (let method of Object.values(methods)) {
+      result[method as U] = new Signal<any, any>(this);
+    }
+    return result as T;
+  }
+
+  protected constructClientRequestHandler<
+    T extends ClientRequests,
+    U extends keyof T = keyof T
+  >(methods: typeof Method.ClientRequest) {
+    const result: { [key in U]?: IClientRequestHandler } = {};
+    for (let method of Object.values(methods)) {
+      result[method as U] = new ClientRequestHandler(
+        this.connection,
+        (method as U) as any
+      );
+    }
+    return result as T;
+  }
+
+  protected constructServerRequestHandler<
+    T extends ServerRequests,
+    U extends keyof T = keyof T
+  >(methods: typeof Method.ServerRequests) {
+    const result: { [key in U]?: IServerRequestHandler } = {};
+    for (let method of Object.values(methods)) {
+      result[method as U] = new ServerRequestHandler(
+        this.connection,
+        (method as U) as any
+      );
+    }
+    return result as T;
+  }
 
   constructor(options: ILSPOptions) {
     super(options);
     this.serverIdentifier = options?.serverIdentifier;
     this.documentsToOpen = [];
-    this.notifications = {
-      $: {
-        logTrace: new Signal(this),
-        setTrace: params => {
-          this.connection.sendNotification('$/setTrace', params);
-        }
-      },
-      window: {
-        showMessage: new Signal(this),
-        logMessage: new Signal(this)
-      }
-    };
+    this.serverNotifications = this.constructNotificationHandlers<
+      ServerNotifications
+    >(Method.ServerNotification);
+    this.clientNotifications = this.constructNotificationHandlers<
+      ClientNotifications
+    >(Method.ClientNotification);
   }
 
   sendOpenWhenReady(documentInfo: IDocumentInfo) {
@@ -69,29 +307,40 @@ export class LSPConnection extends LspWsConnection {
     }
   }
 
-  protected onServerInitialized(params: lsProtocol.InitializeResult) {
+  protected onServerInitialized(params: lsp.InitializeResult) {
     super.onServerInitialized(params);
     while (this.documentsToOpen.length) {
       this.sendOpen(this.documentsToOpen.pop());
     }
-    for (const namespaceName in this.notifications) {
-      const namespace = this.notifications[namespaceName];
-      for (const memberName in namespace) {
-        const endpoint = namespace[memberName];
-        if (endpoint instanceof Signal) {
-          this.connection.onNotification(
-            `${namespaceName}/${memberName}`,
-            params => {
-              endpoint.emit(params);
-            }
-          );
-        }
-      }
+
+    for (const method of Object.values(
+      Method.ServerNotification
+    ) as (keyof ServerNotifications)[]) {
+      const signal = this.serverNotifications[method] as Signal<any, any>;
+      this.connection.onNotification(method, params => {
+        signal.emit(params);
+      });
     }
+
+    for (const method of Object.values(
+      Method.ClientNotification
+    ) as (keyof ClientNotifications)[]) {
+      const signal = this.clientNotifications[method] as Signal<any, any>;
+      signal.connect((emitter, params) => {
+        this.connection.sendNotification(method, params);
+      });
+    }
+
+    this.clientRequests = this.constructClientRequestHandler<ClientRequests>(
+      Method.ClientRequest
+    );
+    this.serverRequests = this.constructServerRequestHandler<ServerRequests>(
+      Method.ServerRequests
+    );
   }
 
   public sendSelectiveChange(
-    changeEvent: lsProtocol.TextDocumentContentChangeEvent,
+    changeEvent: lsp.TextDocumentContentChangeEvent,
     documentInfo: IDocumentInfo
   ) {
     this._sendChange([changeEvent], documentInfo);
@@ -101,23 +350,33 @@ export class LSPConnection extends LspWsConnection {
     this._sendChange([{ text }], documentInfo);
   }
 
+  /**
+   * @deprecated The method should not be used in new code. Use provides() instead.
+   */
   public isRenameSupported() {
     return !!(
       this.serverCapabilities && this.serverCapabilities.renameProvider
     );
   }
 
+  provides(provider: keyof lsp.ServerCapabilities): boolean {
+    return !!(this.serverCapabilities && this.serverCapabilities[provider]);
+  }
+
+  /**
+   * @deprecated The method should not be used in new code
+   */
   async rename(
     location: IPosition,
     documentInfo: IDocumentInfo,
     newName: string,
     emit = true
-  ): Promise<lsProtocol.WorkspaceEdit> {
+  ): Promise<lsp.WorkspaceEdit> {
     if (!this.isReady || !this.isRenameSupported()) {
       return;
     }
 
-    const params: lsProtocol.RenameParams = {
+    const params: lsp.RenameParams = {
       textDocument: {
         uri: documentInfo.uri
       },
@@ -128,7 +387,7 @@ export class LSPConnection extends LspWsConnection {
       newName
     };
 
-    const edit: lsProtocol.WorkspaceEdit = await this.connection.sendRequest(
+    const edit: lsp.WorkspaceEdit = await this.connection.sendRequest(
       'textDocument/rename',
       params
     );
@@ -170,7 +429,7 @@ export class LSPConnection extends LspWsConnection {
   }
 
   private _sendChange(
-    changeEvents: lsProtocol.TextDocumentContentChangeEvent[],
+    changeEvents: lsp.TextDocumentContentChangeEvent[],
     documentInfo: IDocumentInfo
   ) {
     if (!this.isReady) {
@@ -179,11 +438,11 @@ export class LSPConnection extends LspWsConnection {
     if (!this.openedUris.get(documentInfo.uri)) {
       this.sendOpen(documentInfo);
     }
-    const textDocumentChange: lsProtocol.DidChangeTextDocumentParams = {
+    const textDocumentChange: lsp.DidChangeTextDocumentParams = {
       textDocument: {
         uri: documentInfo.uri,
         version: documentInfo.version
-      } as lsProtocol.VersionedTextDocumentIdentifier,
+      } as lsp.VersionedTextDocumentIdentifier,
       contentChanges: changeEvents
     };
     this.connection.sendNotification(
@@ -193,18 +452,19 @@ export class LSPConnection extends LspWsConnection {
     documentInfo.version++;
   }
 
-  async getCompletionResolve(completionItem: lsProtocol.CompletionItem) {
+  async getCompletionResolve(completionItem: lsp.CompletionItem) {
     if (!this.isReady || !this.isCompletionResolveProvider()) {
       return;
     }
-    return this.connection.sendRequest<lsProtocol.CompletionItem>(
+    return this.connection.sendRequest<lsp.CompletionItem>(
       'completionItem/resolve',
       completionItem
     );
   }
 
   /**
-   * Does support completionItem/resolve?.
+   * Does support completionItem/resolve?
+   * @deprecated The method should not be used in new code
    */
   public isCompletionResolveProvider(): boolean {
     return this.serverCapabilities?.completionProvider?.resolveProvider;

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -12,6 +12,7 @@ import {
   TextModelFactory
 } from '@jupyterlab/docregistry';
 import { FileEditor, FileEditorFactory } from '@jupyterlab/fileeditor';
+import { ILoggerRegistry } from '@jupyterlab/logconsole';
 import * as nbformat from '@jupyterlab/nbformat';
 import {
   Notebook,
@@ -107,6 +108,7 @@ export class MockExtension implements ILSPExtension {
   foreign_code_extractors: IForeignCodeExtractorsRegistry;
   code_overrides: ICodeOverridesRegistry;
   console: ILSPLogConsole;
+  user_console: ILoggerRegistry;
   translator: ITranslator;
 
   constructor() {
@@ -128,6 +130,7 @@ export class MockExtension implements ILSPExtension {
     this.foreign_code_extractors = {};
     this.code_overrides = {};
     this.console = new BrowserConsole();
+    this.user_console = null;
   }
 }
 

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -248,7 +248,8 @@ function FeatureSupport<TBase extends TestEnvironmentConstructor>(Base: TBase) {
         languageId: this.document_options.language,
         serverUri: 'ws://localhost:8080',
         rootUri: 'file:///unit-test',
-        serverIdentifier: DEFAULT_SERVER_ID
+        serverIdentifier: DEFAULT_SERVER_ID,
+        console: new BrowserConsole()
       });
     }
 

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.spec.ts
@@ -77,7 +77,7 @@ describe('Diagnostics', () => {
       markers = env.ce_editor.editor.getDoc().getAllMarks();
       expect(markers.length).to.equal(0);
 
-      feature.handleDiagnostic({
+      feature.handleDiagnostic(null, {
         uri: env.document_options.path,
         diagnostics: diagnostics
       });
@@ -99,7 +99,7 @@ describe('Diagnostics', () => {
       env.ce_editor.model.value.text = text;
       await env.adapter.update_documents();
 
-      feature.handleDiagnostic({
+      feature.handleDiagnostic(null, {
         uri: env.document_options.path,
         diagnostics: diagnostics
       });
@@ -124,7 +124,7 @@ describe('Diagnostics', () => {
       env.ce_editor.model.value.text = text;
       await env.adapter.update_documents();
 
-      feature.handleDiagnostic({
+      feature.handleDiagnostic(null, {
         uri: env.document_options.path,
         diagnostics: diagnostics
       });
@@ -167,7 +167,7 @@ describe('Diagnostics', () => {
       let document = env.virtual_editor.virtual_document;
       let uri = env.virtual_editor.virtual_document.uri;
 
-      feature.handleDiagnostic({
+      feature.handleDiagnostic(null, {
         uri: uri,
         diagnostics: [
           {
@@ -285,7 +285,7 @@ describe('Diagnostics', () => {
       } as lsProtocol.PublishDiagnosticsParams;
 
       // test guards against wrongly propagated responses:
-      feature.handleDiagnostic(response);
+      feature.handleDiagnostic(null, response);
       let cm_editors = env.adapter.editors.map(
         ce_editor => (ce_editor as CodeMirrorEditor).editor
       );
@@ -297,7 +297,7 @@ describe('Diagnostics', () => {
       expect(marks_cell_2.length).to.equal(0);
 
       // correct propagation
-      foreign_feature.handleDiagnostic(response);
+      foreign_feature.handleDiagnostic(null, response);
 
       marks_cell_1 = cm_editors[0].getDoc().getAllMarks();
       marks_cell_2 = cm_editors[1].getDoc().getAllMarks();
@@ -314,7 +314,7 @@ describe('Diagnostics', () => {
       expect(is_equal(mark_position.to, { line: 2, ch: 1 })).to.be.true;
 
       // the silenced diagnostic for the %%python magic should be ignored
-      feature.handleDiagnostic({
+      feature.handleDiagnostic(null, {
         uri: document.uri,
         diagnostics: [
           {

--- a/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
+++ b/packages/jupyterlab-lsp/src/features/diagnostics/diagnostics.ts
@@ -8,6 +8,7 @@ import type * as lsProtocol from 'vscode-languageserver-protocol';
 
 import diagnosticsSvg from '../../../style/icons/diagnostics.svg';
 import { CodeDiagnostics as LSPDiagnosticsSettings } from '../../_diagnostics';
+import { LSPConnection } from '../../connection';
 import { PositionConverter } from '../../converter';
 import { CodeMirrorIntegration } from '../../editor_integration/codemirror';
 import { FeatureSettings } from '../../feature';
@@ -288,7 +289,12 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
   }
 
   register(): void {
-    this.connection_handlers.set('diagnostic', this.handleDiagnostic);
+    // this.connection_handlers.set('diagnostic', this.handleDiagnostic);
+    // TODO: unregister
+    this.connection.serverNotifications[
+      'textDocument/publishDiagnostics'
+    ].connect(this.handleDiagnostic);
+
     this.wrapper_handlers.set('focusin', this.switchDiagnosticsPanelSource);
     this.unique_editor_ids = new DefaultMap(() => this.unique_editor_ids.size);
     this.settings.changed.connect(this.refreshDiagnostics, this);
@@ -606,7 +612,10 @@ export class DiagnosticsCM extends CodeMirrorIntegration {
     this.diagnostics_db.set(this.virtual_document, diagnostics_list);
   }
 
-  public handleDiagnostic = (response: lsProtocol.PublishDiagnosticsParams) => {
+  public handleDiagnostic = (
+    connection: LSPConnection,
+    response: lsProtocol.PublishDiagnosticsParams
+  ) => {
     if (!uris_equal(response.uri, this.virtual_document.document_info.uri)) {
       return;
     }

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -218,12 +218,25 @@ export class HoverCM extends CodeMirrorIntegration {
   }
 
   protected on_hover = async () => {
-    return await this.connection.getHoverTooltip(
-      this.virtual_position,
-      // this might be wrong - should not it be using the specific virtual document?
-      this.virtual_document.document_info,
-      false
-    );
+    if (
+      !(
+        this.connection.isReady &&
+        this.connection.serverCapabilities?.hoverProvider
+      )
+    ) {
+      return;
+    }
+    let position = this.virtual_position;
+    return await this.connection.clientRequests['textDocument/hover'].request({
+      textDocument: {
+        // this might be wrong - should not it be using the specific virtual document?
+        uri: this.virtual_document.document_info.uri
+      },
+      position: {
+        line: position.line,
+        character: position.ch
+      }
+    });
   };
 
   protected static get_markup_for_hover(

--- a/packages/jupyterlab-lsp/src/index.ts
+++ b/packages/jupyterlab-lsp/src/index.ts
@@ -1,6 +1,8 @@
 /** The Public API, as exposed in the `main` field of package.json */
 
 /** General public tokens, including lumino Tokens and namespaces */
+import { ILoggerRegistry } from '@jupyterlab/logconsole';
+
 export * from './tokens';
 
 /** Component- and feature-specific APIs */
@@ -124,6 +126,7 @@ export interface ILSPExtension {
   code_overrides: ICodeOverridesRegistry;
   console: ILSPLogConsole;
   translator: ITranslator;
+  user_console: ILoggerRegistry | null;
 }
 
 export class LSPExtension implements ILSPExtension {
@@ -143,6 +146,7 @@ export class LSPExtension implements ILSPExtension {
     private code_overrides_manager: ILSPCodeOverridesManager,
     public console: ILSPLogConsole,
     public translator: ITranslator,
+    public user_console: ILoggerRegistry,
     status_bar: IStatusBar | null
   ) {
     const trans = (translator || nullTranslator).load('jupyterlab-lsp');
@@ -251,7 +255,7 @@ const plugin: JupyterFrontEndPlugin<ILSPFeatureManager> = {
     ILSPLogConsole,
     ITranslator
   ],
-  optional: [IStatusBar],
+  optional: [ILoggerRegistry, IStatusBar],
   activate: (app, ...args) => {
     let extension = new LSPExtension(
       app,
@@ -266,6 +270,7 @@ const plugin: JupyterFrontEndPlugin<ILSPFeatureManager> = {
         ILSPCodeOverridesManager,
         ILSPLogConsole,
         ITranslator,
+        ILoggerRegistry | null,
         IStatusBar | null
       ])
     );

--- a/packages/lsp-ws-connection/package.json
+++ b/packages/lsp-ws-connection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-ws-connection",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Utility for adapting editors to language server protocol",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -27,11 +27,10 @@
   "homepage": "https://github.com/krassowski/jupyterlab-lsp/tree/master/packages/lsp-ws-connection",
   "repository": "github:krassowski/jupyterlab-lsp",
   "dependencies": {
-    "vscode-jsonrpc": "^4.1.0-next",
-    "vscode-languageclient": "^5.2.1",
-    "vscode-languageserver-protocol": "^3.14.1",
-    "vscode-languageserver-types": "^3.14.0",
-    "vscode-ws-jsonrpc": "0.1.1"
+    "vscode-jsonrpc": "^6.0.0",
+    "vscode-languageserver-protocol": "^3.16.0",
+    "vscode-languageserver-types": "^3.16.0",
+    "vscode-ws-jsonrpc": "0.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/packages/lsp-ws-connection/src/types.ts
+++ b/packages/lsp-ws-connection/src/types.ts
@@ -1,4 +1,4 @@
-import * as lsProtocol from 'vscode-languageserver-protocol';
+import type * as lsProtocol from 'vscode-languageserver-protocol';
 
 export interface IPosition {
   line: number;
@@ -27,6 +27,12 @@ export type AnyLocation =
 export type AnyCompletion =
   | lsProtocol.CompletionList
   | lsProtocol.CompletionItem[];
+
+export enum CompletionTriggerKind {
+  Invoked = 1,
+  TriggerCharacter = 2,
+  TriggerForIncompleteCompletions = 3
+}
 
 type ConnectionEvent =
   | 'completion'
@@ -190,169 +196,8 @@ export interface ILspConnection {
   isReferencesSupported(): boolean;
 }
 
-/**
- * Configuration map for codeActionsOnSave
- */
-export interface ICodeActionsOnSaveOptions {
-  [kind: string]: boolean;
-}
-
-export interface ITextEditorOptions {
-  /**
-   * Enable the suggestion box to pop-up on trigger characters.
-   * Defaults to true.
-   */
-  suggestOnTriggerCharacters?: boolean;
-  /**
-   * Accept suggestions on ENTER.
-   * Defaults to 'on'.
-   */
-  acceptSuggestionOnEnter?: boolean | 'on' | 'smart' | 'off';
-  /**
-   * Accept suggestions on TAB.
-   * Defaults to 'on'.
-   */
-  acceptSuggestionOnTab?: boolean | 'on' | 'smart' | 'off';
-  /**
-   * Accept suggestions on provider defined characters.
-   * Defaults to true.
-   */
-  acceptSuggestionOnCommitCharacter?: boolean;
-  /**
-   * Enable selection highlight.
-   * Defaults to true.
-   */
-  selectionHighlight?: boolean;
-  /**
-   * Enable semantic occurrences highlight.
-   * Defaults to true.
-   */
-  occurrencesHighlight?: boolean;
-  /**
-   * Show code lens
-   * Defaults to true.
-   */
-  codeLens?: boolean;
-  /**
-   * Code action kinds to be run on save.
-   */
-  codeActionsOnSave?: ICodeActionsOnSaveOptions;
-  /**
-   * Timeout for running code actions on save.
-   */
-  codeActionsOnSaveTimeout?: number;
-  /**
-   * Enable code folding
-   * Defaults to true.
-   */
-  folding?: boolean;
-  /**
-   * Selects the folding strategy. 'auto' uses the strategies contributed for the current document,
-   * 'indentation' uses the indentation based folding strategy.
-   * Defaults to 'auto'.
-   */
-  foldingStrategy?: 'auto' | 'indentation';
-  /**
-   * Controls whether the fold actions in the gutter stay always visible or hide unless the mouse is over the gutter.
-   * Defaults to 'mouseover'.
-   */
-  showFoldingControls?: 'always' | 'mouseover';
-  /**
-   * Whether to suggest while typing
-   */
-  suggest?: boolean;
-  /**
-   * Debounce (in ms) for suggestions while typing.
-   * Defaults to 200ms
-   */
-  debounceSuggestionsWhileTyping?: number;
-  /**
-   * Enable quick suggestions (shadow suggestions)
-   * Defaults to true.
-   */
-  quickSuggestions?:
-    | boolean
-    | {
-        other: boolean;
-        comments: boolean;
-        strings: boolean;
-      };
-  /**
-   * Quick suggestions show delay (in ms)
-   * Defaults to 200 (ms)
-   */
-  quickSuggestionsDelay?: number;
-  /**
-   * Parameter hint options. Defaults to true.
-   */
-  enableParameterHints?: boolean;
-  /**
-   * Render icons in suggestions box.
-   * Defaults to true.
-   */
-  iconsInSuggestions?: boolean;
-  /**
-   * Enable format on type.
-   * Defaults to false.
-   */
-  formatOnType?: boolean;
-  /**
-   * Enable format on paste.
-   * Defaults to false.
-   */
-  formatOnPaste?: boolean;
-}
-
 export interface ILspOptions {
   serverUri: string;
   languageId: string;
   rootUri: string;
-}
-
-/**
- * An adapter is responsible for connecting a particular text editor with a LSP connection
- * and will send messages over the connection and display responses in the editor
- */
-export abstract class IEditorAdapter<T> {
-  constructor(
-    connection: ILspConnection,
-    options: ITextEditorOptions,
-    editor: T
-  ) {
-    // no implementation
-  }
-
-  /**
-   * Removes the adapter from the editor and closes the connection
-   */
-  public abstract remove(): void;
-}
-
-export function getFilledDefaults(
-  options: ITextEditorOptions
-): ITextEditorOptions {
-  return Object.assign(
-    {},
-    {
-      suggestOnTriggerCharacters: true,
-      acceptSuggestionOnEnter: true,
-      acceptSuggestionOnTab: true,
-      acceptSuggestionOnCommitCharacter: true,
-      selectionHighlight: true,
-      occurrencesHighlight: true,
-      codeLens: true,
-      folding: true,
-      foldingStrategy: 'auto',
-      showFoldingControls: 'mouseover',
-      suggest: true,
-      debounceSuggestionsWhileTyping: 200,
-      quickSuggestions: true,
-      quickSuggestionsDelay: 200,
-      enableParameterHints: true,
-      iconsInSuggestions: true,
-      formatOnType: false,
-      formatOnPaste: false
-    },
-    options
-  );
 }

--- a/packages/lsp-ws-connection/src/ws-connection.ts
+++ b/packages/lsp-ws-connection/src/ws-connection.ts
@@ -1,10 +1,7 @@
 import * as events from 'events';
 
-import * as protocol from 'vscode-languageserver-protocol';
-import {
-  CompletionItemTag,
-  LocationLink
-} from 'vscode-languageserver-protocol';
+import type * as protocol from 'vscode-languageserver-protocol';
+import { CompletionItemTag, LocationLink } from 'vscode-languageserver-types';
 import { ConsoleLogger, MessageConnection, listen } from 'vscode-ws-jsonrpc';
 
 import {
@@ -14,6 +11,7 @@ import {
 import {
   AnyCompletion,
   AnyLocation,
+  CompletionTriggerKind,
   IDocumentInfo,
   ILspConnection,
   ILspOptions,
@@ -355,7 +353,7 @@ export class LspWsConnection
         character: location.ch
       },
       context: {
-        triggerKind: triggerKind || protocol.CompletionTriggerKind.Invoked,
+        triggerKind: triggerKind || CompletionTriggerKind.Invoked,
         triggerCharacter
       }
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,6 +1264,34 @@
     sanitize-html "~1.27.4"
     url "^0.11.0"
 
+"@jupyterlab/apputils@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/apputils/-/apputils-3.0.9.tgz#504273fc0b69f74d8a8b87b7a89ee3d4decd679d"
+  integrity sha512-fsJjl+NX2+e+1FM7SMfpI1VsaPQsaIPnPGsdpQoboJJqdQJHuj1oPXNwc/aI1daEElirB15fYGCUGc2oUrv6RQ==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/services" "^6.0.9"
+    "@jupyterlab/settingregistry" "^3.0.6"
+    "@jupyterlab/statedb" "^3.0.6"
+    "@jupyterlab/translation" "^3.0.9"
+    "@jupyterlab/ui-components" "^3.0.7"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/domutils" "^1.2.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/virtualdom" "^1.8.0"
+    "@lumino/widgets" "^1.16.1"
+    "@types/react" "^17.0.0"
+    buffer "^5.6.0"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+    sanitize-html "~2.3.3"
+    url "^0.11.0"
+
 "@jupyterlab/attachments@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/attachments/-/attachments-3.0.0.tgz#bcd9d17e61d2edf9b87d14561cd6df30c4214e24"
@@ -1378,6 +1406,23 @@
     "@lumino/signaling" "^1.4.3"
     "@lumino/widgets" "^1.16.1"
 
+"@jupyterlab/codeeditor@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codeeditor/-/codeeditor-3.0.9.tgz#e06f82ad3c5199be8e9eb97b598d212af0c4ca08"
+  integrity sha512-OUymghTH6CsAXc4z8EA7BqwdT99mdjJ/X488EOgXCBgeKz3QKB1gQ3GpH26soUv4S0prAs8RKU7rHjfb+DLYBQ==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/nbformat" "^3.0.6"
+    "@jupyterlab/observables" "^4.0.6"
+    "@jupyterlab/translation" "^3.0.9"
+    "@jupyterlab/ui-components" "^3.0.7"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/dragdrop" "^1.7.1"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.16.1"
+
 "@jupyterlab/codemirror@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-3.0.0.tgz#04c309428d32da14b33a3cd38419cd8bd50ee354"
@@ -1398,6 +1443,28 @@
     "@lumino/signaling" "^1.4.3"
     "@lumino/widgets" "^1.16.1"
     codemirror "~5.57.0"
+    react "^17.0.1"
+
+"@jupyterlab/codemirror@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/codemirror/-/codemirror-3.0.9.tgz#2b66c998547ce30a6162141bfb168fb7d2db2ea0"
+  integrity sha512-RgB4ZS1Rhzvk20VDvnP7oQ8Bh9fC0dWDO/hZZwLJamlJLgtQNsCnU3Qw/K2dxhCMWBexI3n+E+0mcv1IXbEtLQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.0.9"
+    "@jupyterlab/codeeditor" "^3.0.9"
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/nbformat" "^3.0.6"
+    "@jupyterlab/observables" "^4.0.6"
+    "@jupyterlab/statusbar" "^3.0.9"
+    "@jupyterlab/translation" "^3.0.9"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/polling" "^1.3.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.16.1"
+    codemirror "~5.58.0"
     react "^17.0.1"
 
 "@jupyterlab/completer@^3.0.0":
@@ -1431,6 +1498,19 @@
     moment "^2.24.0"
     path-browserify "^1.0.0"
     url-parse "~1.4.7"
+
+"@jupyterlab/coreutils@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-5.0.6.tgz#dd36591d01191762ff35e3b096f324e990e0e617"
+  integrity sha512-nXGpI1IJw+4pNq6Afy+oI3LrTsaQ14xG7Kxbhg9UPfoDgsNt2rdG4pwYe4NZyj2GJHAkUj00lcUD9eBTrxMWvw==
+  dependencies:
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    minimist "~1.2.0"
+    moment "^2.24.0"
+    path-browserify "^1.0.0"
+    url-parse "~1.5.1"
 
 "@jupyterlab/docmanager@^3.0.0":
   version "3.0.0"
@@ -1516,10 +1596,34 @@
     "@lumino/widgets" "^1.16.1"
     react "^17.0.1"
 
+"@jupyterlab/logconsole@^3.0.0":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/logconsole/-/logconsole-3.0.10.tgz#2757b374a828ce63a77da4a70a43851f3760c375"
+  integrity sha512-BQ3QygNqCfNL7kBaaIM8uYndCtmZiYGDCClzwDh3W2cWQOdjRyEYhXoTb+kUmINP3eOZgIt40HzRL3W1dAabrQ==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/nbformat" "^3.0.6"
+    "@jupyterlab/outputarea" "^3.0.10"
+    "@jupyterlab/rendermime" "^3.0.10"
+    "@jupyterlab/services" "^6.0.9"
+    "@jupyterlab/translation" "^3.0.9"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.16.1"
+
 "@jupyterlab/nbformat@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/nbformat/-/nbformat-3.0.0.tgz#453932cf707e65ea09781f91f73f1ac33f6de33e"
   integrity sha512-UC7sjnLI34cEi6k6+UPoRNjy8h6MSH5wrx410HyFT7rqjK9sZp4ZE+hL6jvp13rF3HVLvzST2zqT8KB/wLBdDg==
+  dependencies:
+    "@lumino/coreutils" "^1.5.3"
+
+"@jupyterlab/nbformat@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/nbformat/-/nbformat-3.0.6.tgz#858a6567cdd60879bc7f9dad6c9dcb5587417b5d"
+  integrity sha512-4+u770JYPmRpLyEPpnG0crj8ePUkg/vCF1W4hnDDxnLTVjzKw5kv6KVb5yJGEHAihUOf51bjceNUOp/+nLVBTg==
   dependencies:
     "@lumino/coreutils" "^1.5.3"
 
@@ -1562,6 +1666,17 @@
     "@lumino/messaging" "^1.4.3"
     "@lumino/signaling" "^1.4.3"
 
+"@jupyterlab/observables@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/observables/-/observables-4.0.6.tgz#be3bb0f08d2e79f86f4553857ed0aa90d7b293f2"
+  integrity sha512-PYJosNXGSkLExaEXqpUuDjEXTEcxTpvM6kG8I6NFJyDQVD6E50LggC6NofY5EIcEsJsO771BLvI4kwNk7LRQSA==
+  dependencies:
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+
 "@jupyterlab/outputarea@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/outputarea/-/outputarea-3.0.0.tgz#703c9fd47aa4d045690f511859897b0baab25d6f"
@@ -1582,12 +1697,41 @@
     "@lumino/widgets" "^1.16.1"
     resize-observer-polyfill "^1.5.1"
 
+"@jupyterlab/outputarea@^3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/outputarea/-/outputarea-3.0.10.tgz#3e04a0fffd0175eca60ea7781a3b70a924d8779f"
+  integrity sha512-GW2/q9ShK7rSEKA2KeMKT+FiAZkRmOeSQ0PYhXjjrMNFPPTURtzuztMRF7NMVH1QWiYABn03qx1IKHvt1hvdDQ==
+  dependencies:
+    "@jupyterlab/apputils" "^3.0.9"
+    "@jupyterlab/nbformat" "^3.0.6"
+    "@jupyterlab/observables" "^4.0.6"
+    "@jupyterlab/rendermime" "^3.0.10"
+    "@jupyterlab/rendermime-interfaces" "^3.0.9"
+    "@jupyterlab/services" "^6.0.9"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.16.1"
+    resize-observer-polyfill "^1.5.1"
+
 "@jupyterlab/rendermime-interfaces@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.0.0.tgz#ef35a949e784f133a90e6234917d80aac500efa2"
   integrity sha512-gumHlaiv5HUQuZuLz6Zp7FLTaKa429CtTun9aye2zMEdf4qrQnazg7MLDsCkeQAHROBLBu6Qj1tTdmgQivWoMA==
   dependencies:
     "@jupyterlab/translation" "^3.0.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/widgets" "^1.16.1"
+
+"@jupyterlab/rendermime-interfaces@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-3.0.9.tgz#13badf733d79b34bed0392e8a34d30291090e536"
+  integrity sha512-KvoDcIzgvDhvCGDYqFhRM753iOryWFujAEzXjpzvYz/1yNUh5weYsdwdmdCjUTkToM9rFiIDMwjferJPU54thw==
+  dependencies:
+    "@jupyterlab/translation" "^3.0.9"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/widgets" "^1.16.1"
 
@@ -1612,6 +1756,27 @@
     lodash.escape "^4.0.1"
     marked "^1.1.1"
 
+"@jupyterlab/rendermime@^3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/rendermime/-/rendermime-3.0.10.tgz#7592155ea00c3a81f0d9a5662d3ccdeb37f722b1"
+  integrity sha512-9Q32zYpBkbrlAkuHJ7760ZETWQYZkKT9UcJWOMVF7iNgoBfRohAYvPHsoc6JFZyFEFhKzkLwa+CTcL48aGjg7A==
+  dependencies:
+    "@jupyterlab/apputils" "^3.0.9"
+    "@jupyterlab/codemirror" "^3.0.9"
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/nbformat" "^3.0.6"
+    "@jupyterlab/observables" "^4.0.6"
+    "@jupyterlab/rendermime-interfaces" "^3.0.9"
+    "@jupyterlab/services" "^6.0.9"
+    "@jupyterlab/translation" "^3.0.9"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.16.1"
+    lodash.escape "^4.0.1"
+    marked "^2.0.0"
+
 "@jupyterlab/services@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-6.0.0.tgz#1e23f325f5e3ef7c55449b9cd51568f59724ef62"
@@ -1622,6 +1787,24 @@
     "@jupyterlab/observables" "^4.0.0"
     "@jupyterlab/settingregistry" "^3.0.0"
     "@jupyterlab/statedb" "^3.0.0"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/polling" "^1.3.3"
+    "@lumino/signaling" "^1.4.3"
+    node-fetch "^2.6.0"
+    ws "^7.2.0"
+
+"@jupyterlab/services@^6.0.9":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/services/-/services-6.0.9.tgz#70a10d7f6883b8fafff81216663d96858b0cf46b"
+  integrity sha512-zeN9roqwbYo6b2I5BXWx+Mr4KzTpe2UcVwrcAGw9NXqIieb0ZnvtHqtNj/vcHCM2xQKuPup9W1X1bE5b3wF5Yw==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/nbformat" "^3.0.6"
+    "@jupyterlab/observables" "^4.0.6"
+    "@jupyterlab/settingregistry" "^3.0.6"
+    "@jupyterlab/statedb" "^3.0.6"
     "@lumino/algorithm" "^1.3.3"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
@@ -1643,10 +1826,34 @@
     ajv "^6.12.3"
     json5 "^2.1.1"
 
+"@jupyterlab/settingregistry@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/settingregistry/-/settingregistry-3.0.6.tgz#000cd9dc4984a1ccac01d73c7967893befe14b8d"
+  integrity sha512-fIeVJjkaf8FYSJ4jwJobwNeco8J2CEuWzmEJKiDjhmzmRZApS9Jjx+CJXDkTxoSMDQ41ELxQKJq5bcbih/90zQ==
+  dependencies:
+    "@jupyterlab/statedb" "^3.0.6"
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    ajv "^6.12.3"
+    json5 "^2.1.1"
+
 "@jupyterlab/statedb@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/statedb/-/statedb-3.0.0.tgz#a9fc277a74238c7413e7b2ab9a07e4a341f9a0b3"
   integrity sha512-6CLbRwO6aWJOeJTto6YGazEBhNOqPgNhoWt1sd0foYcxu7HrztnLP4M+gYtLvK0jLSmxQ9KKHJRYW5HMvkZaJA==
+  dependencies:
+    "@lumino/commands" "^1.12.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/properties" "^1.2.3"
+    "@lumino/signaling" "^1.4.3"
+
+"@jupyterlab/statedb@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statedb/-/statedb-3.0.6.tgz#d331c815496f80083d53277e1972095da954f31f"
+  integrity sha512-hXewp5TAKneWJcYXenTZuzSUagGjyWv5vRHDFarw1O4pkEg7zz8IyN2yAvbYH6+GDqIhF/91rgGu9alkx/yjjA==
   dependencies:
     "@lumino/commands" "^1.12.0"
     "@lumino/coreutils" "^1.5.3"
@@ -1665,6 +1872,27 @@
     "@jupyterlab/services" "^6.0.0"
     "@jupyterlab/translation" "^3.0.0"
     "@jupyterlab/ui-components" "^3.0.0"
+    "@lumino/algorithm" "^1.3.3"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/disposable" "^1.4.3"
+    "@lumino/messaging" "^1.4.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/widgets" "^1.16.1"
+    csstype "~3.0.3"
+    react "^17.0.1"
+    typestyle "^2.0.4"
+
+"@jupyterlab/statusbar@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/statusbar/-/statusbar-3.0.9.tgz#b00d8b74e813bb9534e7a57d0419579e9367da7a"
+  integrity sha512-MaA6GVi59mH3YRkV5iJPcpdS9opMTgFvcfMQLzKeMJvEQvM2fFGMVixp+q2U6Pa8iJsCp59CUoTyuQQdkw1UFw==
+  dependencies:
+    "@jupyterlab/apputils" "^3.0.9"
+    "@jupyterlab/codeeditor" "^3.0.9"
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/services" "^6.0.9"
+    "@jupyterlab/translation" "^3.0.9"
+    "@jupyterlab/ui-components" "^3.0.7"
     "@lumino/algorithm" "^1.3.3"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/disposable" "^1.4.3"
@@ -1730,6 +1958,16 @@
     "@jupyterlab/statedb" "^3.0.0"
     "@lumino/coreutils" "^1.5.3"
 
+"@jupyterlab/translation@^3.0.9":
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/translation/-/translation-3.0.9.tgz#54472d3d2fef0d56dfa61c2711a9155f3308ad5b"
+  integrity sha512-XsIUt08HDpA2zqhJFmNV9iuxMriV4sAdx4rM1rA0tEUuvWSXerLvpzNUw4LAz+iaJgyUgqqV1gKrOgoMTjtvWA==
+  dependencies:
+    "@jupyterlab/coreutils" "^5.0.6"
+    "@jupyterlab/services" "^6.0.9"
+    "@jupyterlab/statedb" "^3.0.6"
+    "@lumino/coreutils" "^1.5.3"
+
 "@jupyterlab/ui-components@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-3.0.0.tgz#55cba70a479bd1dc062efa6a6db36788f05a468b"
@@ -1738,6 +1976,22 @@
     "@blueprintjs/core" "^3.36.0"
     "@blueprintjs/select" "^3.15.0"
     "@jupyterlab/coreutils" "^5.0.0"
+    "@lumino/coreutils" "^1.5.3"
+    "@lumino/signaling" "^1.4.3"
+    "@lumino/virtualdom" "^1.8.0"
+    "@lumino/widgets" "^1.16.1"
+    react "^17.0.1"
+    react-dom "^17.0.1"
+    typestyle "^2.0.4"
+
+"@jupyterlab/ui-components@^3.0.7":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/ui-components/-/ui-components-3.0.7.tgz#83525d98051e9c74bd415da9e4a0fb20ec6bd609"
+  integrity sha512-kuq2aZ3DcCQNqf5ucsXWREHxbYq23+S12zMertOs+74KQr8jm8chX9HmqpmefNKnSIqqi/RKVSS2PWuSTpkEEw==
+  dependencies:
+    "@blueprintjs/core" "^3.36.0"
+    "@blueprintjs/select" "^3.15.0"
+    "@jupyterlab/coreutils" "^5.0.6"
     "@lumino/coreutils" "^1.5.3"
     "@lumino/signaling" "^1.4.3"
     "@lumino/virtualdom" "^1.8.0"
@@ -4707,6 +4961,11 @@ codemirror@~5.57.0:
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.57.0.tgz#d26365b72f909f5d2dbb6b1209349ca1daeb2d50"
   integrity sha512-WGc6UL7Hqt+8a6ZAsj/f1ApQl3NPvHY/UQSzG6fB6l4BjExgVdhFaxd7mRTw1UCiYe/6q86zHP+kfvBQcZGvUg==
 
+codemirror@~5.58.0:
+  version "5.58.3"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.58.3.tgz#3f0689854ecfbed5d4479a98b96148b2c3b79796"
+  integrity sha512-KBhB+juiyOOgn0AqtRmWyAT3yoElkuvWTI6hsHa9E6GQrl6bk/fdAYcvuqW1/upO9T9rtEtapWdw4XYcNiVDEA==
+
 collapse-white-space@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
@@ -4753,6 +5012,11 @@ colorette@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+
+colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 colors@^1.1.0:
   version "1.4.0"
@@ -5643,6 +5907,11 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.2.tgz#f3b6e549201e46f588b59463dd77187131fe6971"
   integrity sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==
 
+domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
@@ -5664,6 +5933,13 @@ domhandler@^3.0.0, domhandler@^3.3.0:
   dependencies:
     domelementtype "^2.0.1"
 
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
+  integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
+  dependencies:
+    domelementtype "^2.2.0"
+
 domutils@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.2.tgz#7ee5be261944e1ad487d9aa0616720010123922b"
@@ -5672,6 +5948,15 @@ domutils@^2.0.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.0.1"
     domhandler "^3.3.0"
+
+domutils@^2.5.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.6.0.tgz#2e15c04185d43fb16ae7057cb76433c6edb938b7"
+  integrity sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-prop@^4.2.0:
   version "4.2.1"
@@ -6024,6 +6309,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.14.1, escodegen@^1.9.1:
   version "1.14.3"
@@ -7392,6 +7682,16 @@ htmlparser2@^4.1.0:
     domelementtype "^2.0.1"
     domhandler "^3.0.0"
     domutils "^2.0.0"
+    entities "^2.0.0"
+
+htmlparser2@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
     entities "^2.0.0"
 
 http-cache-semantics@^3.8.1:
@@ -8978,6 +9278,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+klona@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
+  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -9321,11 +9626,10 @@ lru-queue@0.1:
 "lsp-ws-connection@file:packages/lsp-ws-connection":
   version "0.5.1"
   dependencies:
-    vscode-jsonrpc "^4.1.0-next"
-    vscode-languageclient "^5.2.1"
-    vscode-languageserver-protocol "^3.14.1"
-    vscode-languageserver-types "^3.14.0"
-    vscode-ws-jsonrpc "0.1.1"
+    vscode-jsonrpc "^6.0.0"
+    vscode-languageserver-protocol "^3.16.0"
+    vscode-languageserver-types "^3.16.0"
+    vscode-ws-jsonrpc "0.2.0"
 
 macos-release@^2.2.0:
   version "2.4.1"
@@ -9452,6 +9756,11 @@ marked@^1.1.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.3.tgz#58817ba348a7c9398cb94d40d12e0d08df83af57"
   integrity sha512-RQuL2i6I6Gn+9n81IDNGbL0VHnta4a+8ZhqvryXEniTb/hQNtf3i26hi1XWUhzb9BgVyWHKR3UO8MaHtKoYibw==
+
+marked@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.5.tgz#2d15c759b9497b0e7b5b57f4c2edabe1002ef9e7"
+  integrity sha512-yfCEUXmKhBPLOzEC7c+tc4XZdIeTdGoRCZakFMkCxodr7wDXqoapIME4wjcpBPJLNyUnKJ3e8rb8wlAgnLnaDw==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -9955,6 +10264,11 @@ nanoid@^3.1.20:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
   integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
+
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -11178,6 +11492,15 @@ postcss@^7.0.27:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@^8.0.2:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.0.tgz#b1a713f6172ca427e3f05ef1303de8b65683325f"
+  integrity sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==
+  dependencies:
+    colorette "^1.2.2"
+    nanoid "^3.1.23"
+    source-map-js "^0.6.2"
 
 postcss@^8.1.4:
   version "8.2.2"
@@ -12774,6 +13097,19 @@ sanitize-html@~1.27.4:
     parse-srcset "^1.0.2"
     postcss "^7.0.27"
 
+sanitize-html@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.3.3.tgz#3db382c9a621cce4c46d90f10c64f1e9da9e8353"
+  integrity sha512-DCFXPt7Di0c6JUnlT90eIgrjs6TsJl/8HYU3KLdmrVclFN4O0heTcVbJiMa23OKVr6aR051XYtsgd8EWwEBwUA==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^6.0.0"
+    is-plain-object "^5.0.0"
+    klona "^2.0.3"
+    parse-srcset "^1.0.2"
+    postcss "^8.0.2"
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -13150,6 +13486,11 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-loader@~0.2.1:
   version "0.2.4"
@@ -14555,6 +14896,14 @@ url-parse@~1.4.7:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url-parse@~1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
+  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -14774,28 +15123,20 @@ vscode-jsonrpc@3.5.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz#87239d9e166b2d7352245b8a813597804c1d63aa"
   integrity sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o=
 
+vscode-jsonrpc@6.0.0, vscode-jsonrpc@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
+  integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
+
 vscode-jsonrpc@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
   integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
 
-vscode-jsonrpc@^4.1.0-next:
-  version "4.1.0-next.3"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz#05fe742959a2726020d4d0bfbc3d3c97873c7fde"
-  integrity sha512-Z6oxBiMks2+UADV1QHXVooSakjyhI+eHTnXzDyVvVMmegvSfkXk2w6mPEdSkaNHFBdtWW7n20H1yw2nA3A17mg==
-
-vscode-jsonrpc@^5.0.1:
+vscode-jsonrpc@^5.0.0, vscode-jsonrpc@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
-
-vscode-languageclient@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz#7cfc83a294c409f58cfa2b910a8cfeaad0397193"
-  integrity sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==
-  dependencies:
-    semver "^5.5.0"
-    vscode-languageserver-protocol "3.14.1"
 
 vscode-languageclient@^6.1.3:
   version "6.1.3"
@@ -14829,13 +15170,21 @@ vscode-languageserver-protocol@3.5.1:
     vscode-jsonrpc "3.5.0"
     vscode-languageserver-types "3.5.0"
 
-vscode-languageserver-protocol@^3.10.3, vscode-languageserver-protocol@^3.14.1, vscode-languageserver-protocol@^3.15.1, vscode-languageserver-protocol@^3.15.3, vscode-languageserver-protocol@^3.7.2:
+vscode-languageserver-protocol@^3.10.3, vscode-languageserver-protocol@^3.15.1, vscode-languageserver-protocol@^3.15.3, vscode-languageserver-protocol@^3.7.2:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
   integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
   dependencies:
     vscode-jsonrpc "^5.0.1"
     vscode-languageserver-types "3.15.1"
+
+vscode-languageserver-protocol@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
+  integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
+  dependencies:
+    vscode-jsonrpc "6.0.0"
+    vscode-languageserver-types "3.16.0"
 
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"
@@ -14847,10 +15196,15 @@ vscode-languageserver-types@3.14.0:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
   integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
-vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.0.3, vscode-languageserver-types@^3.13.0, vscode-languageserver-types@^3.14.0, vscode-languageserver-types@^3.15.1, vscode-languageserver-types@^3.5.0, vscode-languageserver-types@^3.7.2:
+vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.0.3, vscode-languageserver-types@^3.13.0, vscode-languageserver-types@^3.15.1, vscode-languageserver-types@^3.5.0, vscode-languageserver-types@^3.7.2:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+
+vscode-languageserver-types@3.16.0, vscode-languageserver-types@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
+  integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
 vscode-languageserver-types@3.16.0-next.2:
   version "3.16.0-next.2"
@@ -14928,12 +15282,12 @@ vscode-uri@^2.1.1, vscode-uri@^2.1.2:
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
   integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
 
-vscode-ws-jsonrpc@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.1.1.tgz#163ff05662635b4fd161ed132e112cec4d83f126"
-  integrity sha512-1O/FUORbb8dZAvh9AFF6HViLJ0Ja0RbF+sFRnUsoqkuKIRsXDDiiJpwYwT6fmglCLefE5afGPw9NoHvDVN/5yw==
+vscode-ws-jsonrpc@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.2.0.tgz#5e9c26e10da54a1a235da7d59e74508bbcb8edd9"
+  integrity sha512-NE9HNRgPjCaPyTJvIudcpyIWPImxwRDtuTX16yks7SAiZgSXigxAiZOvSvVBGmD1G/OMfrFo6BblOtjVR9DdVA==
   dependencies:
-    vscode-jsonrpc "^4.1.0-next"
+    vscode-jsonrpc "^5.0.0"
 
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## References

Fixes #601 and updates lsp-ws-connection:

## Code changes

- use `import type` if possible
- update:
   - "vscode-jsonrpc": "^6.0.0",
   - "vscode-languageserver-protocol": "^3.16.0",
   - "vscode-languageserver-types": "^3.16.0",
   - "vscode-ws-jsonrpc": "0.2.0"
- remove unused code from lsp-ws-connection
- deprecate the `emit()` and getter based API for lsp-ws-connection
- add new API with well-typed:

```
  public serverNotifications: ServerNotifications;
  public clientNotifications: ClientNotifications;
  public clientRequests: ClientRequests;
  public serverRequests: ServerRequests;
```

## User-facing changes

![Screenshot from 2021-05-23 17-43-24](https://user-images.githubusercontent.com/5832902/119269209-6d94a200-bbee-11eb-8e38-52a6d04950ab.png)

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to public APIs. -->

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
