### PR TITLE
Fix hover malfunction messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,19 @@
 
 ### `@krassowski/jupyterlab-lsp 3.7.1` (unreleased)
 
+- improvements:
+
+  - add a note on manually enabling backend extension ([#621], thanks @icankeep)
+
 - bug fixes:
   - fix rename shortcut registration in file editor ([#614])
-  - add a note on manually enabling backend extension ([#621], thanks @icankeep)
   - improve performance of icon rendering in completer ([#625])
+  - fix cache misses and concurrency issues for hover ([#630])
 
 [#614]: https://github.com/krassowski/jupyterlab-lsp/pull/614
 [#621]: https://github.com/krassowski/jupyterlab-lsp/pull/621
 [#625]: https://github.com/krassowski/jupyterlab-lsp/pull/625
+[#630]: https://github.com/krassowski/jupyterlab-lsp/pull/630
 
 ### `jupyter-lsp 1.3.0` (2021-06-02)
 

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -59,8 +59,8 @@
   "dependencies": {
     "@krassowski/code-jumpers": "~1.1.0",
     "@krassowski/completion-theme": "~3.1.0",
-    "@krassowski/theme-material": "~2.1.0",
-    "@krassowski/theme-vscode": "~2.1.0",
+    "@krassowski/theme-material": "~2.1.1",
+    "@krassowski/theme-vscode": "~2.1.1",
     "lodash.mergewith": "^4.6.1",
     "lsp-ws-connection": "~0.6.0"
   },

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@krassowski/code-jumpers": "~1.1.0",
-    "@krassowski/completion-theme": "~3.0.0",
+    "@krassowski/completion-theme": "~3.1.0",
     "@krassowski/theme-material": "~2.1.0",
     "@krassowski/theme-vscode": "~2.1.0",
     "lodash.mergewith": "^4.6.1",

--- a/packages/theme-material/package.json
+++ b/packages/theme-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/theme-material",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Material theme for JupyterLab-LSP",
   "keywords": [
     "jupyter",

--- a/packages/theme-material/package.json
+++ b/packages/theme-material/package.json
@@ -33,7 +33,7 @@
     "clean": "rimraf lib"
   },
   "dependencies": {
-    "@krassowski/completion-theme": "~3.0.0"
+    "@krassowski/completion-theme": "^3.0.0"
   },
   "devDependencies": {},
   "peerDependencies": {},

--- a/packages/theme-vscode/package.json
+++ b/packages/theme-vscode/package.json
@@ -33,7 +33,7 @@
     "clean": "rimraf lib"
   },
   "dependencies": {
-    "@krassowski/completion-theme": "~3.0.0"
+    "@krassowski/completion-theme": "^3.0.0"
   },
   "devDependencies": {},
   "peerDependencies": {},

--- a/packages/theme-vscode/package.json
+++ b/packages/theme-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/theme-vscode",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "VSCode theme for JupyterLab-LSP",
   "keywords": [
     "jupyter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,7 +1987,7 @@
   version "1.1.0"
 
 "@krassowski/completion-theme@file:packages/completion-theme":
-  version "3.0.0"
+  version "3.1.0"
 
 "@krassowski/jupyterlab-lsp-example-extractor@file:packages/_example-extractor":
   version "0.0.0"
@@ -1998,7 +1998,7 @@
   version "3.7.0"
   dependencies:
     "@krassowski/code-jumpers" "~1.1.0"
-    "@krassowski/completion-theme" "~3.0.0"
+    "@krassowski/completion-theme" "~3.1.0"
     "@krassowski/theme-material" "~2.1.0"
     "@krassowski/theme-vscode" "~2.1.0"
     lodash.mergewith "^4.6.1"
@@ -2007,12 +2007,12 @@
 "@krassowski/theme-material@file:packages/theme-material":
   version "2.1.0"
   dependencies:
-    "@krassowski/completion-theme" "~3.0.0"
+    "@krassowski/completion-theme" "^3.0.0"
 
 "@krassowski/theme-vscode@file:packages/theme-vscode":
   version "2.1.0"
   dependencies:
-    "@krassowski/completion-theme" "~3.0.0"
+    "@krassowski/completion-theme" "^3.0.0"
 
 "@lerna/add@3.21.0":
   version "3.21.0"


### PR DESCRIPTION
## References

Fixes #628.

## Code changes

Fixes all three causes of missed cache hits:
- lack of coordination between requests (subsequent invokes sent while the old request was `await`ing)
- overlapping range for column (character) position in cache getter
- lack of safety check when storing data in cache

## User-facing changes

- No `console.warn` "spam"
- Hover should be slightly faster as we will be hitting cache more often
- Overall LSP should be slightly faster as we will be sending fewer requests on mouse move

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
