### PR TITLE
Add troubleshooting (schema, specs, dialog window)

### DIFF
--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -185,6 +185,8 @@ jobs:
           python setup.py sdist bdist_wheel
           cd ../jupyterlab_lsp
           python setup.py sdist bdist_wheel
+          cd ../klingon_ls_specification
+          python setup.py sdist bdist_wheel
 
       - name: Collect distributions
         run: |
@@ -298,8 +300,13 @@ jobs:
       - name: Install python packages
         run: python -m pip install --find-links=dist --no-index --ignore-installed --no-deps jupyter_lsp jupyterlab_lsp
 
+      - name: Install Klingon file type extension and server specification (for testing languages without language servers)
+        run: python -m pip install --find-links=dist --no-index --ignore-installed --no-deps klingon_ls_specification
+
       - name: Pip check
-        run: python -m pip check
+        run: |
+          python -m pip check
+          python -m pip list | grep -ie klingon-ls-specification
 
       - name: List server extensions
         run: |
@@ -311,21 +318,11 @@ jobs:
           jupyter serverextension list
           jupyter serverextension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -
 
-      - name: Install Klingon integration extension (for testing languages without language servers)
-        run: |
-          cd packages/_klingon-integration
-          jlpm
-          jlpm build
-          jupyter labextension install
-          jupyter labextension list 2>&1 | grep -ie "klingon-integration.*enabled" -
-          jupyter lab build
-
-      - name: Install specification for (non-existent) Klingon language server
-        run: |
-          python -m pip install python_packages/klingon_ls_specification
-
       - name: List frontend extensions
-        run: jupyter labextension list
+        run: |
+          jupyter labextension list
+          jupyter labextension list 2>&1 | grep -ie "jupyterlab_lsp.*enabled" -
+          jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp-klingon-integration.*enabled" -
 
       - name: install node-based language servers
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -321,7 +321,7 @@ jobs:
       - name: List frontend extensions
         run: |
           jupyter labextension list
-          jupyter labextension list 2>&1 | grep -ie "jupyterlab_lsp.*enabled" -
+          jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp.*enabled" -
           jupyter labextension list 2>&1 | grep -ie "jupyterlab-lsp-klingon-integration.*enabled" -
 
       - name: install node-based language servers

--- a/.github/workflows/job.test.yml
+++ b/.github/workflows/job.test.yml
@@ -311,6 +311,19 @@ jobs:
           jupyter serverextension list
           jupyter serverextension list 2>&1 | grep -ie "jupyter_lsp.*enabled" -
 
