### PR TITLE
Handle case where position is null in document.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+python_packages
 .Python
 build/
 develop-eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ __pycache__/
 *.so
 
 # Distribution / packaging
-python_packages
 .Python
 build/
 develop-eggs/

--- a/packages/jupyterlab-lsp/src/components/utils.spec.ts
+++ b/packages/jupyterlab-lsp/src/components/utils.spec.ts
@@ -1,6 +1,7 @@
 import { IDocumentWidget } from '@jupyterlab/docregistry';
 
 import { WidgetAdapter } from '../adapters/adapter';
+import { BrowserConsole } from '../virtual/console';
 import { VirtualDocument } from '../virtual/document';
 
 import { get_breadcrumbs } from './utils';
@@ -13,6 +14,7 @@ function create_dummy_document(options: Partial<VirtualDocument.IOptions>) {
     path: 'Untitled.ipynb.py',
     file_extension: 'py',
     has_lsp_supported_file: false,
+    console: new BrowserConsole(),
     ...options
   });
 }

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -336,7 +336,8 @@ export class NotebookTestEnvironment extends TestEnvironment {
       overrides_registry: {},
       foreign_code_extractors: {},
       has_lsp_supported_file: false,
-      standalone: true
+      standalone: true,
+      console: new BrowserConsole()
     };
   }
 

--- a/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
+++ b/packages/jupyterlab-lsp/src/editor_integration/testutils.ts
@@ -284,7 +284,8 @@ export class FileEditorTestEnvironment extends TestEnvironment {
       has_lsp_supported_file: true,
       standalone: true,
       foreign_code_extractors: {},
-      overrides_registry: {}
+      overrides_registry: {},
+      console: new BrowserConsole()
     };
   }
 

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-bigquery/extractors.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { extract_code, get_the_only_virtual } from '../../extractors/testutils';
+import { BrowserConsole } from '../../virtual/console';
 import { VirtualDocument } from '../../virtual/document';
 
 import { foreign_code_extractors } from './extractors';
@@ -20,7 +21,8 @@ describe('Bigquery SQL extractors', () => {
       foreign_code_extractors: foreign_code_extractors,
       standalone: false,
       file_extension: 'py',
-      has_lsp_supported_file: false
+      has_lsp_supported_file: false,
+      console: new BrowserConsole()
     });
   });
 

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-rpy2/extractors.spec.ts
@@ -6,6 +6,7 @@ import {
   get_the_only_virtual,
   wrap_in_python_lines
 } from '../../extractors/testutils';
+import { BrowserConsole } from '../../virtual/console';
 import { VirtualDocument } from '../../virtual/document';
 
 import { foreign_code_extractors } from './extractors';
@@ -25,7 +26,8 @@ describe('IPython rpy2 extractors', () => {
       foreign_code_extractors: foreign_code_extractors,
       standalone: false,
       file_extension: 'py',
-      has_lsp_supported_file: false
+      has_lsp_supported_file: false,
+      console: new BrowserConsole()
     });
   });
 

--- a/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython-sql/extractors.spec.ts
@@ -5,6 +5,7 @@ import {
   get_the_only_virtual,
   wrap_in_python_lines
 } from '../../extractors/testutils';
+import { BrowserConsole } from '../../virtual/console';
 import { VirtualDocument } from '../../virtual/document';
 
 import { SQL_URL_PATTERN, foreign_code_extractors } from './extractors';
@@ -24,7 +25,8 @@ describe('IPython SQL extractors', () => {
       foreign_code_extractors: foreign_code_extractors,
       standalone: false,
       file_extension: 'py',
-      has_lsp_supported_file: false
+      has_lsp_supported_file: false,
+      console: new BrowserConsole()
     });
   });
 

--- a/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.spec.ts
+++ b/packages/jupyterlab-lsp/src/transclusions/ipython/extractors.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { extract_code, get_the_only_virtual } from '../../extractors/testutils';
+import { BrowserConsole } from '../../virtual/console';
 import { VirtualDocument } from '../../virtual/document';
 
 import { foreign_code_extractors } from './extractors';
@@ -20,7 +21,8 @@ describe('IPython extractors', () => {
       foreign_code_extractors: foreign_code_extractors,
       standalone: false,
       file_extension: 'py',
-      has_lsp_supported_file: false
+      has_lsp_supported_file: false,
+      console: new BrowserConsole()
     });
   });
 

--- a/packages/jupyterlab-lsp/src/virtual/document.spec.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { ISourcePosition, IVirtualPosition } from '../positioning';
 import { foreign_code_extractors } from '../transclusions/ipython-rpy2/extractors';
 
