### PR TITLE
Prepare jupyterlab-lsp 3.8.0 and jupyter-lsp 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## Changelog
 
-### `@krassowski/jupyterlab-lsp 3.7.1` (unreleased)
+### `@krassowski/jupyterlab-lsp 3.8.0` (2021-07-04)
 
 - improvements:
 
   - add a note on manually enabling backend extension ([#621], thanks @icankeep)
-  - in-app troubleshooting/installation help is now offered for servers which are needed but could not be detected (if auto-detection specification for those is present) ([#634])
+  - in-app troubleshooting/installation help is now offered for servers which are needed but could not be detected
+    (if auto-detection specification for those is present) ([#634])
 
 - bug fixes:
   - fix rename shortcut registration in file editor ([#614])
@@ -16,6 +17,25 @@
 [#621]: https://github.com/krassowski/jupyterlab-lsp/pull/621
 [#625]: https://github.com/krassowski/jupyterlab-lsp/pull/625
 [#630]: https://github.com/krassowski/jupyterlab-lsp/pull/630
+[#634]: https://github.com/krassowski/jupyterlab-lsp/pull/634
+
+### `jupyter-lsp 1.4.0` (2021-07-04)
+
+- features:
+
+  - `troubleshoot` property was added to the language server spec, allowing to describe auto-detection troubleshooting
+    ([#634])
+  - new endpoint `specs` will list all language server specifications known to `jupyter-lsp` allowing frontends
+    to suggest installation of specific language servers ([#634])
+
+- changes:
+  - `ShellSpec.is_installed()` signature changed; it now accepts the `LanguageServerManagerAPI` rather than the resolved
+    command location (of `str` type); the specs using only `is_installed_args` are not affected; as this method was only
+    used by internally by the `__call__` implementation (which was adjusted accordingly) this change should not break
+    existing specs unless any of these methods were overridden in sub-classes.
+  - `SpecBase` was moved to `types.py`; it can still be imported from `utils`, but doing so is discouraged
+  - `ShellSpec.solve()` was added to facilitate discovery of command location
+
 [#634]: https://github.com/krassowski/jupyterlab-lsp/pull/634
 
 ### `jupyter-lsp 1.3.0` (2021-06-02)

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp-metapackage",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/krassowski/jupyterlab-lsp",
   "bugs": {

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_lsp version
 """
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/python_packages/jupyterlab_lsp/setup.cfg
+++ b/python_packages/jupyterlab_lsp/setup.cfg
@@ -32,5 +32,5 @@ zip_safe = False
 python_requires = >=3.6
 
 install_requires =
-    jupyter_lsp >=1.1.0
+    jupyter_lsp >=1.4.0
     jupyterlab >=3.0.0,<4.0.0a0


### PR DESCRIPTION
Bumping frontend to 3.8 as there are new features added.

Bumping backend to 1.4 as the schema was extended. There are potentially breaking changes to `ShellSpec` but these pertain methods which were never advertised as public API (though they were not strictly private either). See CHANGELOG for details.