+      - name: Install Klingon integration extension (for testing languages without language servers)
+        run: |
+          cd packages/_klingon-integration
+          jlpm
+          jlpm build
+          jupyter labextension install
+          jupyter labextension list 2>&1 | grep -ie "klingon-integration.*enabled" -
+          jupyter lab build
+
+      - name: Install specification for (non-existent) Klingon language server
+        run: |
+          python -m pip install python_packages/klingon_ls_specification
+
       - name: List frontend extensions
         run: jupyter labextension list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - improvements:
 
   - add a note on manually enabling backend extension ([#621], thanks @icankeep)
+  - in-app troubleshooting/installation help is now offered for servers which are needed but could not be detected (if auto-detection specification for those is present) ([#634])
 
 - bug fixes:
   - fix rename shortcut registration in file editor ([#614])
@@ -15,6 +16,7 @@
 [#621]: https://github.com/krassowski/jupyterlab-lsp/pull/621
 [#625]: https://github.com/krassowski/jupyterlab-lsp/pull/625
 [#630]: https://github.com/krassowski/jupyterlab-lsp/pull/630
+[#634]: https://github.com/krassowski/jupyterlab-lsp/pull/634
 
 ### `jupyter-lsp 1.3.0` (2021-06-02)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,9 @@ to JupyterLab for development:
 ```bash
 jlpm bootstrap
 # if you installed `jupyterlab_lsp` before uninstall it before running the next line
-jupyter labextension develop python_packages/jupyterlab_lsp/ --overwrite
+jupyter labextension develop python_packages/jupyterlab_lsp/jupyterlab_lsp/ --overwrite
+# optional, only needed for running a few tests for behaviour with missing language servers
+jupyter labextension develop python_packages/klingon_ls_specification/ --overwrite
 ```
 
 > Note: on Windows you may need to enable Developer Mode first, as discussed in [jupyterlab#9564](https://github.com/jupyterlab/jupyterlab/issues/9564)

--- a/atest/04_Interface/Statusbar.robot
+++ b/atest/04_Interface/Statusbar.robot
@@ -6,6 +6,7 @@ Resource          ../Keywords.robot
 ${STATUSBAR}      css:div.lsp-statusbar-item
 ${DIAGNOSTIC}     W291 trailing whitespace (pycodestyle)
 ${POPOVER}        css:.lsp-popover
+${HELP_BUTTON}    css:.lsp-popover .lsp-help-button
 
 *** Test Cases ***
 Statusbar Popup Opens
@@ -18,6 +19,29 @@ Statusbar Popup Opens
     Element Should Contain    ${POPOVER}    python
     Element Should Contain    ${POPOVER}    initialized
     [Teardown]    Clean Up After Working With File    Python.ipynb
+
+Troubleshooting And Help Is Offered For Known Non-Installed Servers
+    [Documentation]    When specification of a language server has been configured or provided, but the server is not installed (or detected) the user should get help on installation and/or troubleshooting
+    Prepare File for Editing    Python    status    example.klingon
+    Wait Until Element Contains    ${STATUSBAR}    Initialized (additional servers needed)    timeout=60s
+    Click Element    ${STATUSBAR}
+    Wait Until Page Contains Element    ${POPOVER}    timeout=10s
+    Page Should Contain Element    ${HELP_BUTTON}
+    # sanity check
+    Page Should Not Contain    run-klingon-language-server not found.
+    Click Element    ${HELP_BUTTON}
+    Wait For Dialog
+    # info message should get generated
+    Page Should Contain    There is 1 language server you can easily install that supports klingon.
+    # provided links should be shown
+    Page Should Contain    https://en.wikipedia.org/wiki/Klingon_language
+    # automated shellspec troubleshooting should get generates
+    Page Should Contain    run-klingon-language-server not found.
+    # specification-provided troubeshooting should be shown too
+    Page Should Contain    This is just a test language server.
+    # installation command should be shown
+    Page Should Contain    echo "This language server cannot be installed."
+    [Teardown]    Clean Up After Working With File    example.klingon
 
 Status Changes Between Notebooks
     Setup Notebook    Python    Python.ipynb

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -113,6 +113,7 @@ Open JupyterLab
     Set Environment Variable    MOZ_HEADLESS    ${HEADLESS}
     ${firefox} =    Get Firefox Binary
     ${geckodriver} =    Which    geckodriver
+    Should Not Be Equal As Strings    ${geckodriver}    None    geckodriver not found, do you need to install firefox-geckodriver?
     ${service args} =    Create List    --log    debug
     Create WebDriver    Firefox
     ...    executable_path=${geckodriver}

--- a/docs/Configuring.ipynb
+++ b/docs/Configuring.ipynb
@@ -74,7 +74,12 @@
     "    element of [kernel_info][] response (with fallback on to cell metadata if\n",
     "    missing from kernel response)\n",
     "  - for files the implementation is frontend-specific; in JupyterLab the MIME\n",
-    "    type is obtained from the MIME type registry.\n",
+    "    type is obtained from: a) the code editor MIME type registry, which is by\n",
+    "    default using the CodeMirror mode as for JupyterLab 3.x, or if no specific\n",
+    "    MIME type is found there, then b) from the `DocumentRegistry` file type by\n",
+    "    matching the `contentsModel` against the registered file types using\n",
+    "    `getFileTypeForModel()` method (if multiple MIME types are present, the\n",
+    "    first one will be used).\n",
     "\n",
     "```python\n",
     "# ./jupyter_server_config.json                   ---------- unique! -----------\n",
@@ -315,7 +320,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/Language Servers.ipynb
+++ b/docs/Language Servers.ipynb
@@ -309,11 +309,51 @@
     "  reference navigation\n",
     "- `chktex`, a `.tex` style checker"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Troubleshooting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "wide-table"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "troubleshooting_data = {\n",
+    "    key: spec\n",
+    "    for key, spec in mgr.language_servers.items()\n",
+    "    if (\n",
+    "        \"troubleshoot\" in spec\n",
+    "        # ignore trivial Node.js advice if only this is present\n",
+    "        and spec[\"troubleshoot\"] != \"Node.js is required to install this server.\"\n",
+    "        # ignore trivial shell advice if only this is present\n",
+    "        and spec[\"troubleshoot\"] != f\"{spec['argv'][0]} not found.\"\n",
+    "    )\n",
+    "}\n",
+    "\n",
+    "IPython.display.HTML(Template(\n",
+    "    \"\"\"\n",
+    "    {% for key, spec in specs.items() %}\n",
+    "    <h4>{{ key }}</h4>\n",
+    "    <p style=\"white-space: pre-wrap\">{{ spec.troubleshoot }}</p>\n",
+    "    {% endfor %}\n",
+    "    \"\"\"\n",
+    ").render(specs=troubleshooting_data))"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/Language Servers.ipynb
+++ b/docs/Language Servers.ipynb
@@ -340,14 +340,16 @@
     "    )\n",
     "}\n",
     "\n",
-    "IPython.display.HTML(Template(\n",
-    "    \"\"\"\n",
+    "IPython.display.HTML(\n",
+    "    Template(\n",
+    "        \"\"\"\n",
     "    {% for key, spec in specs.items() %}\n",
     "    <h4>{{ key }}</h4>\n",
     "    <p style=\"white-space: pre-wrap\">{{ spec.troubleshoot }}</p>\n",
     "    {% endfor %}\n",
     "    \"\"\"\n",
-    ").render(specs=troubleshooting_data))"
+    "    ).render(specs=troubleshooting_data)\n",
+    ")"
    ]
   }
  ],

--- a/packages/_klingon-integration/README.md
+++ b/packages/_klingon-integration/README.md
@@ -1,0 +1,6 @@
+# Klingon editor integration
+
+Plugin used to test behaviour of the jupyterlab-lsp extension
+with languages that have no installed server.
+
+Klingon is a fictional language.

--- a/packages/_klingon-integration/babel.config.js
+++ b/packages/_klingon-integration/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@jupyterlab/testutils/lib/babel.config');

--- a/packages/_klingon-integration/package.json
+++ b/packages/_klingon-integration/package.json
@@ -15,13 +15,21 @@
   "devDependencies": {
     "@babel/preset-env": "^7.4.3",
     "@jupyterlab/application": "^3.0.0",
+    "@jupyterlab/builder": "^3.0.0",
     "typescript": "~4.1.3"
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "outputDir": "../../python_packages/klingon_ls_specification/klingon_ls_specification/labextensions/@krassowski/_klingon-integration"
   },
   "scripts": {
-    "build": "tsc -b",
-    "clean:lib": "rimraf lib"
+    "build": "jlpm run build:lib && jlpm run build:labextension",
+    "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
+    "build:lib": "tsc",
+    "clean:lib": "rimraf lib",
+    "watch": "run-p watch:src watch:labextension",
+    "watch:labextension": "jupyter labextension watch .",
+    "watch:src": "tsc -w"
   }
 }

--- a/packages/_klingon-integration/package.json
+++ b/packages/_klingon-integration/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@krassowski/jupyterlab-lsp-klingon-integration",
+  "description": "Klingon language integration for testing @krassowski/jupyterlab-lsp",
+  "version": "0.0.0",
+  "private": true,
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "author": "JupyterLab-LSP Development Team",
+  "files": [
+    "lib/**/*.{js,ts}"
+  ],
+  "dependencies": {
+    "@jupyterlab/application": "^3.0.0"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.4.3",
+    "@jupyterlab/application": "^3.0.0",
+    "typescript": "~4.1.3"
+  },
+  "jupyterlab": {
+    "extension": true
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "clean:lib": "rimraf lib"
+  }
+}

--- a/packages/_klingon-integration/package.json
+++ b/packages/_klingon-integration/package.json
@@ -20,7 +20,7 @@
   },
   "jupyterlab": {
     "extension": true,
-    "outputDir": "../../python_packages/klingon_ls_specification/klingon_ls_specification/labextensions/@krassowski/_klingon-integration"
+    "outputDir": "../../python_packages/klingon_ls_specification/klingon_ls_specification/labextensions/@krassowski/jupyterlab-lsp-klingon-integration"
   },
   "scripts": {
     "build": "jlpm run build:lib && jlpm run build:labextension",

--- a/packages/_klingon-integration/src/index.ts
+++ b/packages/_klingon-integration/src/index.ts
@@ -1,0 +1,34 @@
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+
+const NS = '@krassowski/jupyterlab-lsp-klingon-integration';
+
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: `${NS}:PLUGIN`,
+  activate: (app: JupyterFrontEnd) => {
+    // this will have a language server specification
+    // but the language server will NOT be installed
+    app.docRegistry.addFileType({
+      name: 'klingon',
+      mimeTypes: ['text/klingon'],
+      extensions: ['.klingon'],
+      displayName: 'Klingon',
+      contentType: 'file',
+      fileFormat: 'text'
+    });
+    // this will NOT have a language server specification
+    app.docRegistry.addFileType({
+      name: 'ancient-klingon',
+      mimeTypes: ['text/ancient-klingon'],
+      extensions: ['.ancient_klingon'],
+      displayName: 'Ancient Klingon',
+      contentType: 'file',
+      fileFormat: 'text'
+    });
+  },
+  autoStart: true
+};
+
+export default plugin;

--- a/packages/_klingon-integration/transform.js
+++ b/packages/_klingon-integration/transform.js
@@ -1,0 +1,2 @@
+const config = require('./babel.config.js');
+module.exports = require('babel-jest').createTransformer(config);

--- a/packages/_klingon-integration/tsconfig.json
+++ b/packages/_klingon-integration/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfigbase",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "tsBuildInfoFile": "lib/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../jupyterlab-lsp"
+    }
+  ]
+}

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -108,6 +108,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
   public editorAdded: Signal<WidgetAdapter<T>, IEditorChangedData>;
   public editorRemoved: Signal<WidgetAdapter<T>, IEditorChangedData>;
   public update_finished: Promise<void>;
+  public initialized: Promise<void>;
 
   /**
    * (re)create virtual document using current path and language

--- a/packages/jupyterlab-lsp/src/adapters/notebook/notebook.ts
+++ b/packages/jupyterlab-lsp/src/adapters/notebook/notebook.ts
@@ -33,7 +33,9 @@ export class NotebookAdapter extends WidgetAdapter<NotebookPanel> {
     this.ce_editor_to_cell = new Map();
     this.editor = editor_widget.content;
     this.known_editors_ids = new Set();
-    this.init_once_ready().catch(this.console.warn);
+    this.initialized = new Promise<void>((resolve, reject) => {
+      this.init_once_ready().then(resolve).catch(reject);
+    });
   }
 
   private async update_language_info() {
@@ -123,7 +125,7 @@ export class NotebookAdapter extends WidgetAdapter<NotebookPanel> {
     return this.widget.node;
   }
 
-  async init_once_ready() {
+  protected async init_once_ready() {
     this.console.log('waiting for', this.document_path, 'to fully load');
     await this.widget.context.sessionContext.ready;
     await until_ready(this.is_ready, -1);

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -157,13 +157,17 @@ class LanguageServerInfo extends React.Component<ILanguageServerInfo, any> {
           </p>
           <h4>{trans.__('Installation')}</h4>
           <ul>
-            {Object.entries(specification?.install || {}).map(
-              ([name, command]) => (
-                <li key={this.props.serverId + '-install-' + name}>
-                  {name}: <code>{command}</code>
-                </li>
-              )
-            )}
+            {specification?.install
+              ? Object.entries(specification?.install || {}).map(
+                  ([name, command]) => (
+                    <li key={this.props.serverId + '-install-' + name}>
+                      {name}: <code>{command}</code>
+                    </li>
+                  )
+                )
+              : trans.__(
+                  'No installation instructions were provided with this specification.'
+                )}
           </ul>
         </div>
       </div>
@@ -321,9 +325,6 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
         const specs_for_missing = this.model.language_server_manager.getMatchingSpecs(
           { language }
         );
-        if (language === 'r') {
-          language = 'R';
-        }
         return (
           <div key={i} className={'lsp-missing-server'}>
             {language}

--- a/packages/jupyterlab-lsp/src/components/statusbar.tsx
+++ b/packages/jupyterlab-lsp/src/components/statusbar.tsx
@@ -321,7 +321,9 @@ class LSPPopup extends VDomRenderer<LSPStatus.Model> {
         const specs_for_missing = this.model.language_server_manager.getMatchingSpecs(
           { language }
         );
-        console.log(specs_for_missing);
+        if (language === 'r') {
+          language = 'R';
+        }
         return (
           <div key={i} className={'lsp-missing-server'}>
             {language}

--- a/packages/jupyterlab-lsp/src/editor_integration/cm_adapter.spec.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/cm_adapter.spec.ts
@@ -27,6 +27,10 @@ describe('CodeMirrorAdapter', () => {
         }
       }
 
+      await env.adapter.widget.context.initialize(true);
+      await env.adapter.widget.context.ready;
+      await env.adapter.initialized;
+
       let feature = env.init_integration({
         constructor: UpdateReceivingFeature,
         id: 'UpdateReceivingFeature'

--- a/packages/jupyterlab-lsp/src/tokens.ts
+++ b/packages/jupyterlab-lsp/src/tokens.ts
@@ -46,6 +46,7 @@ export type TLanguageServerId =
 export type TServerKeys = TLanguageServerId;
 
 export type TSessionMap = Map<TServerKeys, SCHEMA.LanguageServerSession>;
+export type TSpecsMap = Map<TServerKeys, SCHEMA.LanguageServerSpec>;
 
 export type TLanguageServerConfigurations = Partial<
   Record<TServerKeys, LSPLanguageServerSettings>
@@ -55,11 +56,18 @@ export interface ILanguageServerManager {
   sessionsChanged: ISignal<ILanguageServerManager, void>;
   sessions: TSessionMap;
   /**
-   * An ordered list of matching servers, with servers of higher priority higher in the list
+   * An ordered list of matching >running< sessions, with servers of higher priority higher in the list
    */
   getMatchingServers(
     options: ILanguageServerManager.IGetServerIdOptions
   ): TLanguageServerId[];
+
+  /**
+   * A list of all known matching specs (whether detected or not).
+   */
+  getMatchingSpecs(
+    options: ILanguageServerManager.IGetServerIdOptions
+  ): TSpecsMap;
   setConfiguration(configuration: TLanguageServerConfigurations): void;
   fetchSessions(): Promise<void>;
   statusUrl: string;

--- a/packages/jupyterlab-lsp/style/statusbar.css
+++ b/packages/jupyterlab-lsp/style/statusbar.css
@@ -131,8 +131,13 @@ body[data-jp-theme-light='false'] .lsp-status-icon.ready svg g {
 }
 
 .lsp-help-button {
+  background: var(--jp-layout-color2);
   border: 1px solid var(--jp-brand-color0);
   float: right;
+}
+
+.lsp-help-button:hover {
+  background: var(--jp-layout-color3);
 }
 
 .lsp-server-links-list a {

--- a/packages/jupyterlab-lsp/style/statusbar.css
+++ b/packages/jupyterlab-lsp/style/statusbar.css
@@ -114,6 +114,10 @@ h5 {
   fill: var(--jp-layout-color3);
 }
 
+.lsp-status-message {
+  user-select: none;
+}
+
 body[data-jp-theme-light='false'] .lsp-status-icon.ready svg g {
   fill: var(--jp-success-color1);
 }
@@ -124,4 +128,18 @@ body[data-jp-theme-light='false'] .lsp-status-icon.ready svg g {
 
 .jp-ToolbarButton .lsp-status-icon svg {
   top: 5px;
+}
+
+.lsp-help-button {
+  border: 1px solid var(--jp-brand-color0);
+  float: right;
+}
+
+.lsp-server-links-list a {
+  color: var(--jp-content-link-color);
+}
+
+.lsp-troubleshoot-section {
+  white-space: pre-wrap;
+  margin: 10px 0;
 }

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -32,7 +32,8 @@
     "@krassowski/theme-vscode": "file:../theme-vscode",
     "@krassowski/code-jumpers": "file:../code-jumpers",
     "@krassowski/jupyterlab-lsp": "file:../jupyterlab-lsp",
-    "@krassowski/jupyterlab-lsp-example-extractor": "file:../_example-extractor"
+    "@krassowski/jupyterlab-lsp-example-extractor": "file:../_example-extractor",
+    "@krassowski/jupyterlab-lsp-klingon-integration": "file:../_klingon-integration"
   },
   "devDependencies": {
     "fs-extra": "^8.0.1",

--- a/packages/metapackage/src/index.ts
+++ b/packages/metapackage/src/index.ts
@@ -2,6 +2,7 @@ import '@krassowski/code-jumpers';
 import '@krassowski/completion-theme';
 import '@krassowski/jupyterlab-lsp';
 import '@krassowski/jupyterlab-lsp-example-extractor';
+import '@krassowski/jupyterlab-lsp-klingon-integration';
 import '@krassowski/theme-material';
 import '@krassowski/theme-vscode';
 import 'lsp-ws-connection';

--- a/packages/metapackage/tsconfig.json
+++ b/packages/metapackage/tsconfig.json
@@ -28,6 +28,9 @@
     },
     {
       "path": "../_example-extractor"
+    },
+    {
+      "path": "../_klingon-integration"
     }
   ]
 }

--- a/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
@@ -8,6 +8,7 @@ from jupyter_server.utils import url_path_join as ujoin
 
 from .manager import LanguageServerManager
 from .schema import SERVERS_RESPONSE
+from .specs.utils import censored_spec
 
 
 class BaseHandler(JupyterHandler):
@@ -55,6 +56,10 @@ class LanguageServersHandler(BaseHandler):
             "sessions": {
                 language_server: session.to_json()
                 for language_server, session in self.manager.sessions.items()
+            },
+            "specs": {
+                key: censored_spec(spec)
+                for key, spec in self.manager.all_language_servers.items()
             },
         }
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/handlers.py
@@ -66,7 +66,7 @@ class LanguageServersHandler(BaseHandler):
         errors = list(self.validator.iter_errors(response))
 
         if errors:  # pragma: no cover
