### PR TITLE
Prepare release 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
 ## Changelog
 
-### `@krassowski/jupyterlab-lsp 3.8.1` (unreleased)
+### `@krassowski/jupyterlab-lsp 3.8.1` (2021-08-02)
 
 - bug fixes:
-  - remove spurious `ValidationError` warnings for non-installed servers ([#645)], thanks @karlaspuldaro)
-  - `%Rdevice` magic is now properly overridden and won't be extracted to R code ([#646)])
-  - Fix hover rendering for MarkedStrings, fix hover disappearing when moving mouse towards it ([#653)])
+  - `%Rdevice` magic is now properly overridden and won't be extracted to R code ([#646])
+  - Fix hover rendering for 1MarkedString1s, fix hover disappearing when moving mouse towards it ([#653])
 
-[#645]: https://github.com/krassowski/jupyterlab-lsp/pull/645
 [#646]: https://github.com/krassowski/jupyterlab-lsp/pull/646
 [#653]: https://github.com/krassowski/jupyterlab-lsp/pull/653
+
+### `jupyter-lsp 1.4.1` (2021-08-02)
+
+- bug fixes:
+  - remove spurious `ValidationError` warnings for non-installed servers ([#645], thanks @karlaspuldaro)
+  - reduce number and verbosity of logs on startup
+
+[#645]: https://github.com/krassowski/jupyterlab-lsp/pull/645
 
 ### `@krassowski/jupyterlab-lsp 3.8.0` (2021-07-04)
 

--- a/packages/jupyterlab-lsp/package.json
+++ b/packages/jupyterlab-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Language Server Protocol integration for JupyterLab",
   "keywords": [
     "jupyter",

--- a/packages/metapackage/package.json
+++ b/packages/metapackage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krassowski/jupyterlab-lsp-metapackage",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "JupyterLab LSP - Meta Package. All of the packages used by JupyterLab LSP",
   "homepage": "https://github.com/krassowski/jupyterlab-lsp",
   "bugs": {

--- a/python_packages/jupyter_lsp/jupyter_lsp/_version.py
+++ b/python_packages/jupyter_lsp/jupyter_lsp/_version.py
@@ -1,3 +1,3 @@
 """ single source of truth for jupyter_lsp version
 """
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/python_packages/jupyter_lsp/setup.py
+++ b/python_packages/jupyter_lsp/setup.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import setuptools
 
 setuptools.setup(
+    name="jupyter-lsp",
     version=re.findall(
         r"""__version__ = "([^"]+)"$""",
         (Path(__file__).parent / "jupyter_lsp" / "_version.py").read_text(

--- a/python_packages/jupyterlab_lsp/setup.py
+++ b/python_packages/jupyterlab_lsp/setup.py
@@ -40,4 +40,6 @@ _release = re.findall(
 setuptools.setup(
     version=f"{_version}{_release}",
     data_files=get_data_files(),
+    # explicit name as a workaround for GitHub dependency analyzer not discovering Python packages otherwise
+    name='jupyterlab-lsp'
 )

--- a/python_packages/jupyterlab_lsp/setup.py
+++ b/python_packages/jupyterlab_lsp/setup.py
@@ -41,5 +41,5 @@ setuptools.setup(
     version=f"{_version}{_release}",
     data_files=get_data_files(),
     # explicit name as a workaround for GitHub dependency analyzer not discovering Python packages otherwise
-    name='jupyterlab-lsp'
+    name="jupyterlab-lsp",
 )

--- a/python_packages/jupyterlab_lsp/setup.py
+++ b/python_packages/jupyterlab_lsp/setup.py
@@ -40,6 +40,7 @@ _release = re.findall(
 setuptools.setup(
     version=f"{_version}{_release}",
     data_files=get_data_files(),
-    # explicit name as a workaround for GitHub dependency analyzer not discovering Python packages otherwise
+    # explicit name as a workaround for GitHub dependency analyzer
+    # not discovering Python packages otherwise
     name="jupyterlab-lsp",
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -11756,9 +11756,9 @@ puppeteer@^1.17.0:
     ws "^6.1.0"
 
 pyright@^1.1:
-  version "1.1.140"
-  resolved "https://registry.yarnpkg.com/pyright/-/pyright-1.1.140.tgz#2692f67b2769e664983dff3fefee4c0e4d12f4fa"
-  integrity sha512-isJj7cahjEK7xAy5/aLJ4TfzLJGA4SCWqPk1pLJA3k8S6VUo4FIiPrvHOd1LM2gxImqgef4rwUeHRC+vrOKLRQ==
+  version "1.1.159"
+  resolved "https://registry.yarnpkg.com/pyright/-/pyright-1.1.159.tgz#185228546adbaff6dbac6127e91a16aa6846e319"
+  integrity sha512-KCKxW9MWLTTmM6CMHixpgX0H+eZO40aAQwXs1qji4Ru+Yq/KJCGb2b7eTqXMoRxEqz1cIinvpaoH11R54gUBGQ==
 
 q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Includes three minor improvements not worth a PR on their own (with the CI times in hours...):
- Reduce the number of logs from manager
- Add explicit package name in `setup.py`
- Bump pyright version