### PR TITLE
Fix rename shortcut in file editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### `@krassowski/jupyterlab-lsp 3.7.1` (unreleased)
+
+- bug fixes:
+  - fix rename shortcut registration in file browser ([#614])
+
+[#614]: https://github.com/krassowski/jupyterlab-lsp/pull/614
+
 ### `jupyter-lsp 1.3.0` (2021-06-02)
 
 - features:

--- a/packages/jupyterlab-lsp/schema/rename.json
+++ b/packages/jupyterlab-lsp/schema/rename.json
@@ -12,7 +12,7 @@
       "selector": ".jp-Notebook .jp-CodeCell"
     },
     {
-      "command": "lsp:rename-symbol-file_editor'",
+      "command": "lsp:rename-symbol-file_editor",
       "keys": ["F2"],
       "selector": ".jp-FileEditor"
     }


### PR DESCRIPTION
## References

None

## Code changes

Remove extra `'` which was leading to the shortcut not getting registered

## User-facing changes

F2 works in file editor.

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