-            self.log.warn("{} validation errors: {}", len(errors), errors)
+            self.log.warning("{} validation errors: {}".format(len(errors), errors))
 
         self.finish(response)
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/schema/schema.json
+++ b/python_packages/jupyter_lsp/jupyter_lsp/schema/schema.json
@@ -139,6 +139,11 @@
           "description": "list of MIME types supported by the language server",
           "title": "MIME Types"
         },
+        "troubleshoot": {
+          "type": "string",
+          "description": "information on troubleshooting the installation or auto-detection of the language server",
+          "title": "Troubleshooting"
+        },
         "urls": {
           "additionalProperties": {
             "format": "uri",
@@ -164,6 +169,9 @@
       "properties": {
         "sessions": {
           "$ref": "#/definitions/sessions"
+        },
+        "specs": {
+          "$ref": "#/definitions/language-server-specs-implementation-map"
         },
         "version": {
           "$ref": "#/definitions/current-version"

--- a/python_packages/jupyter_lsp/jupyter_lsp/session.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/session.py
@@ -16,11 +16,9 @@ from traitlets.config import LoggingConfigurable
 
 from . import stdio
 from .schema import LANGUAGE_SERVER_SPEC
+from .specs.utils import censored_spec
 from .trait_types import Schema
 from .types import SessionStatus
-
-# these are not desirable to publish to the frontend
-SKIP_JSON_SPEC = ["argv", "debug_argv", "env"]
 
 
 class LanguageServerSession(LoggingConfigurable):
@@ -74,7 +72,7 @@ class LanguageServerSession(LoggingConfigurable):
             last_handler_message_at=self.last_handler_message_at.isoformat()
             if self.last_handler_message_at
             else None,
-            spec={k: v for k, v in self.spec.items() if k not in SKIP_JSON_SPEC},
+            spec=censored_spec(self.spec),
         )
 
     def initialize(self):

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/r_languageserver.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/r_languageserver.py
@@ -1,5 +1,20 @@
 from .utils import ShellSpec
 
+TROUBLESHOOT = """\
+Please ensure that RScript executable is in the PATH; \
+this should happen automatically when using Linux, Mac OS or Conda, \
+but will require manual configuration when using the default R installer on Windows.
+
+For more details please consult documentation:
+https://cran.r-project.org/bin/windows/base/rw-FAQ.html#Rcmd-is-not-found-in-my-PATH_0021
+
+If Rscript is already in the PATH, you can check whether the language server package is properly installed with:
+
+  Rscript -e "cat(system.file(package='languageserver'))"
+
+which should return the path to the installed package.
+"""
+
 
 class RLanguageServer(ShellSpec):
     package = "languageserver"
@@ -26,4 +41,5 @@ class RLanguageServer(ShellSpec):
             cran=f'install.packages("{package}")',
             conda="conda install -c conda-forge r-languageserver",
         ),
+        troubleshoot=TROUBLESHOOT,
     )

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/r_languageserver.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/r_languageserver.py
@@ -8,7 +8,8 @@ but will require manual configuration when using the default R installer on Wind
 For more details please consult documentation:
 https://cran.r-project.org/bin/windows/base/rw-FAQ.html#Rcmd-is-not-found-in-my-PATH_0021
 
-If Rscript is already in the PATH, you can check whether the language server package is properly installed with:
+If Rscript is already in the PATH, you can check whether \
+the language server package is properly installed with:
 
   Rscript -e "cat(system.file(package='languageserver'))"
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
@@ -70,7 +70,7 @@ class ShellSpec(SpecBase):  # pragma: no cover
 
         return {
             self.key: {
-                "argv": [cmd, *self.args] if cmd else [],
+                "argv": [cmd, *self.args] if cmd else [self.cmd, *self.args],
                 "languages": self.languages,
                 "version": SPEC_VERSION,
                 **spec,

--- a/python_packages/jupyter_lsp/jupyter_lsp/tests/test_detect.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/tests/test_detect.py
@@ -1,5 +1,3 @@
-import shutil
-
 from jupyter_lsp.specs.r_languageserver import RLanguageServer
 from jupyter_lsp.specs.utils import PythonModuleSpec
 
@@ -18,17 +16,14 @@ def test_detect(manager):
 
 
 def test_r_package_detection():
-    existing_runner = shutil.which("Rscript")
-
     with_installed_server = RLanguageServer()
-    assert with_installed_server.is_installed(cmd=existing_runner) is True
-    assert with_installed_server.is_installed(cmd=None) is False
+    assert with_installed_server.is_installed(mgr=None) is True
 
     class NonInstalledRServer(RLanguageServer):
         package = "languageserver-fork"
 
     non_installed_server = NonInstalledRServer()
-    assert non_installed_server.is_installed(cmd=existing_runner) is False
+    assert non_installed_server.is_installed(mgr=None) is False
 
 
 def test_missing_python_module_spec():
@@ -36,6 +31,11 @@ def test_missing_python_module_spec():
 
     class NonInstalledPythonServer(PythonModuleSpec):
         python_module = "not_installed_python_module"
+        key = "a_module"
 
     not_installed_server = NonInstalledPythonServer()
-    assert not_installed_server(mgr=None) == {}
+
+    assert not_installed_server.is_installed(mgr=None) is False
+
+    # we ant the spec even when not installed
+    assert "languages" in not_installed_server(mgr=None)["a_module"]

--- a/python_packages/jupyter_lsp/jupyter_lsp/types.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/types.py
@@ -17,6 +17,7 @@ from typing import (
     Optional,
     Pattern,
     Text,
+    Union,
 )
 
 from jupyter_server.transutils import _
@@ -256,5 +257,29 @@ class LanguageServerManagerAPI(LoggingConfigurable, HasListeners):
         return roots
 
 
+SimpleSpecMaker = Callable[[LanguageServerManagerAPI], KeyedLanguageServerSpecs]
+
+# String corresponding to a fragment of a shell command
+# arguments list such as returned by `shlex.split`
+Token = Text
+
+
+class SpecBase:
+    """Base for a spec finder that returns a spec for starting a language server"""
+
+    key = ""
+    languages: List[Text] = []
+    args: List[Token] = []
+    spec: LanguageServerSpec = {}
+
+    def is_installed(self, mgr: LanguageServerManagerAPI) -> bool:
+        return True
+
+    def __call__(
+        self, mgr: LanguageServerManagerAPI
+    ) -> KeyedLanguageServerSpecs:  # pragma: no cover
+        return {}
+
+
 # Gotta be down here so it can by typed... really should have a IL
-SpecMaker = Callable[[LanguageServerManagerAPI], KeyedLanguageServerSpecs]
+SpecMaker = Union[SpecBase, SimpleSpecMaker]

--- a/python_packages/jupyter_lsp/jupyter_lsp/types.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/types.py
@@ -272,7 +272,10 @@ class SpecBase:
     args: List[Token] = []
     spec: LanguageServerSpec = {}
 
-    def is_installed(self, mgr: LanguageServerManagerAPI) -> bool:
+    def is_installed(self, mgr: LanguageServerManagerAPI) -> bool:  # pragma: no cover
+        """Whether the language server is installed or not.
+
+        This method may become abstract in the next major release."""
         return True
 
     def __call__(

--- a/python_packages/klingon_ls_specification/klingon_ls_specification/__init__.py
+++ b/python_packages/klingon_ls_specification/klingon_ls_specification/__init__.py
@@ -1,0 +1,39 @@
+from jupyter_lsp.specs.utils import ShellSpec
+
+
+class KlingonServerSpecification(ShellSpec):
+    """Dummy specs for testing the behaviour with non-installed servers."""
+
+    # This one (obviously) does not exist; for a real server,
+    # just use the name of the command to run; please note
+    # that there are other convenience classes such as
+    # `PythonModuleSpec` or `NodeModuleSpec`.
+    cmd = "run-klingon-language-server"
+
+    # Language will be matched against the programming language of file which
+    # gets inferred from MIME type (and MIME type gets inferred from the file
+    # extension, using the file type registered with `DocumentRegistry` in
+    # `packages/_klingon-integration/src/index.ts`). Note that in general case
+    # there registering the file type may not be needed (because the MIME type
+    # for many languages can be inferred from the code highlighting modes, or
+    # can be retrieved directly from kernel response in notebooks).
+    languages = ["klingon"]
+
+    spec = {
+        "troubleshoot": "This is just a test language server.",
+        "urls": {"Wikipedia": "https://en.wikipedia.org/wiki/Klingon_language"},
+        "install": {"pip": 'echo "This language server cannot be installed."'},
+    }
+
+    def is_installed(self, manager) -> bool:
+        # For a real server do not override this method,
+        # but instead use `is_installed_args` (if possible).
+        return False
+
+
+# Note: in a real world use, you could just create a function that accepts one
+# argument (of `LanguageServerManager` type) and returns a nested dict
+# following our schema, but using an object of class inheriting from `SpecBase`
+# (note: `ShellSpec` inherits from `SpecBase`) allows for adding methods such
+# as `is_installed()` easily.
+SPECS = KlingonServerSpecification()

--- a/python_packages/klingon_ls_specification/setup.cfg
+++ b/python_packages/klingon_ls_specification/setup.cfg
@@ -1,0 +1,14 @@
+[metadata]
+name = klingon-ls-specification
+version = 0.0.0
+description = Klingon language server specification for testing behaviour with non-installed language servers
+author = JupyterLab-LSP Development Team
+
+[options]
+packages = find:
+install_requires =
+    jupyter_lsp >=1.1.0
+
+[options.entry_points]
+jupyter_lsp_spec_v1 =
+    jupyter-klingon-language-server = klingon_ls_specification:SPECS

--- a/python_packages/klingon_ls_specification/setup.cfg
+++ b/python_packages/klingon_ls_specification/setup.cfg
@@ -6,6 +6,8 @@ author = JupyterLab-LSP Development Team
 
 [options]
 packages = find:
+include_package_data = True
+zip_safe = False
 install_requires =
     jupyter_lsp >=1.1.0
 

--- a/python_packages/klingon_ls_specification/setup.py
+++ b/python_packages/klingon_ls_specification/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/python_packages/klingon_ls_specification/setup.py
+++ b/python_packages/klingon_ls_specification/setup.py
@@ -5,7 +5,10 @@ from setuptools import setup
 LABEXTENSIONS_DIR = Path("klingon_ls_specification/labextensions")
 LABEXTENSIONS_INSTALL_DIR = Path("share") / "jupyter" / "labextensions"
 LAB_PACKAGE_PATH = (
-    LABEXTENSIONS_DIR / "@krassowski" / "_klingon-integration" / "package.json"
+    LABEXTENSIONS_DIR
+    / "@krassowski"
+    / "jupyterlab-lsp-klingon-integration"
+    / "package.json"
 )
 
 

--- a/python_packages/klingon_ls_specification/setup.py
+++ b/python_packages/klingon_ls_specification/setup.py
@@ -1,3 +1,24 @@
+from pathlib import Path
+
 from setuptools import setup
 
-setup()
+LABEXTENSIONS_DIR = Path("klingon_ls_specification/labextensions")
+LABEXTENSIONS_INSTALL_DIR = Path("share") / "jupyter" / "labextensions"
+LAB_PACKAGE_PATH = (
+    LABEXTENSIONS_DIR / "@krassowski" / "_klingon-integration" / "package.json"
+)
+
+
+def get_data_files():
+    extension_files = [
+        (
+            str(LABEXTENSIONS_INSTALL_DIR / file.relative_to(LABEXTENSIONS_DIR).parent),
+            [str(file.as_posix())],
+        )
+        for file in LABEXTENSIONS_DIR.rglob("*.*")
+    ]
+
+    return extension_files
+
+
+setup(data_files=get_data_files())

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ test = pytest
 [flake8]
 exclude = .git,__pycache__,envs,.ipynb_checkpoints,.mypy_cache
 max-line-length = 88
-ignore = E203
+ignore = E203,W503
 
 [isort]
 profile = black

--- a/yarn.lock
+++ b/yarn.lock
@@ -1994,23 +1994,28 @@
   dependencies:
     "@krassowski/jupyterlab-lsp" "^3.6"
 
+"@krassowski/jupyterlab-lsp-klingon-integration@file:packages/_klingon-integration":
+  version "0.0.0"
+  dependencies:
+    "@jupyterlab/application" "^3.0.0"
+
 "@krassowski/jupyterlab-lsp@file:packages/jupyterlab-lsp":
   version "3.7.0"
   dependencies:
     "@krassowski/code-jumpers" "~1.1.0"
     "@krassowski/completion-theme" "~3.1.0"
-    "@krassowski/theme-material" "~2.1.0"
-    "@krassowski/theme-vscode" "~2.1.0"
+    "@krassowski/theme-material" "~2.1.1"
+    "@krassowski/theme-vscode" "~2.1.1"
     lodash.mergewith "^4.6.1"
     lsp-ws-connection "~0.6.0"
 
 "@krassowski/theme-material@file:packages/theme-material":
-  version "2.1.0"
+  version "2.1.1"
   dependencies:
     "@krassowski/completion-theme" "^3.0.0"
 
 "@krassowski/theme-vscode@file:packages/theme-vscode":
-  version "2.1.0"
+  version "2.1.1"
   dependencies:
     "@krassowski/completion-theme" "^3.0.0"
 


### PR DESCRIPTION
## References

Fixes #631

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- the `status/` endpoint of jupyter-lsp (backend) now returns an extra key `specs` with specifications for all known language servers (whether installed or not)
- new attribute `LanguageServerManager.all_language_servers: KeyedLanguageServerSpecs`
- added new property to specs: `troubleshoot` allowing to describe how to troubleshoot installation/auto-detection of the language server
- `SpecsMaker` now explicitly includes `SpecBase`, which got `is_installed()` as proper API member

## User-facing changes

![Screenshot from 2021-06-25 23-30-11](https://user-images.githubusercontent.com/5832902/123491197-12e7cf00-d60e-11eb-9957-c0e3010a148d.png)
![Screenshot from 2021-06-25 23-30-02](https://user-images.githubusercontent.com/5832902/123491198-13806580-d60e-11eb-8707-620dc134f5d8.png)


## Backwards-incompatible changes

None?

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [x] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