+import { BrowserConsole } from './console';
 import { VirtualDocument, is_within_range } from './document';
 
 import Mock = jest.Mock;
@@ -58,7 +59,8 @@ describe('VirtualDocument', () => {
       foreign_code_extractors: foreign_code_extractors,
       standalone: false,
       file_extension: 'py',
-      has_lsp_supported_file: false
+      has_lsp_supported_file: false,
+      console: new BrowserConsole()
     });
   });
 

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -133,6 +133,7 @@ export namespace VirtualDocument {
     overrides_registry: ICodeOverridesRegistry;
     path: string;
     file_extension: string;
+    console: ILSPLogConsole;
     /**
      * Notebooks or any other aggregates of documents are not supported
      * by the LSP specification, and we need to make appropriate
@@ -149,7 +150,6 @@ export namespace VirtualDocument {
      */
     standalone?: boolean;
     parent?: VirtualDocument;
-    console?: ILSPLogConsole;
   }
 }
 
@@ -179,6 +179,8 @@ export class VirtualDocument {
   public foreign_document_closed: Signal<VirtualDocument, IForeignContext>;
   public foreign_document_opened: Signal<VirtualDocument, IForeignContext>;
   public readonly instance_id: number;
+  protected console: ILSPLogConsole;
+
   standalone: boolean;
   isDisposed = false;
   /**
@@ -225,6 +227,7 @@ export class VirtualDocument {
   constructor(options: VirtualDocument.IOptions) {
     this.options = options;
     this.path = options.path;
+    this.console = options.console;
     this.file_extension = options.file_extension;
     this.has_lsp_supported_file = options.has_lsp_supported_file;
     this.parent = options.parent;

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -747,6 +747,10 @@ export class VirtualDocument {
   }
 
   transform_source_to_editor(pos: ISourcePosition): IEditorPosition {
+    if (pos == null) {
+      this.console.warn('no position available');
+      return
+    }
     let source_line = this.source_lines.get(pos.line);
     let editor_line = source_line.editor_line;
     let editor_shift = source_line.editor_shift;
@@ -781,6 +785,10 @@ export class VirtualDocument {
   }
 
   get_editor_at_virtual_line(pos: IVirtualPosition): CodeEditor.IEditor {
+    if (pos == null) {
+      this.console.warn('no position available');
+      return
+    }
     let line = pos.line;
     // tolerate overshot by one (the hanging blank line at the end)
     if (!this.virtual_lines.has(line)) {
@@ -790,6 +798,10 @@ export class VirtualDocument {
   }
 
   get_editor_at_source_line(pos: ISourcePosition): CodeEditor.IEditor {
+    if (pos == null) {
+      this.console.warn('no position available');
+      return
+    }
     return this.source_lines.get(pos.line).editor;
   }
 

--- a/packages/jupyterlab-lsp/src/virtual/document.ts
+++ b/packages/jupyterlab-lsp/src/virtual/document.ts
@@ -752,7 +752,7 @@ export class VirtualDocument {
   transform_source_to_editor(pos: ISourcePosition): IEditorPosition {
     if (pos == null) {
       this.console.warn('no position available');
-      return
+      return;
     }
     let source_line = this.source_lines.get(pos.line);
     let editor_line = source_line.editor_line;
@@ -790,7 +790,7 @@ export class VirtualDocument {
   get_editor_at_virtual_line(pos: IVirtualPosition): CodeEditor.IEditor {
     if (pos == null) {
       this.console.warn('no position available');
-      return
+      return;
     }
     let line = pos.line;
     // tolerate overshot by one (the hanging blank line at the end)
@@ -803,7 +803,7 @@ export class VirtualDocument {
   get_editor_at_source_line(pos: ISourcePosition): CodeEditor.IEditor {
     if (pos == null) {
       this.console.warn('no position available');
-      return
+      return;
     }
     return this.source_lines.get(pos.line).editor;
   }


### PR DESCRIPTION
## References

This fixes issue #543 which #544 fixed partially.

## Code changes

Add a check that `pos` isn't `null` before trying to access its properties.

## Chores

- [x] linted <!-- Required: Run "jlpm lint" and "python scripts/lint.py" from the root of the repository, then check this box like this: [x] -->
- [x] tested <!-- Recommended: Let us know if you already added a test case (if relevant). -->
- [ ] documented <!-- Optional: Would it be good to improve the documentation? If yes, please consider doing this and checking this box. -->
- [ ] changelog entry <!-- Recommended: Add a note in the CHANGELOG.md file under the most recent >unreleased< version; if one does not exist, feel free to create one by increasing the version number (no worries if you are not certain of the details - we can improve it later; let's just have something to work with) -->
