### PR TITLE
Improve performance of icon rendering in completer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - bug fixes:
   - fix rename shortcut registration in file editor ([#614])
   - add a note on manually enabling backend extension ([#621], thanks @icankeep)
+  - improve performance of icon rendering in completer ([#625])
 
 [#614]: https://github.com/krassowski/jupyterlab-lsp/pull/614
 [#621]: https://github.com/krassowski/jupyterlab-lsp/pull/621
+[#625]: https://github.com/krassowski/jupyterlab-lsp/pull/625
 
 ### `jupyter-lsp 1.3.0` (2021-06-02)
 

--- a/packages/completion-theme/package.json
+++ b/packages/completion-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/completion-theme",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Completion theme manager for JupyterLab-LSP",
   "keywords": [
     "jupyter",

--- a/packages/completion-theme/src/index.ts
+++ b/packages/completion-theme/src/index.ts
@@ -53,6 +53,7 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
       ? icons_sets.dark
       : icons_sets.light;
     const icons: Map<keyof ICompletionIconSet, LabIcon> = new Map();
+    let options = this.current_theme.icons.options || {};
     const mode = this.is_theme_light() ? 'light' : 'dark';
     for (let [completion_kind, svg] of Object.entries(set)) {
       let name =
@@ -67,7 +68,10 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
         });
         this.icons_cache.set(name, icon);
       }
-      icons.set(completion_kind as keyof ICompletionIconSet, icon);
+      icons.set(
+        completion_kind as keyof ICompletionIconSet,
+        icon.bindprops(options)
+      );
     }
     return icons;
   }
@@ -83,7 +87,6 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
     if (this.current_theme === null) {
       return null;
     }
-    let options = this.current_theme.icons.options || {};
     if (type) {
       if (this.icon_overrides.has(type.toLowerCase())) {
         type = this.icon_overrides.get(type.toLowerCase());
@@ -92,7 +95,7 @@ export class CompletionThemeManager implements ILSPCompletionThemeManager {
         type.substring(0, 1).toUpperCase() + type.substring(1).toLowerCase();
     }
     if (this.current_icons.has(type)) {
-      return this.current_icons.get(type).bindprops(options);
+      return this.current_icons.get(type);
     }
 
     if (type === KernelKind) {


### PR DESCRIPTION
## References

Relates to #272.

## Code changes

Bindprops early to avoid cache invalidation of LabIcon. JupyterLab since 2.1 has an ability to cache LabIcon svg strings (https://github.com/jupyterlab/jupyterlab/pull/8125) but we were not getting these benefits as using bindprops late in the code was causing a react proxy to be created and used which is preventing the caching mechanism from working.
 
## User-facing changes

The rendering time for long lists of completion items decrease notably:
- `pandas.<tab>` from 178 ms to 97ms (for list of 150 completions)
- `numpy.<tab>` from 1043 ms to 641 ms (for list of 1125 completions)

We should be able to improve this further with JupyterLab 3.1 since some of the current workarounds won't be needed any longer.

#### Pandas

Before:

![Screenshot from 2021-06-15 23-35-12](https://user-images.githubusercontent.com/5832902/122138834-75d3ac00-ce3f-11eb-96c1-b0776729b3c2.png)

After:

![Screenshot from 2021-06-15 23-33-54](https://user-images.githubusercontent.com/5832902/122138842-78ce9c80-ce3f-11eb-8a62-1dabcb57f5e6.png)

### Numpy

Before

![Screenshot from 2021-06-16 01-13-03](https://user-images.githubusercontent.com/5832902/122139308-994b2680-ce40-11eb-9ff7-5373c6a66e38.png)

After

![Screenshot from 2021-06-16 01-18-17](https://user-images.githubusercontent.com/5832902/122139427-e62efd00-ce40-11eb-843b-df2832220311.png)


## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
