### PR TITLE
Fix warnings for uninstalled language servers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,7 +332,7 @@ python scripts/lint.py
 
 ### Specs
 
-While language servers can be configured by the user using a simple JSON or Python [configuration file](./Configuring.html#language-servers),
+While language servers can be configured by the user using a simple JSON or Python [configuration file](./docs/Configuring.ipynb),
 it is preferable to provide users with an option that does not require manual configuration. The language server specifications (specs)
 wrap the configuration (as would be defined by the user) into a Python class or function that can be either:
 
@@ -361,7 +361,7 @@ A spec is a Python callable (a function, or a class with `__call__` method) that
 
 The above example is only intended as an illustration and not as an up-to-date guide.
 For details on the dictionary contents, see the [schema][] definition and [built-in specs][].
-Basic concepts (meaning of the `argv` and `languages` arguments) are also explained in the [configuration files](./Configuring.html#language-servers) documentation.
+Basic concepts (meaning of the `argv` and `languages` arguments) are also explained in the [configuration files](./docs/Configuring.ipynb) documentation.
 
 When contributing a specification we recommend to make use of the helper classes and other [utilities][] that take care of the common use-cases:
 

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
@@ -141,9 +141,15 @@ class NodeModuleSpec(SpecBase):
             troubleshooting.append(spec["troubleshoot"])
         spec["troubleshoot"] = "\n\n".join(troubleshooting)
 
+        is_installed = self.is_installed(mgr)
+        
         return {
             self.key: {
-                "argv": [mgr.nodejs, node_module, *self.args],
+                "argv": (
+                    [mgr.nodejs, node_module, *self.args]
+                    if is_installed
+                    else []
+                ),
                 "languages": self.languages,
                 "version": SPEC_VERSION,
                 **spec,

--- a/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py
@@ -142,14 +142,10 @@ class NodeModuleSpec(SpecBase):
         spec["troubleshoot"] = "\n\n".join(troubleshooting)
 
         is_installed = self.is_installed(mgr)
-        
+
         return {
             self.key: {
-                "argv": (
-                    [mgr.nodejs, node_module, *self.args]
-                    if is_installed
-                    else []
-                ),
+                "argv": ([mgr.nodejs, node_module, *self.args] if is_installed else []),
                 "languages": self.languages,
                 "version": SPEC_VERSION,
                 **spec,


### PR DESCRIPTION
## References
Fixes #640 - language server validator errors
Also updates broken link to configuring language server doc

## Code changes
Update `NodeModuleSpec` `__call__` function to resolve `argv` as an empty array when spec is not installed (same approach used in [PythonModuleSpec](https://github.com/krassowski/jupyterlab-lsp/blob/bba7fd1f3f10e93c2dc428bb19eb2959a9b29def/python_packages/jupyter_lsp/jupyter_lsp/specs/utils.py#L81)).

This gets rid of `<ValidationError: "None is not of type 'string'">` messages, logged when `node_module` attribute is passed as `None` to `argv` array for any `NodeModuleSpec` not installed.

## User-facing changes
No more warnings logged for uninstalled language servers  when running lab using `--debug` .

## Backwards-incompatible changes
None

## Chores
- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested (Ran `python scripts/utest.py` + manual checked for warning logs in debug mode)
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->