### PR TITLE
Correct rpy2 `%Rdevice` magic integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### `@krassowski/jupyterlab-lsp 3.8.1` (unreleased)
+
+- bug fixes:
+  - `%Rdevice` magic is now properly overridden and won't be extracted to R code [(#646)]
+
+[#646]: https://github.com/krassowski/jupyterlab-lsp/pull/646
+
 ### `@krassowski/jupyterlab-lsp 3.8.0` (2021-07-04)
 
 - improvements:

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
@@ -34,6 +34,14 @@ describe('IPython rpy2 extractors', () => {
   });
 
   describe('%R line magic', () => {
+    it('should not extract parts of non-code commands', () => {
+      let code = wrap_in_python_lines('%Rdevice svg');
+      let { cell_code_kept, foreign_document_map } = extract(code);
+
+      expect(cell_code_kept).to.equal(code);
+      expect(foreign_document_map.size).to.equal(0);
+    });
+
     it('correctly gives ranges in source', () => {
       let code = '%R ggplot()';
       let { foreign_document_map } = extract(code);

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.ts
@@ -53,7 +53,8 @@ export let foreign_code_extractors: IForeignCodeExtractorsRegistry = {
       language: 'r',
       // it is very important to not include the space which will be trimmed in the capture group,
       // otherwise the offset will be off by one and the R language server will crash
-      pattern: '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + ' ?(.*)?\n?',
+      pattern:
+        '(?:^|\n)%R' + rpy2_args_pattern(RPY2_MAX_ARGS) + '(?: (.*))?(?:\n|$)',
       foreign_capture_groups: [RPY2_MAX_ARGS * 2 + 1],
       foreign_replacer: create_rpy_code_extractor(true),
       extract_arguments: rpy2_args,

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/overrides.spec.ts
@@ -34,6 +34,23 @@ describe('rpy2 IPython overrides', () => {
     let line_magics = new ReversibleOverridesMap(
       overrides.filter(override => override.scope == 'line')
     );
+
+    it('works with other Rdevice', () => {
+      let line = '%Rdevice svg';
+      let override = line_magics.override_for(line);
+      expect(override).to.equal(
+        'rpy2.ipython.rmagic.RMagics.Rdevice(" svg", "")'
+      );
+      let reverse = line_magics.reverse.override_for(override);
+      expect(reverse).to.equal(line);
+    });
+
+    it('does not overwrite non-rpy2 magics', () => {
+      let line = '%RestMagic';
+      let override = line_magics.override_for(line);
+      expect(override).to.equal(null);
+    });
+
     it('works with the short form arguments, inputs and outputs', () => {
       let line = '%R -i x';
       let override = line_magics.override_for(line);

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/rpy2.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/rpy2.ts
@@ -46,11 +46,17 @@ export function parse_r_args(args: string[], content_position: number) {
   };
 }
 
-export function rpy2_reverse_pattern(quote = '"', multi_line = false): string {
+export function rpy2_reverse_pattern(
+  quote = '"',
+  multi_line = false,
+  magic = 'R'
+): string {
   return (
     '(\\S+)?' +
     '(?:, (\\S+))?'.repeat(9) +
-    '( = )?rpy2\\.ipython\\.rmagic\\.RMagics.R\\(' +
+    '( = )?rpy2\\.ipython\\.rmagic\\.RMagics.' +
+    magic +
+    '\\(' +
     quote +
     (multi_line ? '([\\s\\S]*)' : '(.*?)') +
     quote +


### PR DESCRIPTION
## Code changes

- The `%R` magic could override non-R magics that started with `R`; this is now fixed and a test is added
- The `%Rdevice` magic which is why I originally found that bug was added

## User-facing changes

Better rpy2 integration

## Backwards-incompatible changes

None

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
