### PR TITLE
Fix hover rendering for `MarkedString`s, fix hover disappearing when moving mouse towards it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ### `@krassowski/jupyterlab-lsp 3.8.1` (unreleased)
 
 - bug fixes:
-  - `%Rdevice` magic is now properly overridden and won't be extracted to R code [(#646)]
+  - remove spurious `ValidationError` warnings for non-installed servers ([(#645)], thanks @karlaspuldaro)
+  - `%Rdevice` magic is now properly overridden and won't be extracted to R code ([(#646)])
+  - Fix hover rendering for MarkedStrings, fix hover disappearing when moving mouse towards it ([(#653)])
 
+[#645]: https://github.com/krassowski/jupyterlab-lsp/pull/645
 [#646]: https://github.com/krassowski/jupyterlab-lsp/pull/646
+[#653]: https://github.com/krassowski/jupyterlab-lsp/pull/653
 
 ### `@krassowski/jupyterlab-lsp 3.8.0` (2021-07-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ### `@krassowski/jupyterlab-lsp 3.8.1` (unreleased)
 
 - bug fixes:
-  - remove spurious `ValidationError` warnings for non-installed servers ([(#645)], thanks @karlaspuldaro)
-  - `%Rdevice` magic is now properly overridden and won't be extracted to R code ([(#646)])
-  - Fix hover rendering for MarkedStrings, fix hover disappearing when moving mouse towards it ([(#653)])
+  - remove spurious `ValidationError` warnings for non-installed servers ([#645)], thanks @karlaspuldaro)
+  - `%Rdevice` magic is now properly overridden and won't be extracted to R code ([#646)])
+  - Fix hover rendering for MarkedStrings, fix hover disappearing when moving mouse towards it ([#653)])
 
 [#645]: https://github.com/krassowski/jupyterlab-lsp/pull/645
 [#646]: https://github.com/krassowski/jupyterlab-lsp/pull/646

--- a/atest/05_Features/Hover.robot
+++ b/atest/05_Features/Hover.robot
@@ -57,7 +57,6 @@ Trigger Via Hover With Modifier
     Mouse Over    ${sel}
     # move it back and forth (wiggle) while hodling the ctrl modifier
     Mouse Over With Control    ${sel}    x_wiggle=5
-    Wait Until Page Contains Element    ${HOVER_SIGNAL}
     Wait Until Keyword Succeeds    4x    0.1s    Page Should Contain Element    ${HOVER_BOX}
 
 Trigger Via Modifier Key Press

--- a/atest/07_Configuration.robot
+++ b/atest/07_Configuration.robot
@@ -58,7 +58,7 @@ Settings Should Change Editor Diagnostics
     Set Editor Content    {"language_servers": {"${server}": {"serverSettings": ${settings}}}}    ${CSS USER SETTINGS}
     Wait Until Page Contains    No errors found
     Capture Page Screenshot    02-default-diagnostics-and-unsaved-settings.png
-    Click Element    css:button[title\='Save User Settings']
+    Click Element    css:button[title^\='Save User Settings']
     Click Element    ${JLAB XP CLOSE SETTINGS}
     Drag and Drop By Offset    ${tab}    0    100
     Lab Command    ${save command}

--- a/atest/Keywords.robot
+++ b/atest/Keywords.robot
@@ -375,7 +375,7 @@ Configure JupyterLab Plugin
     Open in Advanced Settings    ${plugin id}
     Set Editor Content    ${settings json}    ${CSS USER SETTINGS}
     Wait Until Page Contains    No errors found
-    Click Element    css:button[title\='Save User Settings']
+    Click Element    css:button[title^\='Save User Settings']
     Wait Until Page Contains    No errors found
     Click Element    ${JLAB XP CLOSE SETTINGS}
 

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -283,6 +283,7 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
     // while already reverted in https://github.com/jupyterlab/jupyterlab/pull/10741,
     // it was not released yet and many users will continue to run 3.1.0 and 3.1.1
     // so lets workaround it for now
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const completedManually = state === 'completed manually';
 

--- a/packages/jupyterlab-lsp/src/adapters/adapter.ts
+++ b/packages/jupyterlab-lsp/src/adapters/adapter.ts
@@ -278,7 +278,15 @@ export abstract class WidgetAdapter<T extends IDocumentWidget> {
       return;
     }
 
-    if (state === 'completed') {
+    // TODO: remove workaround no later than with 3.2 release of JupyterLab
+    // workaround for https://github.com/jupyterlab/jupyterlab/issues/10721
+    // while already reverted in https://github.com/jupyterlab/jupyterlab/pull/10741,
+    // it was not released yet and many users will continue to run 3.1.0 and 3.1.1
+    // so lets workaround it for now
+    // @ts-ignore
+    const completedManually = state === 'completed manually';
+
+    if (state === 'completed' || completedManually) {
       // note: must only be send to the appropriate connections as
       // some servers (Julia) break if they receive save notification
       // for a document that was not opened before, see:

--- a/packages/jupyterlab-lsp/src/features/hover.ts
+++ b/packages/jupyterlab-lsp/src/features/hover.ts
@@ -41,7 +41,13 @@ interface IResponseData {
   ce_editor: CodeEditor.IEditor;
 }
 
-function isCloseTo(what: HTMLElement, who: MouseEvent, cushion = 50) {
+/**
+ * Check whether mouse is close to given element (within a specified number of pixels)
+ * @param what target element
+ * @param who mouse event determining position and target
+ * @param cushion number of pixels on each side defining "closeness" boundary
+ */
+function isCloseTo(what: HTMLElement, who: MouseEvent, cushion = 50): boolean {
   const target = who.type === 'mouseleave' ? who.relatedTarget : who.target;
 
   if (what === target || what.contains(target as HTMLElement)) {
@@ -94,8 +100,11 @@ function to_markup(
   content: string | lsProtocol.MarkedString
 ): lsProtocol.MarkupContent {
   if (typeof content === 'string') {
+    // coerce deprecated MarkedString to an MarkupContent; if given as a string it is markdown too,
+    // quote: "It is either a markdown string or a code-block that provides a language and a code snippet."
+    // (https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#markedString)
     return {
-      kind: 'plaintext',
+      kind: 'markdown',
       value: content
     };
   } else {


### PR DESCRIPTION
## Code changes

- fixes incorrect rendering of hovers provided as `MarkedString`s (which are deprecated but still supported)
- solves the difficulty of moving the mouse to the hover tooltip, by implementing a cushion of 50 pixels where mousleave/mousemove events do not trigger closing the tooltip

## User-facing changes

| before | after |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/5832902/127781913-6fecd280-fa5a-4cc3-8849-b54def83681e.png) | ![after](https://user-images.githubusercontent.com/5832902/127781918-7138f809-ebe8-4a16-a598-561b291a1b67.png) |

| before | after |
|--------|-------|
| ![before-no-border](https://user-images.githubusercontent.com/5832902/127781896-4b0e3593-103c-4fa1-818c-de37fedf5f93.gif) | ![soft-border](https://user-images.githubusercontent.com/5832902/127781897-5a199ac1-b4c2-4f77-b81e-90ad714c56cc.gif) |

## Backwards-incompatible changes

None

## Chores

- [x] linted
- [ ] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [x] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
