### PR TITLE
Pin robotframework for lint step on CI

### DIFF
--- a/requirements/lint.yml
+++ b/requirements/lint.yml
@@ -10,7 +10,6 @@ dependencies:
   - isort
   - mypy
   - robotframework-lint >=1.1
-  - robotframework >=4
+  - robotframework >=4,<4.1
   - pytest-tornasync
-  - pip:
-      - types-six
+  - types-six


### PR DESCRIPTION
Pin `robotframework<4.1` for lint step (see https://github.com/robotframework/robotframework/issues/4044) and use types-six from conda as this package is now available on conda-forge